### PR TITLE
fix: OverlayView timer uses .common RunLoop mode (#23)

### DIFF
--- a/EyePostureReminder/Views/OverlayView.swift
+++ b/EyePostureReminder/Views/OverlayView.swift
@@ -196,7 +196,7 @@ struct OverlayView: View {
     // MARK: - Timer
 
     private func startTimer() {
-        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+        let t = Timer(timeInterval: 1, repeats: true) { _ in
             if secondsRemaining > 0 {
                 secondsRemaining -= 1
             } else {
@@ -204,6 +204,8 @@ struct OverlayView: View {
                 performAutoDismiss()
             }
         }
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
     }
 
     // MARK: - Haptic Feedback


### PR DESCRIPTION
## Problem

The countdown timer in `OverlayView` used `Timer.scheduledTimer`, which schedules on the `.default` RunLoop mode. When the user performs a drag gesture (swipe-to-dismiss), UIKit switches the RunLoop to `.tracking` mode — and the timer silently stops firing. This freezes the countdown display for the entire duration of the gesture, extending the perceived break.

## Fix

Replaced `Timer.scheduledTimer` with `Timer(timeInterval:repeats:block:)` + `RunLoop.main.add(timer, forMode: .common)`. The `.common` pseudo-mode includes both `.default` and `.tracking`, so the timer fires correctly during drag gestures.

```swift
// Before
timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in ... }

// After
let t = Timer(timeInterval: 1, repeats: true) { _ in ... }
RunLoop.main.add(t, forMode: .common)
timer = t
```

## Testing

- `OverlayView.swift` compiles cleanly
- Verified fix is isolated to `startTimer()` only — no other logic changed
- Pre-existing build failure in `SettingsViewModel.swift` (unrelated, present on main) blocked full test suite

Fixes #23