### PR TITLE
fix: OverlayView timer uses .common RunLoop mode (#23)

### DIFF
--- a/EyePostureReminder/Views/OverlayView.swift
+++ b/EyePostureReminder/Views/OverlayView.swift
@@ -196,7 +196,7 @@ struct OverlayView: View {
     // MARK: - Timer
 
     private func startTimer() {
-        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
+        let t = Timer(timeInterval: 1, repeats: true) { _ in
             if secondsRemaining > 0 {
                 secondsRemaining -= 1
             } else {
@@ -204,6 +204,8 @@ struct OverlayView: View {
                 performAutoDismiss()
             }
         }
+        RunLoop.main.add(t, forMode: .common)
+        timer = t
     }
 
     // MARK: - Haptic Feedback


### PR DESCRIPTION
## Problem

The countdown timer in `OverlayView` used `Timer.scheduledTimer`, which schedules on the `.default` RunLoop mode. When the user performs a drag gesture (swipe-to-dismiss), UIKit switches the RunLoop to `.tracking` mode — and the timer silently stops firing. This freezes the countdown for the entire duration of the gesture, silently extending the break.

## Fix

Replaced `Timer.scheduledTimer` with `Timer(timeInterval:repeats:block:)` added to `RunLoop.main` with `.common` mode. The `.common` pseudo-mode includes both `.default` and `.tracking`, so the timer fires correctly during drag gestures.

```swift
// Before
timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in ... }

// After
let t = Timer(timeInterval: 1, repeats: true) { _ in ... }
RunLoop.main.add(t, forMode: .common)
timer = t
```

## Notes

- `OverlayView.swift` compiles cleanly ✅
- Pre-existing build failure in `SettingsViewModel.swift` (unrelated, present on `main`) blocks the full test suite — not caused by this change

Fixes #23