### PR TITLE
fix: Reset snoozeCount on new reminder cycle (#22)

### DIFF
--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -120,6 +120,9 @@ final class AppCoordinator: ObservableObject {
         // continuous screen-on threshold is reached.
         self.screenTimeTracker.onThresholdReached = { [weak self] type in
             guard let self else { return }
+            // New reminder cycle — reset consecutive snooze count so the user
+            // gets a fresh snooze budget on every threshold fire.
+            self.settings.snoozeCount = 0
             let duration = self.settings.settings(for: type).breakDuration
             self.overlayManager.showOverlay(
                 for: type, duration: duration, hapticsEnabled: self.settings.hapticsEnabled) {}


### PR DESCRIPTION
## Problem

When `ScreenTimeTracker` fires `onThresholdReached` (a new reminder cycle begins via screen-time threshold), `snoozeCount` was never reset. After hitting the max consecutive snooze limit (2 snoozes), the user could never snooze again until the app was restarted.

## Root Cause

The `onThresholdReached` closure in `AppCoordinator.init` showed the overlay but did not reset `settings.snoozeCount`. The notification-driven code path (`handleNotification(for:)`) already correctly reset the count — the screen-time path was missing the same reset.

## Fix

Set `settings.snoozeCount = 0` at the top of the `onThresholdReached` closure, giving users a fresh snooze budget on every new reminder cycle.

```swift
// Before
self.screenTimeTracker.onThresholdReached = { [weak self] type in
    guard let self else { return }
    let duration = self.settings.settings(for: type).breakDuration
    ...

// After
self.screenTimeTracker.onThresholdReached = { [weak self] type in
    guard let self else { return }
    self.settings.snoozeCount = 0  // ← new: reset on each new reminder cycle
    let duration = self.settings.settings(for: type).breakDuration
    ...
```

## Tests

- **575/575 tests pass** (including all 29 `AppCoordinatorTests`)
- No regressions

Fixes #22