### PR TITLE
fix: Dismiss active overlay when pause condition fires (#27)

### DIFF
--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -133,6 +133,12 @@ final class AppCoordinator: ObservableObject {
             guard let self else { return }
             if isPaused {
                 self.screenTimeTracker.pauseAll()
+                // Dismiss any overlay that is currently on screen and drop queued ones.
+                // CarPlay/driving contexts should never show a break overlay.
+                if self.overlayManager.isOverlayVisible {
+                    self.overlayManager.dismissOverlay()
+                }
+                self.overlayManager.clearQueue()
                 Logger.scheduling.info("PauseConditionManager: pausing reminders (active condition)")
             } else {
                 guard (self.settings.snoozedUntil ?? .distantPast) <= Date() else {


### PR DESCRIPTION
## Summary

Fixes #27.

When a pause condition fires (CarPlay connects, driving detected, Focus mode activates) while a break overlay is on screen, the overlay was left running. The screen-time tracker was correctly paused, but the visible overlay was never dismissed.

## Root cause

`AppCoordinator`'s `onPauseStateChanged` callback only called `screenTimeTracker.pauseAll()` when `isPaused = true`. It did not check or dismiss the active overlay.

## Fix

In the `isPaused = true` branch, added:
```swift
if self.overlayManager.isOverlayVisible {
    self.overlayManager.dismissOverlay()
}
self.overlayManager.clearQueue()
```

This dismisses any visible overlay immediately and drops any queued overlays that haven't shown yet. Both operations are no-ops if no overlay is active/queued, so there is no regression risk.

## Testing
- Build: ✅ succeeded  
- 575 unit tests: ✅ 0 failures