### PR TITLE
fix: Re-evaluate pause state when settings change (#26)

### DIFF
--- a/EyePostureReminder/Services/PauseConditionManager.swift
+++ b/EyePostureReminder/Services/PauseConditionManager.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import Combine
 import CoreMotion
 import Foundation
 import Intents
@@ -196,6 +197,8 @@ final class PauseConditionManager: PauseConditionProviding {
 
     private var activeConditions: Set<PauseConditionSource> = []
 
+    private var cancellables: Set<AnyCancellable> = []
+
     init(
         settings: SettingsStore,
         focusDetector: FocusStatusDetecting = LiveFocusStatusDetector(),
@@ -222,6 +225,26 @@ final class PauseConditionManager: PauseConditionProviding {
             self.update(.driving, isActive: driving && self.settings.pauseWhileDriving)
         }
 
+        // Re-evaluate all conditions whenever a pause setting is toggled.
+        // Note: @Published fires in willSet, so we use the value passed by the publisher
+        // rather than re-reading from settings (which still holds the old value at that point).
+        settings.$pauseDuringFocus
+            .dropFirst()
+            .sink { [weak self] newValue in
+                guard let self else { return }
+                self.update(.focusMode, isActive: self.focusDetector.isFocused && newValue)
+            }
+            .store(in: &cancellables)
+
+        settings.$pauseWhileDriving
+            .dropFirst()
+            .sink { [weak self] newValue in
+                guard let self else { return }
+                self.update(.carPlay, isActive: self.carPlayDetector.isCarPlayActive && newValue)
+                self.update(.driving, isActive: self.drivingDetector.isDriving && newValue)
+            }
+            .store(in: &cancellables)
+
         focusDetector.startMonitoring()
         carPlayDetector.startMonitoring()
         drivingDetector.startMonitoring()
@@ -229,10 +252,19 @@ final class PauseConditionManager: PauseConditionProviding {
     }
 
     func stopMonitoring() {
+        cancellables.removeAll()
         focusDetector.stopMonitoring()
         carPlayDetector.stopMonitoring()
         drivingDetector.stopMonitoring()
         Logger.scheduling.debug("PauseConditionManager: monitoring stopped")
+    }
+
+    /// Re-evaluates all three conditions against current detector state and settings.
+    /// Called when a pause-related setting changes so the paused state stays consistent.
+    private func reevaluate() {
+        update(.focusMode, isActive: focusDetector.isFocused && settings.pauseDuringFocus)
+        update(.carPlay, isActive: carPlayDetector.isCarPlayActive && settings.pauseWhileDriving)
+        update(.driving, isActive: drivingDetector.isDriving && settings.pauseWhileDriving)
     }
 
     private func update(_ source: PauseConditionSource, isActive: Bool) {

--- a/Tests/EyePostureReminderTests/Services/PauseConditionManagerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/PauseConditionManagerTests.swift
@@ -277,6 +277,69 @@ final class PauseConditionManagerTests: XCTestCase {
 
         XCTAssertEqual(callbackCount, 1, "Callback must not fire when isPaused value does not change")
     }
+
+    // MARK: - Settings Toggle Re-evaluation (Issue #26)
+
+    func test_pauseDuringFocus_toggledOff_whileFocusActive_resumesImmediately() {
+        settings.pauseDuringFocus = true
+        mockFocus.simulateFocusChange(true)
+        XCTAssertTrue(sut.isPaused, "Precondition: must be paused with focus active")
+
+        settings.pauseDuringFocus = false
+
+        XCTAssertFalse(sut.isPaused, "Disabling pauseDuringFocus while focus is still active must immediately resume")
+    }
+
+    func test_pauseWhileDriving_toggledOff_whileDrivingActive_resumesImmediately() {
+        settings.pauseWhileDriving = true
+        mockDriving.simulateDrivingChange(true)
+        XCTAssertTrue(sut.isPaused, "Precondition: must be paused with driving active")
+
+        settings.pauseWhileDriving = false
+
+        XCTAssertFalse(sut.isPaused, "Disabling pauseWhileDriving while driving is still active must immediately resume")
+    }
+
+    func test_pauseWhileDriving_toggledOff_whileCarPlayActive_resumesImmediately() {
+        settings.pauseWhileDriving = true
+        mockCarPlay.simulateCarPlayChange(true)
+        XCTAssertTrue(sut.isPaused, "Precondition: must be paused with CarPlay active")
+
+        settings.pauseWhileDriving = false
+
+        XCTAssertFalse(sut.isPaused, "Disabling pauseWhileDriving while CarPlay is still active must immediately resume")
+    }
+
+    func test_pauseDuringFocus_toggledOn_whileFocusActive_pausesImmediately() {
+        settings.pauseDuringFocus = false
+        mockFocus.simulateFocusChange(true)
+        XCTAssertFalse(sut.isPaused, "Precondition: must not be paused when setting is off")
+
+        settings.pauseDuringFocus = true
+
+        XCTAssertTrue(sut.isPaused, "Enabling pauseDuringFocus while focus is already active must immediately pause")
+    }
+
+    func test_settingToggle_withNoActiveCondition_doesNotChangePauseState() {
+        settings.pauseDuringFocus = true
+        XCTAssertFalse(sut.isPaused, "Precondition: not paused — no conditions active")
+
+        settings.pauseDuringFocus = false
+
+        XCTAssertFalse(sut.isPaused, "Toggling setting with no active condition must not change isPaused")
+    }
+
+    func test_pauseDuringFocus_toggledOff_withMultipleConditions_remainsPausedIfOtherActive() {
+        settings.pauseDuringFocus = true
+        settings.pauseWhileDriving = true
+        mockFocus.simulateFocusChange(true)
+        mockDriving.simulateDrivingChange(true)
+        XCTAssertTrue(sut.isPaused, "Precondition: paused by both conditions")
+
+        settings.pauseDuringFocus = false
+
+        XCTAssertTrue(sut.isPaused, "Must remain paused — driving condition is still active")
+    }
 }
 
 // MARK: - SettingsStore Pause-Flag Tests


### PR DESCRIPTION
## Problem

When a user has Focus Mode ON and then disables "Pause During Focus" in Settings, reminders never resume. `PauseConditionManager` only updated `activeConditions` via detector callbacks — toggling a setting fired no callback, so the condition stayed in the active set indefinitely.

## Root Cause

`@Published` fires in `willSet`, before the property is actually assigned. The Combine subscription receives the **new** setting value and uses it directly (rather than re-reading `self.settings`, which still holds the old value at that point).

## Fix

Subscribe to `settings.$pauseDuringFocus` and `settings.$pauseWhileDriving` in `startMonitoring()`. On each change, re-evaluate the relevant conditions using the publisher's new value:

- `pauseDuringFocus` toggle → re-evaluate `.focusMode`
- `pauseWhileDriving` toggle → re-evaluate `.carPlay` and `.driving`

Symmetric: enabling a setting while the condition is already active immediately pauses reminders too.

Subscriptions are cancelled in `stopMonitoring()`.

## Tests Added (6 new)

- `test_pauseDuringFocus_toggledOff_whileFocusActive_resumesImmediately`
- `test_pauseWhileDriving_toggledOff_whileDrivingActive_resumesImmediately`
- `test_pauseWhileDriving_toggledOff_whileCarPlayActive_resumesImmediately`
- `test_pauseDuringFocus_toggledOn_whileFocusActive_pausesImmediately`
- `test_settingToggle_withNoActiveCondition_doesNotChangePauseState`
- `test_pauseDuringFocus_toggledOff_withMultipleConditions_remainsPausedIfOtherActive`

## Verification

Build clean ✅  All tests pass ✅