### PR TITLE
fix(snooze): replace legacy snooze(for:) with DST-aware SnoozeOption API

### DIFF
--- a/EyePostureReminder/Views/SettingsView.swift
+++ b/EyePostureReminder/Views/SettingsView.swift
@@ -107,25 +107,21 @@ struct SettingsView: View {
                     }
                     .accessibilityHint(Text("settings.snooze.cancelButton.hint", bundle: .module))
                 } else {
-                    Button(action: { viewModel?.snooze(for: 5) }) {
+                    Button(action: { viewModel?.snooze(option: .fiveMinutes) }) {
                         Text("settings.snooze.5min", bundle: .module)
                     }
                     .font(AppFont.body)
                     .accessibilityLabel(Text("settings.snooze.5min.label", bundle: .module))
                     .accessibilityHint(Text("settings.snooze.5min.hint", bundle: .module))
 
-                    Button(action: { viewModel?.snooze(for: 60) }) {
+                    Button(action: { viewModel?.snooze(option: .oneHour) }) {
                         Text("settings.snooze.1hour", bundle: .module)
                     }
                     .font(AppFont.body)
                     .accessibilityLabel(Text("settings.snooze.1hour.label", bundle: .module))
                     .accessibilityHint(Text("settings.snooze.1hour.hint", bundle: .module))
 
-                    Button(action: {
-                        let endOfDay = Calendar.current.startOfDay(for: Date()).addingTimeInterval(24 * 3600)
-                        let minutesLeft = max(1, Int(endOfDay.timeIntervalSince(Date()) / 60))
-                        viewModel?.snooze(for: minutesLeft)
-                    }) {
+                    Button(action: { viewModel?.snooze(option: .restOfDay) }) {
                         Text("settings.snooze.restOfDay", bundle: .module)
                     }
                     .font(AppFont.body)


### PR DESCRIPTION
## Summary

Fixes #24 — snooze buttons in SettingsView were calling the legacy `snooze(for: minutes)` method, which computes end dates using raw `TimeInterval` arithmetic. During a DST boundary (clocks spring forward/fall back), this produces a snooze end time that's an hour off.

## Root Cause

- `snooze(for: 60)` → `Date().addingTimeInterval(3600)` — adds exactly 3600 seconds, DST-blind
- `restOfDay` computed midnight as `startOfDay + 24*3600` — same issue

## Fix

Replace all three call sites with `snooze(option:)` using the `SnoozeOption` enum:

| Before | After |
|--------|-------|
| `snooze(for: 5)` | `snooze(option: .fiveMinutes)` |
| `snooze(for: 60)` | `snooze(option: .oneHour)` |
| inline Calendar + `snooze(for: minutesLeft)` | `snooze(option: .restOfDay)` |

`SnoozeOption.endDate` uses `Calendar.current.date(byAdding: .day, value: 1, to: startOfDay)` which respects DST. Also removes the duplicated inline calendar math from the view.

## Testing

- ✅ BUILD SUCCEEDED
- ✅ 575/575 tests pass