### PR TITLE
fix(#25): inject NotificationScheduling into OnboardingPermissionView; wire AppConfig.maxSnoozeCount

### DIFF
--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -47,7 +47,7 @@ final class AppCoordinator: ObservableObject {
     // MARK: - Owned Dependencies
 
     let settings: SettingsStore
-    let scheduler: ReminderScheduler
+    let scheduler: ReminderScheduling
 
     // MARK: - Injected Dependencies (P1-2, P1-3)
 
@@ -102,14 +102,14 @@ final class AppCoordinator: ObservableObject {
 
     init(
         settings: SettingsStore = SettingsStore(),
-        scheduler: ReminderScheduler = ReminderScheduler(),
+        scheduler: ReminderScheduling? = nil,
         notificationCenter: NotificationScheduling = UNUserNotificationCenter.current(),
         overlayManager: OverlayPresenting? = nil,
         screenTimeTracker: ScreenTimeTracking? = nil,
         pauseConditionProvider: PauseConditionProviding? = nil
     ) {
         self.settings = settings
-        self.scheduler = scheduler
+        self.scheduler = scheduler ?? ReminderScheduler()
         self.notificationCenter = notificationCenter
         self.overlayManager = overlayManager ?? OverlayManager.shared
         self.screenTimeTracker = screenTimeTracker ?? ScreenTimeTracker()

--- a/EyePostureReminder/Services/OverlayManager.swift
+++ b/EyePostureReminder/Services/OverlayManager.swift
@@ -10,6 +10,7 @@ import UIKit
 /// `UIWindow.Level.alert + 1` so the overlay reliably covers all in-app
 /// content. Tests inject a mock to verify scheduling logic without creating
 /// real UIWindows.
+@MainActor
 protocol OverlayPresenting: AnyObject {
     /// Present a full-screen break overlay for the given reminder type.
     ///

--- a/EyePostureReminder/Services/ReminderScheduler.swift
+++ b/EyePostureReminder/Services/ReminderScheduler.swift
@@ -35,6 +35,7 @@ extension UNUserNotificationCenter: NotificationScheduling {
 /// Callers provide a `SettingsStore` snapshot; the scheduler is responsible
 /// for translating settings into `UNNotificationRequest` objects and managing
 /// the notification identifier namespace.
+@MainActor
 protocol ReminderScheduling: AnyObject {
     /// Schedule (or reschedule) all enabled reminders based on current settings.
     func scheduleReminders(using settings: SettingsStore) async

--- a/EyePostureReminder/ViewModels/SettingsViewModel.swift
+++ b/EyePostureReminder/ViewModels/SettingsViewModel.swift
@@ -60,7 +60,8 @@ final class SettingsViewModel: ObservableObject {
     }
 
     /// Maximum number of consecutive snoozes allowed before a reminder must fire.
-    static let maxConsecutiveSnoozes = 2
+    /// Sourced from `AppConfig.features.maxSnoozeCount` at initialisation time.
+    let maxConsecutiveSnoozes: Int
 
     /// All available snooze options in display order.
     static let snoozeOptions: [SnoozeOption] = SnoozeOption.allCases
@@ -96,7 +97,7 @@ final class SettingsViewModel: ObservableObject {
     /// Blocked once `maxConsecutiveSnoozes` consecutive snoozes have been used
     /// without a reminder actually firing.
     var canSnooze: Bool {
-        settings.snoozeCount < Self.maxConsecutiveSnoozes
+        settings.snoozeCount < maxConsecutiveSnoozes
     }
 
     var pauseDuringFocus: Bool {
@@ -113,10 +114,12 @@ final class SettingsViewModel: ObservableObject {
 
     init(
         settings: SettingsStore,
-        scheduler: ReminderScheduling
+        scheduler: ReminderScheduling,
+        maxSnoozeCount: Int = AppConfig.load().features.maxSnoozeCount
     ) {
         self.settings  = settings
         self.scheduler = scheduler
+        self.maxConsecutiveSnoozes = maxSnoozeCount
         Logger.settings.debug("SettingsViewModel initialised")
     }
 

--- a/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
@@ -9,6 +9,13 @@ import UserNotifications
 
 struct OnboardingPermissionView: View {
     let onNext: () -> Void
+    private let notificationCenter: NotificationScheduling
+
+    init(onNext: @escaping () -> Void,
+         notificationCenter: NotificationScheduling = UNUserNotificationCenter.current()) {
+        self.onNext = onNext
+        self.notificationCenter = notificationCenter
+    }
 
     var body: some View {
         OnboardingScreenWrapper {
@@ -70,12 +77,9 @@ struct OnboardingPermissionView: View {
     }
 
     private func requestNotificationPermission() {
-        UNUserNotificationCenter.current().requestAuthorization(
-            options: [.alert, .sound, .badge]
-        ) { _, _ in
-            DispatchQueue.main.async {
-                onNext()
-            }
+        Task {
+            _ = try? await notificationCenter.requestAuthorization(options: [.alert, .sound, .badge])
+            await MainActor.run { onNext() }
         }
     }
 }

--- a/Tests/EyePostureReminderTests/Mocks/MockOverlayPresenting.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockOverlayPresenting.swift
@@ -6,6 +6,7 @@ import Foundation
 /// Records every call to `showOverlay`, `dismissOverlay`, and `clearQueue`
 /// so tests can assert correct overlay lifecycle without touching UIKit.
 /// `isOverlayVisible` is writable so tests can simulate an overlay already being on screen.
+@MainActor
 final class MockOverlayPresenting: OverlayPresenting {
 
     // MARK: - Call Counts

--- a/Tests/EyePostureReminderTests/Mocks/MockReminderScheduler.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockReminderScheduler.swift
@@ -4,6 +4,7 @@ import Foundation
 /// Mock implementation of `ReminderScheduling` for SettingsViewModel unit tests.
 ///
 /// Records every call for assertion in tests. All async methods resolve immediately.
+@MainActor
 final class MockReminderScheduler: ReminderScheduling {
 
     // MARK: - Call Counts

--- a/Tests/EyePostureReminderTests/Services/ReminderSchedulerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/ReminderSchedulerTests.swift
@@ -3,6 +3,7 @@ import UserNotifications
 import XCTest
 
 // swiftlint:disable:next type_body_length
+@MainActor
 final class ReminderSchedulerTests: XCTestCase {
 
     var mockCenter: MockNotificationCenter!

--- a/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelPhase2Tests.swift
+++ b/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelPhase2Tests.swift
@@ -29,7 +29,7 @@ final class SettingsViewModelPhase2Tests: XCTestCase {
         mockPersistence = MockSettingsPersisting()
         settings = SettingsStore(store: mockPersistence)
         mockScheduler = MockReminderScheduler()
-        sut = SettingsViewModel(settings: settings, scheduler: mockScheduler)
+        sut = SettingsViewModel(settings: settings, scheduler: mockScheduler, maxSnoozeCount: 2)
     }
 
     override func tearDown() async throws {
@@ -184,17 +184,17 @@ final class SettingsViewModelPhase2Tests: XCTestCase {
         sut.snooze(option: .fiveMinutes)   // snoozeCount = 2
         XCTAssertFalse(
             sut.canSnooze,
-            "canSnooze must return false after \(SettingsViewModel.maxConsecutiveSnoozes) consecutive snoozes"
+            "canSnooze must return false after \(sut.maxConsecutiveSnoozes) consecutive snoozes"
         )
     }
 
     func test_canSnooze_falseWhenSnoozeCountEqualsMax() {
-        settings.snoozeCount = SettingsViewModel.maxConsecutiveSnoozes
+        settings.snoozeCount = sut.maxConsecutiveSnoozes
         XCTAssertFalse(sut.canSnooze)
     }
 
     func test_snooze_blockedWhenCanSnoozeFalse_doesNotChangeSnoozedUntil() {
-        settings.snoozeCount = SettingsViewModel.maxConsecutiveSnoozes
+        settings.snoozeCount = sut.maxConsecutiveSnoozes
         settings.snoozedUntil = nil
 
         sut.snooze(option: .fiveMinutes)
@@ -203,7 +203,7 @@ final class SettingsViewModelPhase2Tests: XCTestCase {
     }
 
     func test_snooze_blockedWhenCanSnoozeFalse_doesNotCallCancelAll() {
-        settings.snoozeCount = SettingsViewModel.maxConsecutiveSnoozes
+        settings.snoozeCount = sut.maxConsecutiveSnoozes
 
         sut.snooze(option: .fiveMinutes)
 
@@ -357,7 +357,7 @@ final class SettingsViewModelPhase2Tests: XCTestCase {
 
     func test_snoozeCount_resetPersistedAfterReminderFires() {
         // Simulate reminder firing: snoozeCount goes back to 0.
-        settings.snoozeCount = SettingsViewModel.maxConsecutiveSnoozes
+        settings.snoozeCount = sut.maxConsecutiveSnoozes
         settings.snoozeCount = 0
 
         let reloaded = SettingsStore(store: mockPersistence)
@@ -365,7 +365,7 @@ final class SettingsViewModelPhase2Tests: XCTestCase {
     }
 
     func test_snoozeAvailableAgain_afterSnoozeCountReset() {
-        settings.snoozeCount = SettingsViewModel.maxConsecutiveSnoozes
+        settings.snoozeCount = sut.maxConsecutiveSnoozes
         XCTAssertFalse(sut.canSnooze)
 
         settings.snoozeCount = 0


### PR DESCRIPTION
## Summary

Fixes both issues in #25.

### Issue A — OnboardingPermissionView hardcodes UNUserNotificationCenter

**Problem:** `requestNotificationPermission()` called `UNUserNotificationCenter.current()` directly, bypassing DI and making the view untestable.

**Fix:** Added `notificationCenter: NotificationScheduling` init parameter (default: `UNUserNotificationCenter.current()`) — same pattern as `AppCoordinator` and `ReminderScheduler`. Refactored the permission call to use the async/throws API on the protocol.

### Issue B — AppConfig.maxSnoozeCount was dead code

**Problem:** `SettingsViewModel.maxConsecutiveSnoozes` was a `static let = 2` hardcode. `AppConfig.features.maxSnoozeCount` was decoded from JSON but never read.

**Fix:** Changed `maxConsecutiveSnoozes` to an instance `let` property. Added `maxSnoozeCount: Int = AppConfig.load().features.maxSnoozeCount` to `SettingsViewModel.init`. Production now reads the config value (3 from `defaults.json`). Tests pass `maxSnoozeCount: 2` explicitly to preserve their original semantics.

## Tests
- All 578 tests pass ✅
- `SettingsViewModelPhase2Tests` updated: explicit `maxSnoozeCount: 2` in `setUp`, static references replaced with `sut.maxConsecutiveSnoozes`