### PR TITLE
fix(ui): Fix sub-44pt tap targets and hardcoded 24h time format

### DIFF
--- a/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
@@ -63,6 +63,7 @@ struct OnboardingPermissionView: View {
                     // Secondary option — no system prompt, just advance
                     Button(action: onNext) {
                         Text("onboarding.permission.skipButton", bundle: .module)
+                            .frame(minHeight: 44)
                     }
                         .foregroundStyle(.secondary)
                         .font(.subheadline)

--- a/EyePostureReminder/Views/Onboarding/OnboardingSetupView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingSetupView.swift
@@ -72,6 +72,7 @@ struct OnboardingSetupView: View {
                     // Secondary option
                     Button(action: onCustomize) {
                         Text("onboarding.setup.customizeButton", bundle: .module)
+                            .frame(minHeight: 44)
                     }
                         .foregroundStyle(.indigo)
                         .font(.subheadline)

--- a/EyePostureReminder/Views/SettingsView.swift
+++ b/EyePostureReminder/Views/SettingsView.swift
@@ -23,9 +23,7 @@ struct SettingsView: View {
 
     private var snoozeUntilFormatted: String {
         guard let until = settings.snoozedUntil, until > Date() else { return "" }
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        return formatter.string(from: until)
+        return until.formatted(date: .omitted, time: .shortened)
     }
 
     var body: some View {


### PR DESCRIPTION
## Summary

Fixes two UX issues in onboarding and settings views.

### Issue #35 — Sub-44pt tap targets on secondary onboarding buttons
Added `.frame(minHeight: 44)` to the label text inside the "Skip" button on `OnboardingPermissionView` and the "Customize" button on `OnboardingSetupView`. This ensures both interactive elements meet the iOS HIG minimum 44pt tap target requirement.

**Files:** `EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift`, `OnboardingSetupView.swift`

### Issue #36 — Hardcoded 24h time format in SettingsView snooze display
Replaced `DateFormatter` with `dateFormat = "HH:mm"` with `Date.formatted(date:time:)` using `.shortened` time style. This respects the device's locale and region settings — US users will see `2:30 PM` instead of `14:30`.

**File:** `EyePostureReminder/Views/SettingsView.swift`

Closes #35, Closes #36