### PR TITLE
fix(ui): Use design system tokens in onboarding + localize a11y strings

### DIFF
--- a/EyePostureReminder/Resources/Localizable.xcstrings
+++ b/EyePostureReminder/Resources/Localizable.xcstrings
@@ -156,6 +156,50 @@
         }
       }
     },
+    "settings.reminder.toggle.enabled.hint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to disable %@ reminders"
+          }
+        }
+      }
+    },
+    "settings.reminder.toggle.disabled.hint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tap to enable %@ reminders"
+          }
+        }
+      }
+    },
+    "settings.reminder.durationPicker" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Break duration"
+          }
+        }
+      }
+    },
+    "settings.reminder.durationPicker.hint" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sets how long each %@ break overlay stays on screen"
+          }
+        }
+      }
+    },
     "settings.reminder.section.footer" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
@@ -28,19 +28,18 @@ struct OnboardingPermissionView: View {
 
                     // Headline
                     Text("onboarding.permission.title", bundle: .module)
-                        .font(.title2)
-                        .fontWeight(.bold)
+                        .font(AppFont.headline)
                         .multilineTextAlignment(.center)
 
                     // Explanation + reassurance copy
                     VStack(spacing: AppSpacing.md) {
                         Text("onboarding.permission.body1", bundle: .module)
-                            .font(.body)
+                            .font(AppFont.body)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)
 
                         Text("onboarding.permission.body2", bundle: .module)
-                            .font(.body)
+                            .font(AppFont.body)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)
                     }
@@ -55,7 +54,7 @@ struct OnboardingPermissionView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
-                    .tint(.indigo)
+                    .tint(AppColor.reminderBlue)
                     .padding(.horizontal, AppSpacing.xl)
                     .accessibilityLabel(Text("onboarding.permission.enableButton", bundle: .module))
                     .accessibilityHint(Text("onboarding.permission.enableButton.hint", bundle: .module))
@@ -93,10 +92,10 @@ private struct NotificationPreviewCard: View {
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
                 Image(systemName: AppSymbol.eyeBreak)
-                    .foregroundStyle(.indigo)
-                    .font(.caption)
+                    .foregroundStyle(AppColor.reminderBlue)
+                    .font(AppFont.caption)
                 Text("onboarding.permission.notificationCard.appName", bundle: .module)
-                    .font(.caption)
+                    .font(AppFont.caption)
                     .fontWeight(.semibold)
                     .foregroundStyle(.secondary)
                 Spacer()

--- a/EyePostureReminder/Views/Onboarding/OnboardingSetupView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingSetupView.swift
@@ -19,12 +19,11 @@ struct OnboardingSetupView: View {
                     // Headline + subheadline
                     VStack(spacing: AppSpacing.sm) {
                         Text("onboarding.setup.title", bundle: .module)
-                            .font(.title2)
-                            .fontWeight(.bold)
+                            .font(AppFont.headline)
                             .multilineTextAlignment(.center)
 
                         Text("onboarding.setup.subtitle", bundle: .module)
-                            .font(.headline)
+                            .font(AppFont.bodyEmphasized)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)
                     }
@@ -33,14 +32,14 @@ struct OnboardingSetupView: View {
                     VStack(spacing: AppSpacing.md) {
                         SetupPreviewCard(
                             icon: AppSymbol.eyeBreak,
-                            color: .indigo,
+                            color: AppColor.reminderBlue,
                             title: String(localized: "onboarding.setup.eyeBreaks.title", bundle: .module),
                             interval: String(localized: "onboarding.setup.eyeBreaks.interval", bundle: .module),
                             duration: String(localized: "onboarding.setup.eyeBreaks.duration", bundle: .module)
                         )
                         SetupPreviewCard(
                             icon: AppSymbol.postureCheck,
-                            color: .green,
+                            color: AppColor.reminderGreen,
                             title: String(localized: "onboarding.setup.postureChecks.title", bundle: .module),
                             interval: String(localized: "onboarding.setup.postureChecks.interval", bundle: .module),
                             duration: String(localized: "onboarding.setup.postureChecks.duration", bundle: .module)
@@ -50,7 +49,7 @@ struct OnboardingSetupView: View {
 
                     // Reassurance copy
                     Text("onboarding.setup.body", bundle: .module)
-                        .font(.body)
+                        .font(AppFont.body)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, AppSpacing.sm)
@@ -64,7 +63,7 @@ struct OnboardingSetupView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
-                    .tint(.indigo)
+                    .tint(AppColor.reminderBlue)
                     .padding(.horizontal, AppSpacing.xl)
                     .accessibilityLabel(Text("onboarding.setup.getStartedButton", bundle: .module))
                     .accessibilityHint(Text("onboarding.setup.getStartedButton.hint", bundle: .module))
@@ -74,7 +73,7 @@ struct OnboardingSetupView: View {
                         Text("onboarding.setup.customizeButton", bundle: .module)
                             .frame(minHeight: 44)
                     }
-                        .foregroundStyle(.indigo)
+                        .foregroundStyle(AppColor.reminderBlue)
                         .font(.subheadline)
                         .accessibilityLabel(Text("onboarding.setup.customizeButton", bundle: .module))
                         .accessibilityHint(Text("onboarding.setup.customizeButton.hint", bundle: .module))

--- a/EyePostureReminder/Views/Onboarding/OnboardingWelcomeView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingWelcomeView.swift
@@ -18,11 +18,11 @@ struct OnboardingWelcomeView: View {
                     HStack(spacing: AppSpacing.lg) {
                         Image(systemName: AppSymbol.eyeBreak)
                             .font(.system(size: 72))
-                            .foregroundStyle(.indigo)
+                            .foregroundStyle(AppColor.reminderBlue)
                             .accessibilityHidden(true)
                         Image(systemName: AppSymbol.postureCheck)
                             .font(.system(size: 72))
-                            .foregroundStyle(.green)
+                            .foregroundStyle(AppColor.reminderGreen)
                             .accessibilityHidden(true)
                     }
                     .padding(AppSpacing.xl)
@@ -33,19 +33,18 @@ struct OnboardingWelcomeView: View {
                     // Headline + Subheadline
                     VStack(spacing: AppSpacing.sm) {
                         Text("onboarding.welcome.title", bundle: .module)
-                            .font(.title2)
-                            .fontWeight(.bold)
+                            .font(AppFont.headline)
                             .multilineTextAlignment(.center)
 
                         Text("onboarding.welcome.subtitle", bundle: .module)
-                            .font(.headline)
+                            .font(AppFont.bodyEmphasized)
                             .foregroundStyle(.secondary)
                             .multilineTextAlignment(.center)
                     }
 
                     // Value proposition body
                     Text("onboarding.welcome.body", bundle: .module)
-                        .font(.body)
+                        .font(AppFont.body)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, AppSpacing.sm)
@@ -59,7 +58,7 @@ struct OnboardingWelcomeView: View {
                     }
                     .buttonStyle(.borderedProminent)
                     .controlSize(.large)
-                    .tint(.indigo)
+                    .tint(AppColor.reminderBlue)
                     .padding(.horizontal, AppSpacing.xl)
                     .accessibilityLabel(Text("onboarding.welcome.nextButton", bundle: .module))
                     .accessibilityHint(Text("onboarding.welcome.nextButton.hint", bundle: .module))

--- a/EyePostureReminder/Views/ReminderRowView.swift
+++ b/EyePostureReminder/Views/ReminderRowView.swift
@@ -19,8 +19,8 @@ struct ReminderRowView: View {
         .onChange(of: isEnabled) { _ in onChanged() }
         .accessibilityHint(
             isEnabled
-                ? "Tap to disable \(type.title) reminders"
-                : "Tap to enable \(type.title) reminders"
+                ? String(format: String(localized: "settings.reminder.toggle.enabled.hint", bundle: .module), type.title)
+                : String(format: String(localized: "settings.reminder.toggle.disabled.hint", bundle: .module), type.title)
         )
 
         if isEnabled {
@@ -37,13 +37,18 @@ struct ReminderRowView: View {
                 )
             )
 
-            Picker("Break duration", selection: $breakDuration) {
+            Picker(String(localized: "settings.reminder.durationPicker", bundle: .module), selection: $breakDuration) {
                 ForEach(durationOptions, id: \.self) { seconds in
                     Text(formatDuration(seconds)).tag(seconds)
                 }
             }
             .onChange(of: breakDuration) { _ in onChanged() }
-            .accessibilityHint("Sets how long each \(type.title) break overlay stays on screen")
+            .accessibilityHint(
+                String(
+                    format: String(localized: "settings.reminder.durationPicker.hint", bundle: .module),
+                    type.title
+                )
+            )
         }
     }
 


### PR DESCRIPTION
Fixes two design system issues.

**Issue 32** — All 3 onboarding views replaced raw .indigo/.green colors with AppColor.reminderBlue/reminderGreen and raw .font(.title2)/.font(.headline)/.font(.body)/.font(.caption) with AppFont tokens.

**Issue 33** — ReminderRowView hardcoded English accessibility strings replaced with String(localized:) calls. 4 new keys added to Localizable.xcstrings: settings.reminder.toggle.enabled.hint, settings.reminder.toggle.disabled.hint, settings.reminder.durationPicker, settings.reminder.durationPicker.hint.

Closes 32, Closes 33