### PR TITLE
fix: Fix SwiftLint violations — sorted imports, closure syntax, exclude DerivedData

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -3,6 +3,8 @@
 
 # ── Excluded paths ────────────────────────────────────────────────────────────
 excluded:
+  - .build
+  - DerivedData
   - EyePostureReminder/DerivedData
   - EyePostureReminder/.build
   - Pods

--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -1,6 +1,6 @@
+import os
 import UIKit
 import UserNotifications
-import os
 
 final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 

--- a/EyePostureReminder/Services/ReminderScheduler.swift
+++ b/EyePostureReminder/Services/ReminderScheduler.swift
@@ -1,6 +1,6 @@
 import Foundation
-import UserNotifications
 import os
+import UserNotifications
 
 // MARK: - NotificationScheduling Protocol
 

--- a/EyePostureReminder/ViewModels/SettingsViewModel.swift
+++ b/EyePostureReminder/ViewModels/SettingsViewModel.swift
@@ -1,5 +1,5 @@
-import Foundation
 import Combine
+import Foundation
 import os
 
 /// Observable shell binding `SettingsStore` to Settings UI.

--- a/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
@@ -119,5 +119,5 @@ private struct NotificationPreviewCard: View {
 }
 
 #Preview {
-    OnboardingPermissionView(onNext: {})
+    OnboardingPermissionView { }
 }

--- a/EyePostureReminder/Views/Onboarding/OnboardingView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingView.swift
@@ -10,9 +10,9 @@ struct OnboardingView: View {
 
     var body: some View {
         TabView(selection: $currentPage) {
-            OnboardingWelcomeView(onNext: { currentPage = 1 })
+            OnboardingWelcomeView { currentPage = 1 }
                 .tag(0)
-            OnboardingPermissionView(onNext: { currentPage = 2 })
+            OnboardingPermissionView { currentPage = 2 }
                 .tag(1)
             OnboardingSetupView(
                 onGetStarted: finishOnboarding,

--- a/EyePostureReminder/Views/Onboarding/OnboardingWelcomeView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingWelcomeView.swift
@@ -72,5 +72,5 @@ struct OnboardingWelcomeView: View {
 }
 
 #Preview {
-    OnboardingWelcomeView(onNext: {})
+    OnboardingWelcomeView { }
 }

--- a/EyePostureReminder/Views/SettingsView.swift
+++ b/EyePostureReminder/Views/SettingsView.swift
@@ -55,9 +55,10 @@ struct SettingsView: View {
                         type: .eyes,
                         isEnabled: $settings.eyesEnabled,
                         interval: $settings.eyesInterval,
-                        breakDuration: $settings.eyesBreakDuration,
-                        onChanged: { viewModel?.reminderSettingChanged(for: .eyes) }
-                    )
+                        breakDuration: $settings.eyesBreakDuration
+                    ) {
+                        viewModel?.reminderSettingChanged(for: .eyes)
+                    }
                 } header: {
                     Text("settings.section.eyes", bundle: .module)
                 } footer: {
@@ -72,9 +73,10 @@ struct SettingsView: View {
                         type: .posture,
                         isEnabled: $settings.postureEnabled,
                         interval: $settings.postureInterval,
-                        breakDuration: $settings.postureBreakDuration,
-                        onChanged: { viewModel?.reminderSettingChanged(for: .posture) }
-                    )
+                        breakDuration: $settings.postureBreakDuration
+                    ) {
+                        viewModel?.reminderSettingChanged(for: .posture)
+                    }
                 } header: {
                     Text("settings.section.posture", bundle: .module)
                 } footer: {
@@ -89,39 +91,55 @@ struct SettingsView: View {
             Section {
                 if isSnoozed {
                     HStack {
-                        Label(String(format: String(localized: "settings.snooze.activeLabel", bundle: .module), snoozeUntilFormatted), systemImage: "moon.zzz.fill")
+                        Label(
+                            String(
+                                format: String(localized: "settings.snooze.activeLabel", bundle: .module),
+                                snoozeUntilFormatted
+                            ),
+                            systemImage: "moon.zzz.fill"
+                        )
                             .font(AppFont.body)
                             .foregroundStyle(AppColor.warningText)
                         Spacer()
                     }
                     .accessibilityElement(children: .ignore)
-                    .accessibilityLabel(String(format: String(localized: "settings.snooze.activeLabel.accessibility", bundle: .module), snoozeUntilFormatted))
+                    .accessibilityLabel(String(
+                        format: String(localized: "settings.snooze.activeLabel.accessibility", bundle: .module),
+                        snoozeUntilFormatted
+                    ))
 
                     Button(role: .destructive) {
                         viewModel?.cancelSnooze()
                     } label: {
-                        Label(title: { Text("settings.snooze.cancelButton", bundle: .module) }, icon: { Image(systemName: "bell.fill") })
+                        Label {
+                            Text("settings.snooze.cancelButton", bundle: .module)
+                        } icon: {
+                            Image(systemName: "bell.fill")
+                        }
                             .font(AppFont.body)
                     }
                     .accessibilityHint(Text("settings.snooze.cancelButton.hint", bundle: .module))
                 } else {
-                    Button(action: { viewModel?.snooze(option: .fiveMinutes) }) {
-                        Text("settings.snooze.5min", bundle: .module)
-                    }
+                    Button(
+                        action: { viewModel?.snooze(option: .fiveMinutes) },
+                        label: { Text("settings.snooze.5min", bundle: .module) }
+                    )
                     .font(AppFont.body)
                     .accessibilityLabel(Text("settings.snooze.5min.label", bundle: .module))
                     .accessibilityHint(Text("settings.snooze.5min.hint", bundle: .module))
 
-                    Button(action: { viewModel?.snooze(option: .oneHour) }) {
-                        Text("settings.snooze.1hour", bundle: .module)
-                    }
+                    Button(
+                        action: { viewModel?.snooze(option: .oneHour) },
+                        label: { Text("settings.snooze.1hour", bundle: .module) }
+                    )
                     .font(AppFont.body)
                     .accessibilityLabel(Text("settings.snooze.1hour.label", bundle: .module))
                     .accessibilityHint(Text("settings.snooze.1hour.hint", bundle: .module))
 
-                    Button(action: { viewModel?.snooze(option: .restOfDay) }) {
-                        Text("settings.snooze.restOfDay", bundle: .module)
-                    }
+                    Button(
+                        action: { viewModel?.snooze(option: .restOfDay) },
+                        label: { Text("settings.snooze.restOfDay", bundle: .module) }
+                    )
                     .font(AppFont.body)
                     .foregroundStyle(AppColor.warningText)
                     .accessibilityLabel(Text("settings.snooze.restOfDay.label", bundle: .module))
@@ -161,13 +179,14 @@ struct SettingsView: View {
                     .accessibilityElement(children: .ignore)
                         .accessibilityLabel(Text("settings.notifications.disabledLabel", bundle: .module))
 
-                    Button(action: {
-                        if let url = URL(string: UIApplication.openSettingsURLString) {
-                            UIApplication.shared.open(url)
-                        }
-                    }) {
-                        Text("settings.notifications.openSettings", bundle: .module)
-                    }
+                    Button(
+                        action: {
+                            if let url = URL(string: UIApplication.openSettingsURLString) {
+                                UIApplication.shared.open(url)
+                            }
+                        },
+                        label: { Text("settings.notifications.openSettings", bundle: .module) }
+                    )
                     .font(AppFont.body)
                     .accessibilityHint(Text("settings.notifications.openSettings.hint", bundle: .module))
                 }

--- a/Tests/EyePostureReminderTests/Mocks/MockMediaControlling.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockMediaControlling.swift
@@ -1,5 +1,5 @@
-import Foundation
 @testable import EyePostureReminder
+import Foundation
 
 /// Mock implementation of `MediaControlling` for unit tests.
 ///

--- a/Tests/EyePostureReminderTests/Mocks/MockNotificationCenter.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockNotificationCenter.swift
@@ -1,6 +1,6 @@
+@testable import EyePostureReminder
 import Foundation
 import UserNotifications
-@testable import EyePostureReminder
 
 /// Mock implementation of `NotificationScheduling` for unit tests.
 ///

--- a/Tests/EyePostureReminderTests/Mocks/MockOverlayPresenting.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockOverlayPresenting.swift
@@ -1,5 +1,5 @@
-import Foundation
 @testable import EyePostureReminder
+import Foundation
 
 /// Mock implementation of `OverlayPresenting` for unit tests.
 ///

--- a/Tests/EyePostureReminderTests/Mocks/MockReminderScheduler.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockReminderScheduler.swift
@@ -1,5 +1,5 @@
-import Foundation
 @testable import EyePostureReminder
+import Foundation
 
 /// Mock implementation of `ReminderScheduling` for SettingsViewModel unit tests.
 ///

--- a/Tests/EyePostureReminderTests/Mocks/MockSettingsPersisting.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockSettingsPersisting.swift
@@ -1,5 +1,5 @@
-import Foundation
 @testable import EyePostureReminder
+import Foundation
 
 /// In-memory implementation of `SettingsPersisting` for unit tests.
 ///

--- a/Tests/EyePostureReminderTests/Models/ReminderTypeTests.swift
+++ b/Tests/EyePostureReminderTests/Models/ReminderTypeTests.swift
@@ -6,7 +6,9 @@ final class ReminderTypeTests: XCTestCase {
     // MARK: - CaseIterable / Exhaustiveness
 
     func test_allCases_countIsTwo() {
-        XCTAssertEqual(ReminderType.allCases.count, 2,
+        XCTAssertEqual(
+            ReminderType.allCases.count,
+            2,
             "Adding a new ReminderType case requires updating this test and all switch statements.")
     }
 
@@ -157,7 +159,9 @@ final class ReminderTypeTests: XCTestCase {
     func test_initFromCategoryIdentifier_roundtrip_forAllCases() {
         for type in ReminderType.allCases {
             let roundtripped = ReminderType(categoryIdentifier: type.categoryIdentifier)
-            XCTAssertEqual(roundtripped, type,
+            XCTAssertEqual(
+                roundtripped,
+                type,
                 "Round-trip via categoryIdentifier failed for \(type.rawValue)")
         }
     }

--- a/Tests/EyePostureReminderTests/Models/ReminderTypeTests.swift
+++ b/Tests/EyePostureReminderTests/Models/ReminderTypeTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import EyePostureReminder
+import XCTest
 
 final class ReminderTypeTests: XCTestCase {
 

--- a/Tests/EyePostureReminderTests/Models/SettingsStorePhase2Tests.swift
+++ b/Tests/EyePostureReminderTests/Models/SettingsStorePhase2Tests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import EyePostureReminder
+import XCTest
 
 /// Phase 2 unit tests for `SettingsStore` covering haptics and snooze-count persistence.
 final class SettingsStorePhase2Tests: XCTestCase {

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -364,7 +364,9 @@ final class AppCoordinatorTests: XCTestCase {
             pauseConditionProvider: mockPause
         )
         defer { coordinator.stopFallbackTimers() }
-        XCTAssertEqual(mockPause.startMonitoringCallCount, 1,
+        XCTAssertEqual(
+            mockPause.startMonitoringCallCount,
+            1,
             "AppCoordinator.init must call startMonitoring() on the injected PauseConditionProviding")
     }
 
@@ -381,7 +383,9 @@ final class AppCoordinatorTests: XCTestCase {
             pauseConditionProvider: MockPauseConditionProvider()
         )
         coordinator.stopFallbackTimers()
-        XCTAssertEqual(mockTracker.stopCallCount, 1,
+        XCTAssertEqual(
+            mockTracker.stopCallCount,
+            1,
             "stopFallbackTimers must call stop() on the injected ScreenTimeTracking")
     }
 }

--- a/Tests/EyePostureReminderTests/Services/AudioInterruptionManagerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AudioInterruptionManagerTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import EyePostureReminder
+import XCTest
 
 /// Unit tests for `AudioInterruptionManager`.
 ///

--- a/Tests/EyePostureReminderTests/Services/OverlayManagerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/OverlayManagerTests.swift
@@ -109,7 +109,9 @@ final class OverlayManagerTests: XCTestCase {
         mock.showOverlay(for: .posture, duration: 10, hapticsEnabled: true) {}
         mock.showOverlay(for: .eyes, duration: 30, hapticsEnabled: false) {}
 
-        XCTAssertEqual(mock.showCallOrder, [.eyes, .posture, .eyes],
+        XCTAssertEqual(
+            mock.showCallOrder,
+            [.eyes, .posture, .eyes],
             "showOverlay calls must be recorded in FIFO (first-in, first-out) order")
         XCTAssertEqual(mock.showCallDurations, [20, 10, 30])
         XCTAssertEqual(mock.showCallCount, 3)

--- a/Tests/EyePostureReminderTests/Services/OverlayManagerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/OverlayManagerTests.swift
@@ -1,5 +1,5 @@
-import XCTest
 @testable import EyePostureReminder
+import XCTest
 
 /// Unit tests for `OverlayManager`.
 ///

--- a/Tests/EyePostureReminderTests/Views/DesignSystemTests.swift
+++ b/Tests/EyePostureReminderTests/Views/DesignSystemTests.swift
@@ -92,7 +92,9 @@ final class DesignSystemTests: XCTestCase {
     func test_appSpacing_valuesAreAscending() {
         let spacings: [CGFloat] = [AppSpacing.xs, AppSpacing.sm, AppSpacing.md, AppSpacing.lg, AppSpacing.xl]
         for i in 1..<spacings.count {
-            XCTAssertGreaterThan(spacings[i], spacings[i - 1],
+            XCTAssertGreaterThan(
+                spacings[i],
+                spacings[i - 1],
                 "Spacing tokens must be in strictly ascending order")
         }
     }
@@ -100,13 +102,17 @@ final class DesignSystemTests: XCTestCase {
     // MARK: - AppLayout: iOS HIG Compliance
 
     func test_appLayout_minTapTarget_meetsHIGMinimum() {
-        XCTAssertGreaterThanOrEqual(AppLayout.minTapTarget, 44,
+        XCTAssertGreaterThanOrEqual(
+            AppLayout.minTapTarget,
+            44,
             "Minimum tap target must be ≥44pt per iOS HIG")
     }
 
     func test_appLayout_overlayIconSize_isReasonable() {
         XCTAssertGreaterThan(AppLayout.overlayIconSize, 0)
-        XCTAssertGreaterThanOrEqual(AppLayout.overlayIconSize, AppLayout.minTapTarget,
+        XCTAssertGreaterThanOrEqual(
+            AppLayout.overlayIconSize,
+            AppLayout.minTapTarget,
             "Overlay icon must be at least as large as minimum tap target")
     }
 
@@ -119,7 +125,9 @@ final class DesignSystemTests: XCTestCase {
     }
 
     func test_appLayout_snoozeButtonHeight_meetsHIGMinimum() {
-        XCTAssertGreaterThanOrEqual(AppLayout.snoozeButtonHeight, 44,
+        XCTAssertGreaterThanOrEqual(
+            AppLayout.snoozeButtonHeight,
+            44,
             "Snooze button height must be ≥44pt per iOS HIG")
     }
 
@@ -134,22 +142,34 @@ final class DesignSystemTests: XCTestCase {
     // MARK: - AppAnimation: Duration Spec Compliance
 
     func test_appAnimation_overlayAppear_is0point3s() {
-        XCTAssertEqual(AppAnimation.overlayAppear, 0.3, accuracy: 0.001,
+        XCTAssertEqual(
+            AppAnimation.overlayAppear,
+            0.3,
+            accuracy: 0.001,
             "Overlay appear animation must be 0.3s (ease-out)")
     }
 
     func test_appAnimation_overlayDismiss_is0point2s() {
-        XCTAssertEqual(AppAnimation.overlayDismiss, 0.2, accuracy: 0.001,
+        XCTAssertEqual(
+            AppAnimation.overlayDismiss,
+            0.2,
+            accuracy: 0.001,
             "Overlay dismiss animation must be 0.2s (ease-in)")
     }
 
     func test_appAnimation_overlayAutoDismiss_is0point3s() {
-        XCTAssertEqual(AppAnimation.overlayAutoDismiss, 0.3, accuracy: 0.001,
+        XCTAssertEqual(
+            AppAnimation.overlayAutoDismiss,
+            0.3,
+            accuracy: 0.001,
             "Overlay auto-dismiss animation must be 0.3s (linear)")
     }
 
     func test_appAnimation_snoozeAutoDismiss_is5s() {
-        XCTAssertEqual(AppAnimation.snoozeAutoDismiss, 5.0, accuracy: 0.001,
+        XCTAssertEqual(
+            AppAnimation.snoozeAutoDismiss,
+            5.0,
+            accuracy: 0.001,
             "Snooze sheet auto-dismiss timeout must be 5 seconds")
     }
 

--- a/Tests/EyePostureReminderTests/Views/DesignSystemTests.swift
+++ b/Tests/EyePostureReminderTests/Views/DesignSystemTests.swift
@@ -1,6 +1,6 @@
-import XCTest
-import SwiftUI
 @testable import EyePostureReminder
+import SwiftUI
+import XCTest
 
 /// Regression tests for `DesignSystem.swift` — the single source of truth for
 /// all visual tokens (colors, fonts, spacing, animation, layout).


### PR DESCRIPTION
## Summary

Fixes three SwiftLint issues in one branch:

### #19 — Sorted Imports (14 violations)
Sorted `import` statements alphabetically in 13 Swift files across the app and test targets.

### #20 — Closure Syntax & Line Length (1 error, 13 warnings in SettingsView + Onboarding)
- Converted labeled-argument closures to trailing closure syntax in `OnboardingView`, `OnboardingPermissionView`, `OnboardingWelcomeView`
- Fixed `multiple_closures_with_trailing_closure` in `SettingsView` (Button calls now use explicit `label:` parameter)
- Broke long lines in the snooze section to comply with `line_length` rule (160-char error + 120-char warnings)

### #21 — Exclude DerivedData (8 false positives)
Added `.build` and `DerivedData` root-level paths to the `excluded` list in `.swiftlint.yml`.

## Verification
- SwiftLint passes with zero violations for the three issue categories
- Build succeeded ✓

Closes #19, Closes #20, Closes #21