### PR TITLE
fix: Make snooze-wake notification silent + clear stale snoozedUntil on foreground

### DIFF
--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -19,6 +19,17 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         return true
     }
 
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        // Safety net: if the snooze-wake notification was swiped away on a killed
+        // app the in-process Task never fires. Clear any stale snoozedUntil so the
+        // first scheduleReminders() call (via EyePostureReminderApp .task) sees a
+        // clean slate. handleForegroundTransition() handles the background→foreground
+        // path; this covers cold-launch after a dismissed snooze-wake notification.
+        Task { @MainActor [weak self] in
+            await self?.coordinator?.clearExpiredSnoozeIfNeeded()
+        }
+    }
+
     // MARK: - UNUserNotificationCenterDelegate
 
     /// Foreground delivery — show overlay immediately via coordinator.

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -296,6 +296,18 @@ final class AppCoordinator: ObservableObject {
 
     // MARK: - App Lifecycle Hooks
 
+    /// Clears `snoozedUntil` if it has already passed.
+    ///
+    /// Called by `AppDelegate.applicationDidBecomeActive` so that a stale
+    /// `snoozedUntil` (left by a swiped-away snooze-wake notification on a
+    /// killed app) is cleaned up before `scheduleReminders()` runs.
+    func clearExpiredSnoozeIfNeeded() async {
+        guard let snoozeEnd = settings.snoozedUntil, snoozeEnd <= Date() else { return }
+        settings.snoozedUntil = nil
+        settings.snoozeCount  = 0
+        Logger.scheduling.info("clearExpiredSnoozeIfNeeded: stale snoozedUntil cleared")
+    }
+
     /// Called when the app returns to the foreground from background.
     ///
     /// Clears any expired snooze and re-arms the wake task if snooze is still
@@ -385,9 +397,15 @@ final class AppCoordinator: ObservableObject {
         let interval = max(1, date.timeIntervalSinceNow)
 
         let content = UNMutableNotificationContent()
-        content.title              = "Reminders Resumed"
-        content.body               = "Your eye and posture reminders are now active again."
-        content.sound              = nil   // silent — informational only
+        // Truly silent wake notification — no banner, no sound, no badge.
+        // iOS 15+ .passive level suppresses lock-screen display and sound entirely.
+        content.title              = ""
+        content.body               = ""
+        content.sound              = nil
+        content.badge              = nil
+        if #available(iOS 15, *) {
+            content.interruptionLevel = .passive
+        }
         content.categoryIdentifier = Self.snoozeWakeCategory
 
         let trigger = UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false)


### PR DESCRIPTION
## Problem

The snooze-wake notification (used to wake the app after a snooze period) was showing a visible banner to users because it had a `title` and `body` set. Additionally, if a user swiped away the snooze-wake notification on a killed app, `snoozedUntil` could remain stale until the next manual open.

## Fix

### 1. Silent notification (`AppCoordinator.swift`)
- Cleared `title` and `body` on the `UNMutableNotificationContent`
- Kept `sound = nil`
- Added explicit `badge = nil`
- Set `interruptionLevel = .passive` (iOS 15+) — suppresses banner, sound, and screen-wake entirely

### 2. Stale `snoozedUntil` safety net (`AppCoordinator.swift` + `AppDelegate.swift`)
- Added `clearExpiredSnoozeIfNeeded()` to `AppCoordinator` — clears `snoozedUntil`/`snoozeCount` if already past
- Called it from `AppDelegate.applicationDidBecomeActive` as a first-line safety net covering the killed-app + swiped-notification path (before `scheduleReminders()` runs)

Closes #29