### PR TITLE
fix: VoiceOver accessibility P1/P2 fixes

### DIFF
--- a/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
@@ -11,6 +11,8 @@ struct OnboardingPermissionView: View {
     let onNext: () -> Void
     private let notificationCenter: NotificationScheduling
 
+    @Environment(\.accessibilityEnabled) private var accessibilityEnabled
+
     init(onNext: @escaping () -> Void,
          notificationCenter: NotificationScheduling = UNUserNotificationCenter.current()) {
         self.onNext = onNext
@@ -70,11 +72,11 @@ struct OnboardingPermissionView: View {
                 .padding()
                 .frame(maxWidth: AppLayout.onboardingMaxContentWidth)
                 .frame(maxWidth: .infinity)
-                // Use highPriorityGesture so this view consumes horizontal drags
-                // before the parent TabView sees them, preventing accidental swipe
-                // past the permission screen.
+                // Block horizontal drags to prevent accidental swipe past the
+                // permission screen — but only when VoiceOver is off, so the
+                // three-finger page-navigation gesture still works.
                 .highPriorityGesture(
-                    DragGesture(minimumDistance: 10)
+                    DragGesture(minimumDistance: accessibilityEnabled ? .infinity : 10)
                         .onChanged { _ in }
                 )
             }

--- a/EyePostureReminder/Views/OverlayView.swift
+++ b/EyePostureReminder/Views/OverlayView.swift
@@ -52,6 +52,11 @@ struct OverlayView: View {
             dismissButton
             centerContent
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityAddTraits(.isModal)
+        .accessibilityAction(AccessibilityActionKind.escape) {
+            performDismiss(method: .button)
+        }
         .opacity(contentOpacity)
         .offset(y: slideOffset)
         .gesture(swipeUpDismissGesture)

--- a/EyePostureReminder/Views/SettingsView.swift
+++ b/EyePostureReminder/Views/SettingsView.swift
@@ -513,6 +513,7 @@ private struct SettingsNotificationWarningSection: View {
                 .font(AppFont.body)
                 .foregroundStyle(AppColor.accentWarm)
                 .accessibilityHint(Text("settings.notifications.openSettings.hint", bundle: .module))
+                .accessibilityIdentifier("settings.notifications.openSettings")
                 .listRowBackground(AppColor.accentWarm.opacity(AppOpacity.warningBackground))
                 .listRowSeparatorTint(AppColor.accentWarm.opacity(AppOpacity.warningSeparator))
             }

--- a/EyePostureReminder/Views/YinYangEyeView.swift
+++ b/EyePostureReminder/Views/YinYangEyeView.swift
@@ -67,6 +67,15 @@ struct YinYangEyeView: View {
                 breathing = false
             }
         }
+        .onChange(of: reduceMotion) { newValue in
+            if newValue {
+                withAnimation(.easeInOut(duration: 0.3)) {
+                    breathing = false
+                }
+            } else if isVisible {
+                startAnimations()
+            }
+        }
     }
 
     private func startAnimations() {


### PR DESCRIPTION
## Summary
Fixes four VoiceOver / accessibility issues (2× P1, 2× P2).

### Fix 1 (P1): OverlayView — escape action for Z-scrub dismiss
- Added `.accessibilityAction(.escape)` so VoiceOver users can dismiss the overlay with the standard two-finger Z-scrub gesture
- Added `.accessibilityAddTraits(.isModal)` as defense-in-depth (complements the UIKit-level setting in OverlayManager)

### Fix 2 (P1): OnboardingPermissionView — unblock VoiceOver page navigation
- The `highPriorityGesture(DragGesture(...))` was consuming three-finger swipes, trapping VoiceOver users on page 2
- Now uses `@Environment(\.accessibilityEnabled)` to set `minimumDistance: .infinity` when assistive tech is active, effectively disabling the blocking gesture

### Fix 3 (P2): YinYangEyeView — respect Reduce Motion changes at runtime
- Added `.onChange(of: reduceMotion)` to stop the breathing animation immediately when Reduce Motion is enabled mid-session, and restart it when disabled

### Fix 4 (P2): SettingsView — add missing accessibilityIdentifier
- Added `.accessibilityIdentifier("settings.notifications.openSettings")` to the notification warning button

**Build:** ✅ zero errors, zero warnings