### PR TITLE
docs(uitests): remove stale 'reserved for future' from showOverlayEyes/showOverlayPosture (#344)

### DIFF
--- a/Tests/EyePostureReminderUITests/UITestHelpers.swift
+++ b/Tests/EyePostureReminderUITests/UITestHelpers.swift
@@ -15,9 +15,9 @@ enum TestLaunchArguments {
     static let skipOnboarding = "--skip-onboarding"
     /// Clears `hasSeenOnboarding` → app starts fresh with the onboarding flow.
     static let resetOnboarding = "--reset-onboarding"
-    /// Triggers the eye break overlay immediately on launch (reserved for future test-mode support).
+    /// Triggers the eye break overlay immediately on launch; used by OverlayTests and DarkModeUITests to display the overlay without waiting for the timer.
     static let showOverlayEyes = "--show-overlay-eyes"
-    /// Triggers the posture check overlay immediately on launch (reserved for future test-mode support).
+    /// Triggers the posture check overlay immediately on launch; used by OverlayTests and DarkModeUITests to display the overlay without waiting for the timer.
     static let showOverlayPosture = "--show-overlay-posture"
 }
 


### PR DESCRIPTION
Fixes #344

Both `showOverlayEyes` and `showOverlayPosture` launch arguments are already active in `OverlayTests` and `DarkModeUITests`. Updated doc comments to describe their actual purpose instead of the stale 'reserved for future test-mode support' wording.

No runtime behavior changed.