### PR TITLE
fix: resolve App Group mismatch and update App Store SKU

### DIFF
--- a/.squad/agents/virgil/history.md
+++ b/.squad/agents/virgil/history.md
@@ -142,3 +142,21 @@ Orchestration log recorded at 2026-04-30T09:27:10Z. Enhanced CI diagnostics docu
 - Preserved build-for-testing + test-without-building flow and TEST_TARGET_NAME ambiguity workaround; shard filtering is applied via `-only-testing` during `test-without-building`.
 - Added per-shard `.xcresult` paths and artifact names to prevent collisions in parallel jobs.
 - Local validation performed: shell syntax checks, CI YAML parse check, `./scripts/build.sh build`, and a targeted shard run (`HomeScreenTests`) using the new flags.
+
+## 2026-04-30 — Release/TestFlight triage pass (#379, #377, #196, #185, #201, #410)
+
+- Completed code-fixable pre-submission blockers in PR #415:
+  - #379: Renamed shared App Group identifier to `group.com.yashasg.kshana` across all app/extension entitlements, shared constants, tests, and technical docs to match bundle prefix.
+  - #377: Updated App Store SKU in `docs/APP_STORE_LISTING.md` from `eye-posture-reminder` to `kshana` and added explicit immutable-SKU setup checklist item.
+- Validation performed:
+  - Baseline `./scripts/build.sh all` passed before changes.
+  - Post-change `./scripts/build.sh all` passed after changes.
+- External/manual issues triaged with concrete unblock checklists posted:
+  - #196 (Custom EULA upload in ASC), #185 (public HTTPS privacy policy hosting + ASC metadata wiring), #201 (Apple entitlement follow-up case 102881605113).
+- Dependency status:
+  - #410 confirmed BLOCKED in issue comment because #201 remains unresolved.
+
+### Learnings
+- For release-readiness tasks, mirror every in-repo config change with an explicit App Store Connect checklist line so operations cannot drift from source-controlled intent.
+- App Group identifiers should match the bundle namespace prefix when possible; mismatched prefixes create avoidable provisioning and registration mistakes during first submission.
+- `./scripts/build.sh all` mutates `TestResults.xcresult/Info.plist`; keep that artifact out of commits during docs/config triage by explicitly reverting it before commit.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -374,7 +374,7 @@ Tests/
   - Push Notifications (for `UNUserNotificationCenter`)
   - Motion usage (`NSMotionUsageDescription` — driving detection)
   - Focus status usage (`NSFocusStatusUsageDescription` — Focus Mode detection)
-  - App Groups (`group.com.yashasgujjar.kshana`) for main app ↔ Screen Time extension state
+  - App Groups (`group.com.yashasg.kshana`) for main app ↔ Screen Time extension state
   - FamilyControls entitlement (`com.apple.developer.family-controls`) for runtime Screen Time shielding, blocked on Apple approval in #201
   - No `UIBackgroundModes: audio` (audio session is foreground-only)
 
@@ -958,7 +958,7 @@ Phase 3 requires a new Xcode project (or XcodeGen `project.yml`) with **four tar
 
 All four targets must:
 - Be in the **same Xcode project**
-- Share **App Groups entitlement** (`com.apple.security.application-groups` with ID `group.com.yashasgujjar.kshana`)
+- Share **App Groups entitlement** (`com.apple.security.application-groups` with ID `group.com.yashasg.kshana`)
 - Carry **FamilyControls entitlement** (`com.apple.developer.family-controls` with `individual` scope)
 
 ---
@@ -1002,7 +1002,7 @@ class DeviceActivityMonitor: DeviceActivityScheduler {
         // Called by system when a scheduled interval begins (e.g., 20 min of Safari use)
         
         // Read App Group state to determine which apps to shield
-        let shared = UserDefaults(suiteName: "group.com.yashasgujjar.kshana")
+        let shared = UserDefaults(suiteName: "group.com.yashasg.kshana")
         let shieldedApps = shared?.array(forKey: "shieldedApps") as? [String] ?? []
         
         // Apply ManagedSettingsStore shields
@@ -1015,7 +1015,7 @@ class DeviceActivityMonitor: DeviceActivityScheduler {
     
     override func intervalDidEnd(for activity: DeviceActivityName) {
         // Called when interval ends; main app can resume
-        let shared = UserDefaults(suiteName: "group.com.yashasgujjar.kshana")
+        let shared = UserDefaults(suiteName: "group.com.yashasg.kshana")
         shared?.set(["shieldActive": false], forKey: "shieldState")
     }
 }
@@ -1023,7 +1023,7 @@ class DeviceActivityMonitor: DeviceActivityScheduler {
 
 **Key points:**
 - Extension runs in **separate process** (XPC sandbox) — no direct access to main app memory
-- Only communication channel: **App Groups shared container** (`UserDefaults(suiteName: "group.com.yashasgujjar.kshana")`)
+- Only communication channel: **App Groups shared container** (`UserDefaults(suiteName: "group.com.yashasg.kshana")`)
 - Extension is **system-triggered** — not user-triggered, not controlled by main app
 
 ---
@@ -1091,7 +1091,7 @@ class ShieldActionHandler: ShieldActionDelegate {
         
         if action.label == ShieldConfiguration.Label(text: "Start Break") {
             // User tapped "Start Break" — defer (keep shield) + signal main app
-            let shared = UserDefaults(suiteName: "group.com.yashasgujjar.kshana")
+            let shared = UserDefaults(suiteName: "group.com.yashasg.kshana")
             shared?.set(Date.now, forKey: "breakStartedAt")
             verdict = .defer
         } else {
@@ -1179,7 +1179,7 @@ This dual-mode design ensures:
 
 ### 5.5.10 App Group State Schema
 
-**Location:** `UserDefaults(suiteName: "group.com.yashasgujjar.kshana")`
+**Location:** `UserDefaults(suiteName: "group.com.yashasg.kshana")`
 
 Used by main app ↔ extension communication:
 

--- a/Extensions/DeviceActivityMonitorExtension/DeviceActivityMonitorExtension.Distribution.entitlements
+++ b/Extensions/DeviceActivityMonitorExtension/DeviceActivityMonitorExtension.Distribution.entitlements
@@ -5,7 +5,7 @@
 	<!-- App Group: enables reading ShieldSession keys written by the main app. -->
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.yashasgujjar.kshana</string>
+		<string>group.com.yashasg.kshana</string>
 	</array>
 	<!--
 	  com.apple.developer.family-controls is intentionally ABSENT from distribution entitlements.

--- a/Extensions/DeviceActivityMonitorExtension/DeviceActivityMonitorExtension.entitlements
+++ b/Extensions/DeviceActivityMonitorExtension/DeviceActivityMonitorExtension.entitlements
@@ -5,7 +5,7 @@
 	<!-- App Group: enables writing break reason/duration that extensions read. -->
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.yashasgujjar.kshana</string>
+		<string>group.com.yashasg.kshana</string>
 	</array>
 	<!--
 	  com.apple.developer.family-controls is intentionally ABSENT.

--- a/Extensions/DeviceActivityMonitorExtension/DeviceActivityMonitorExtension.swift
+++ b/Extensions/DeviceActivityMonitorExtension/DeviceActivityMonitorExtension.swift
@@ -3,7 +3,7 @@
 ///
 /// This extension applies and removes `ManagedSettingsStore` shield restrictions
 /// during a break session. It reads break context from the shared App Group
-/// `UserDefaults` (`group.com.yashasgujjar.kshana`) so it can customise shield
+/// `UserDefaults` (`group.com.yashasg.kshana`) so it can customise shield
 /// behaviour without importing the main app module.
 ///
 /// **Entitlement dependency:** Real shield application via `ManagedSettingsStore`
@@ -47,7 +47,7 @@ final class DeviceActivityMonitorExtensionImpl: DeviceActivityMonitor {
     /// fall back to a generic shield rather than skipping restrictions entirely.
     ///
     /// - Parameter defaults: The App Group `UserDefaults` suite. Defaults to the
-    ///   shared `group.com.yashasgujjar.kshana` suite.
+    ///   shared `group.com.yashasg.kshana` suite.
     static func readSession(
         from defaults: UserDefaults? = AppGroupDefaults.resolve(consumer: "DeviceActivityMonitorExtension")
     ) -> (reason: ShieldTriggerReason?, durationSeconds: Double, triggeredAt: Date?) {

--- a/Extensions/Shared/ShieldSessionKeys.swift
+++ b/Extensions/Shared/ShieldSessionKeys.swift
@@ -4,7 +4,7 @@
 /// `EyePostureReminder/Services/ScreenTimeShieldTypes.swift` (`ShieldSession`).
 /// Duplicated here because App Extension targets cannot import the main app module.
 ///
-/// App Group: `group.com.yashasgujjar.kshana`
+/// App Group: `group.com.yashasg.kshana`
 
 public enum ShieldSessionKeys {
     /// Encoded `ShieldSessionSnapshot` payload for atomic cross-process session reads.
@@ -16,5 +16,5 @@ public enum ShieldSessionKeys {
     /// Wall-clock trigger time stored as `timeIntervalSince1970` (`Double`).
     public static let triggeredAt = "shield.triggeredAt"
     /// Shared App Group suite name.
-    public static let appGroupID = "group.com.yashasgujjar.kshana"
+    public static let appGroupID = "group.com.yashasg.kshana"
 }

--- a/Extensions/ShieldConfigurationExtension/ShieldConfigurationDataSource.swift
+++ b/Extensions/ShieldConfigurationExtension/ShieldConfigurationDataSource.swift
@@ -4,7 +4,7 @@
 /// This stub compiles without the `com.apple.developer.family-controls`
 /// entitlement. Runtime shield rendering requires:
 ///   1. FamilyControls entitlement approved (issue #201)
-///   2. App Group provisioning profile including `group.com.yashasgujjar.kshana`
+///   2. App Group provisioning profile including `group.com.yashasg.kshana`
 ///
 /// The principal class is registered via `Info.plist` (`NSExtensionPrincipalClass`).
 /// `ShieldConfigurationDataSource` is an ObjC-rooted class; Swift subclasses are

--- a/Extensions/ShieldConfigurationExtension/ShieldConfigurationExtension.Distribution.entitlements
+++ b/Extensions/ShieldConfigurationExtension/ShieldConfigurationExtension.Distribution.entitlements
@@ -5,7 +5,7 @@
 	<!-- App Group: shared UserDefaults for Screen Time extension ↔ app communication (#202/#203). -->
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.yashasgujjar.kshana</string>
+		<string>group.com.yashasg.kshana</string>
 	</array>
 	<!--
 	  com.apple.developer.family-controls is intentionally ABSENT from distribution entitlements.

--- a/Extensions/ShieldConfigurationExtension/ShieldConfigurationExtension.entitlements
+++ b/Extensions/ShieldConfigurationExtension/ShieldConfigurationExtension.entitlements
@@ -5,7 +5,7 @@
 	<!-- App Group: enables reading ShieldSession keys written by the main app. -->
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.yashasgujjar.kshana</string>
+		<string>group.com.yashasg.kshana</string>
 	</array>
 	<!--
 	  com.apple.developer.family-controls is intentionally ABSENT.

--- a/EyePostureReminder/EyePostureReminder.Distribution.entitlements
+++ b/EyePostureReminder/EyePostureReminder.Distribution.entitlements
@@ -7,7 +7,7 @@
 	<!-- App Group: shared UserDefaults for Screen Time extension ↔ app communication (#202/#203). -->
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.yashasgujjar.kshana</string>
+		<string>group.com.yashasg.kshana</string>
 	</array>
 	<!--
 	  com.apple.developer.family-controls is intentionally ABSENT from distribution entitlements.

--- a/EyePostureReminder/EyePostureReminder.entitlements
+++ b/EyePostureReminder/EyePostureReminder.entitlements
@@ -7,7 +7,7 @@
 	<!-- App Group: shared UserDefaults for Screen Time extension ↔ app communication (#202/#203). -->
 	<key>com.apple.security.application-groups</key>
 	<array>
-		<string>group.com.yashasgujjar.kshana</string>
+		<string>group.com.yashasg.kshana</string>
 	</array>
 	<!--
 	  com.apple.developer.family-controls is intentionally ABSENT.

--- a/EyePostureReminder/Services/ScreenTimeShieldTypes.swift
+++ b/EyePostureReminder/Services/ScreenTimeShieldTypes.swift
@@ -51,7 +51,7 @@ struct ShieldSession: Sendable, Equatable {
         ShieldSessionSnapshot.isValidDurationSeconds(durationSeconds)
     }
 
-    // MARK: Shared UserDefaults keys (App Group: group.com.yashasgujjar.kshana)
+    // MARK: Shared UserDefaults keys (App Group: group.com.yashasg.kshana)
 
     static let sessionDataKey = ShieldSessionKeys.sessionData
     static let reasonKey = ShieldSessionKeys.breakReason

--- a/EyePostureReminder/Services/SelectedAppsState.swift
+++ b/EyePostureReminder/Services/SelectedAppsState.swift
@@ -7,7 +7,7 @@
 /// **Testability:** The initialiser accepts any `UserDefaults` instance so unit
 /// tests can pass an isolated in-memory suite without requiring the real App Group
 /// to exist (which demands a device + provisioning profile). Tests never touch the
-/// real `group.com.yashasgujjar.kshana` suite.
+/// real `group.com.yashasg.kshana` suite.
 ///
 /// **Token serialisation:** `ApplicationToken` and `ActivityCategoryToken` values
 /// from `FamilyControls` are opaque and not `Codable`. Only aggregate counts that

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -404,7 +404,7 @@ Local notification fallback ensures we gracefully degrade if Screen Time APIs un
 ### Architecture Changes (Phase 3)
 
 #### New Targets & Frameworks
-- **App Group:** `group.com.yashasgujjar.kshana` (shared between main app and extensions)
+- **App Group:** `group.com.yashasg.kshana` (shared between main app and extensions)
 - **Main App Entitlements:** `com.apple.developer.family-controls` (FamilyControls)
 - **ShieldConfiguration Extension:** Implements `ShieldConfigurationProvider` protocol (ManagedSettingsUI)
 - **ShieldAction Extension:** Implements `ShieldActionProvider` protocol for app/website unblocker buttons
@@ -537,7 +537,7 @@ Device resumes normal activity
 - **Owner:** Basher (Services Dev)
 - **Status:** 🔄 PLANNED
 - **Scope:**
-  - App Group (`group.com.yashasgujjar.kshana`) UserDefaults syncing config + state
+  - App Group (`group.com.yashasg.kshana`) UserDefaults syncing config + state
   - Main app writes: authorized apps, shield schedule, last shield time
   - Extensions read: config for shield rendering
   - Optional watchdog: separate app extension that monitors break compliance (logs to shared container)

--- a/Tests/EyePostureReminderTests/Services/DeviceActivityMonitoringValidationTests.swift
+++ b/Tests/EyePostureReminderTests/Services/DeviceActivityMonitoringValidationTests.swift
@@ -11,7 +11,7 @@ import XCTest
 ///
 /// ## What is NOT tested here
 /// - `DeviceActivityCenter` / `ManagedSettings` / `FamilyControls` — blocked by #201.
-/// - Real App Group `UserDefaults` (`group.com.yashasgujjar.kshana`) — requires device + entitlement.
+/// - Real App Group `UserDefaults` (`group.com.yashasg.kshana`) — requires device + entitlement.
 /// - Extension process lifecycle — requires Xcode project migration (M3.3).
 ///
 /// ## Coverage targets

--- a/Tests/EyePostureReminderTests/Services/SelectedAppsStateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/SelectedAppsStateTests.swift
@@ -5,7 +5,7 @@ import XCTest
 /// Unit tests for `SelectedAppsState` and shared App Group selection metadata.
 ///
 /// All tests use an isolated `UserDefaults` suite so they never touch the real
-/// App Group (`group.com.yashasgujjar.kshana`), which requires a provisioned
+/// App Group (`group.com.yashasg.kshana`), which requires a provisioned
 /// device + entitlement profile. This makes the tests runnable in any SPM host.
 @MainActor
 final class SelectedAppsStateTests: XCTestCase {
@@ -78,7 +78,7 @@ final class SelectedAppsStateTests: XCTestCase {
     func test_appGroupSuiteName_isStable() {
         XCTAssertEqual(
             SelectedAppsState.appGroupSuiteName,
-            "group.com.yashasgujjar.kshana",
+            "group.com.yashasg.kshana",
             "App Group suite name must match the provisioned App Group — changing it breaks extension communication"
         )
     }

--- a/docs/APP_STORE_LISTING.md
+++ b/docs/APP_STORE_LISTING.md
@@ -184,7 +184,7 @@ All App Store age rating questionnaire answers are "No" / "None".
 | Field | Value |
 |---|---|
 | **Bundle ID** | com.yashasg.eyeposturereminder |
-| **SKU** | eye-posture-reminder |
+| **SKU** | kshana |
 | **Copyright** | © 2026 Yashasg |
 | **Support URL** | https://github.com/yashasg/fantastic-octo-fortnight |
 | **Marketing URL** | https://github.com/yashasg/fantastic-octo-fortnight |
@@ -216,6 +216,11 @@ Complete every item before submitting for App Review.
 ### App Store Connect Configuration
 
 - [ ] Bundle ID finalized: `com.yashasg.eyeposturereminder`
+- [ ] App Group `group.com.yashasg.kshana` registered in Apple Developer Portal and associated with:
+  - `com.yashasg.eyeposturereminder`
+  - `com.yashasg.eyeposturereminder.shieldconfiguration`
+  - `com.yashasg.eyeposturereminder.deviceactivitymonitor`
+- [ ] SKU set in App Store Connect: `kshana` (must be unique; cannot be changed after creation)
 - [ ] Support URL set: `https://github.com/yashasg/fantastic-octo-fortnight`
 - [ ] App name, subtitle, keywords, and description finalized (Sections 1–4 above)
 - [ ] Age rating questionnaire completed (all answers "No" / "None" → 4+)

--- a/docs/SPIKE_SCREEN_TIME_APIS.md
+++ b/docs/SPIKE_SCREEN_TIME_APIS.md
@@ -68,7 +68,7 @@ kshana (Main App)
 - An Xcode project (`.xcodeproj`) with dedicated extension targets
 - Each extension has its own `Info.plist` (`NSExtension` key with `NSExtensionPointIdentifier`)
 - Each extension is embedded in the host via the "Embed App Extensions" build phase
-- Extensions and host share the same App Group (`group.com.yashasgujjar.kshana`)
+- Extensions and host share the same App Group (`group.com.yashasg.kshana`)
 
 This means **the current SPM-only project structure must be migrated to a proper Xcode project** before real Screen Time shield functionality can be added. This migration is the primary prerequisite for M3.3 (recommend new issue #203, see §8).
 
@@ -80,18 +80,18 @@ All three extension processes and the main app run in separate sandboxes. Commun
 
 | Mechanism | Use |
 |---|---|
-| `UserDefaults(suiteName: "group.com.yashasgujjar.kshana")` | Active shield state, break reason, duration |
+| `UserDefaults(suiteName: "group.com.yashasg.kshana")` | Active shield state, break reason, duration |
 | Shared file container | (Not needed for M3 scope) |
 | `CFNotificationCenter` (Darwin notifications) | (Not needed — extensions respond to DeviceActivity events, not app-initiated notifications) |
 
-**App Group identifier:** `group.com.yashasgujjar.kshana`  
+**App Group identifier:** `group.com.yashasg.kshana`  
 This must be added to both the main app and all three extension targets in their entitlements files.
 
 **Data written by main app, read by extensions:**
 ```
-group.com.yashasgujjar.kshana/shield.breakReason      — "eyes" | "posture"
-group.com.yashasgujjar.kshana/shield.durationSeconds  — Double / TimeInterval
-group.com.yashasgujjar.kshana/shield.triggeredAt      — Date
+group.com.yashasg.kshana/shield.breakReason      — "eyes" | "posture"
+group.com.yashasg.kshana/shield.durationSeconds  — Double / TimeInterval
+group.com.yashasg.kshana/shield.triggeredAt      — Date
 ```
 
 **Owned types (added in this spike):**
@@ -192,7 +192,7 @@ This preserves compatibility for users who haven't granted FamilyControls access
 1. Convert SPM-only project to Xcode project (retain `Package.swift` for test tooling compatibility)
 2. Add `ShieldConfigurationExtension` target with stub `ShieldConfigurationDataSource`
 3. Add `DeviceActivityMonitorExtension` target with stub `DeviceActivityMonitor`
-4. Configure app group `group.com.yashasgujjar.kshana` in all three entitlement files
+4. Configure app group `group.com.yashasg.kshana` in all three entitlement files
 5. Wire `ScreenTimeShieldProviding` protocol to a real `ScreenTimeShieldManager` (conditional compilation guard: `#if canImport(FamilyControls)`)
 6. Validate extension targets compile on device build (CI can't run these)
 


### PR DESCRIPTION
Summary: align shared App Group identifier to group.com.yashasg.kshana across app and extension entitlements, shared constants, tests, and technical docs. Update App Store listing SKU to kshana and add explicit submission checklist items for App Group registration and SKU setup. Validation: baseline scripts/build.sh all and post-change scripts/build.sh all passed. Closes #379. Closes #377.