### PR TITLE
ci: harden extension signing checks for #210

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: ["**"]
   pull_request:
     branches: [main]
 

--- a/.squad/agents/virgil/history.md
+++ b/.squad/agents/virgil/history.md
@@ -160,3 +160,22 @@ Orchestration log recorded at 2026-04-30T09:27:10Z. Enhanced CI diagnostics docu
 - For release-readiness tasks, mirror every in-repo config change with an explicit App Store Connect checklist line so operations cannot drift from source-controlled intent.
 - App Group identifiers should match the bundle namespace prefix when possible; mismatched prefixes create avoidable provisioning and registration mistakes during first submission.
 - `./scripts/build.sh all` mutates `TestResults.xcresult/Info.plist`; keep that artifact out of commits during docs/config triage by explicitly reverting it before commit.
+
+## 2026-04-30 — #210 CI/CD extension-signing hardening follow-up
+
+- Extended CI trigger coverage so tests run on push to any branch (`.github/workflows/ci.yml` now uses `push.branches: ["**"]`).
+- Hardened signed archive validation in `scripts/build_signed.sh`:
+  - Added `verify_archived_extensions()` to fail archive when `EXTENSION_PROFILES_AVAILABLE=YES` but extension `.appex` binaries are missing from `PlugIns/`.
+  - Keeps current blocked path intact (`EXTENSION_PROFILES_AVAILABLE=NO`) while enforcing correctness once #201 profiles are configured.
+- Fixed App Group identifier typo in signed-build doctor output:
+  - `group.com.yashasgujjar.kshana` → `group.com.yashasg.kshana`.
+
+### Validation
+- Baseline before changes: `./scripts/build.sh all && ./scripts/setup-screentime.sh --build` ✅
+- Post-change: `./scripts/build.sh all && ./scripts/setup-screentime.sh --build` ✅
+- Script checks: `bash -n scripts/build_signed.sh scripts/setup-screentime.sh scripts/build.sh` ✅
+- Signing diagnostics: `./scripts/build_signed.sh doctor` ✅
+
+### Learnings
+- Archive success is not enough for extension distribution; CI/signing scripts should assert expected `.appex` payload presence explicitly when extension signing is enabled.
+- Keeping `EXTENSION_PROFILES_AVAILABLE` as the switch preserves pre-approval flow while giving a strict post-approval gate with zero workflow changes.

--- a/scripts/build_signed.sh
+++ b/scripts/build_signed.sh
@@ -447,6 +447,37 @@ inject_build_number() {
   pass "CFBundleVersion set to $build_num in archive (source Info.plist unchanged)"
 }
 
+verify_archived_extensions() {
+  [[ "$EXTENSION_PROFILES_AVAILABLE" == "YES" ]] || return 0
+
+  local plugins_dir="${ARCHIVE_PATH}/Products/Applications/${APP_TARGET}.app/PlugIns"
+  local missing=0
+  local shield_appex="${plugins_dir}/ShieldConfigurationExtension.appex"
+  local monitor_appex="${plugins_dir}/DeviceActivityMonitorExtension.appex"
+
+  if [[ ! -d "$plugins_dir" ]]; then
+    fail "Archive is missing PlugIns directory: $plugins_dir"
+    return 1
+  fi
+
+  if [[ ! -d "$shield_appex" ]]; then
+    fail "Archive is missing ShieldConfiguration extension binary."
+    missing=1
+  fi
+
+  if [[ ! -d "$monitor_appex" ]]; then
+    fail "Archive is missing DeviceActivityMonitor extension binary."
+    missing=1
+  fi
+
+  if [[ "$missing" -ne 0 ]]; then
+    fail "Extension archive validation failed. Check extension target embedding/signing settings."
+    return 1
+  fi
+
+  pass "Archive includes ShieldConfiguration + DeviceActivityMonitor extensions"
+}
+
 run_xcodebuild() {
   local start
   local status
@@ -801,7 +832,7 @@ cmd_doctor() {
     if entitlements_requests_focus_status "$SIGNED_ENTITLEMENTS_PATH"; then
       warn "Signed entitlements request Focus Status. The App ID/profile must include that capability."
     elif entitlements_requests_app_groups "$SIGNED_ENTITLEMENTS_PATH"; then
-      warn "Signed entitlements request App Groups. The App ID/profile must include group.com.yashasgujjar.kshana."
+      warn "Signed entitlements request App Groups. The App ID/profile must include group.com.yashasg.kshana."
     else
       pass "Signed entitlements: App Store profile-safe"
     fi
@@ -894,6 +925,7 @@ cmd_archive() {
   fi
 
   inject_build_number
+  verify_archived_extensions
   pass "Archive created: $ARCHIVE_PATH"
 }
 


### PR DESCRIPTION
## Summary
- run CI on pushes to any branch so build/test/lint feedback is continuous
- harden scripts/build_signed.sh to verify extension appex payloads are present in archive when EXTENSION_PROFILES_AVAILABLE=YES
- fix signed-build doctor App Group hint typo (group.com.yashasg.kshana)
- append Virgil session learnings in .squad/agents/virgil/history.md

## Validation
- ./scripts/build.sh all && ./scripts/setup-screentime.sh --build (baseline)
- ./scripts/build.sh all && ./scripts/setup-screentime.sh --build (post-change)
- bash -n scripts/build_signed.sh scripts/setup-screentime.sh scripts/build.sh
- ./scripts/build_signed.sh doctor

## Issue
- Refs #210
- Remaining acceptance blockers are external to repo (#201 entitlement approval + extension distribution profiles/secrets in GitHub Actions).