### PR TITLE
ci: clean up all TestFlight signing temp assets

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -172,11 +172,6 @@ jobs:
             ASC_AUTH_KEY_PATH="$ASC_KEY_FILE" \
             ./scripts/build_signed.sh upload
 
-      # ── Clean up API key ──────────────────────────────────────────────────
-      - name: Clean up API key
-        if: always()
-        run: rm -f "$RUNNER_TEMP/asc_api_key.p8" || true
-
       # ── Upload IPA as artifact ────────────────────────────────────────────
       - name: Upload IPA artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
@@ -186,6 +181,12 @@ jobs:
           retention-days: 30
 
       # ── Cleanup signing assets ────────────────────────────────────────────
-      - name: Clean up keychain
+      - name: Clean up signing assets
         if: always()
-        run: security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" || true
+        run: |
+          rm -f "$RUNNER_TEMP/build_certificate.p12" || true
+          rm -f "$RUNNER_TEMP/build_pp.mobileprovision" || true
+          rm -f "$RUNNER_TEMP/shield_config_pp.mobileprovision" || true
+          rm -f "$RUNNER_TEMP/device_activity_pp.mobileprovision" || true
+          rm -f "$RUNNER_TEMP/asc_api_key.p8" || true
+          security delete-keychain "$RUNNER_TEMP/app-signing.keychain-db" || true


### PR DESCRIPTION
Summary:
- consolidate TestFlight cleanup into one always-run step
- delete decoded cert/profile temp files, optional extension profiles, API key, and keychain
- keep deploy flow unchanged

Validation:
- ruby -e "require \"yaml\"; YAML.load_file(\".github/workflows/testflight.yml\")"

Fixes #420
Refs #421