### PR TITLE
UX: Improve Smart Pause footer text for better feature discoverability

### DIFF
--- a/EyePostureReminder/Resources/Localizable.xcstrings
+++ b/EyePostureReminder/Resources/Localizable.xcstrings
@@ -1197,7 +1197,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Reminders resume when conditions end."
+            "value": "Automatically pauses reminders during Focus Mode or while driving. Reminders resume when these modes end."
           }
         }
       }


### PR DESCRIPTION
## Problem
Issue #433: Settings > Preferences includes Smart Pause toggles ("Pause During Focus", "Pause While Driving") but the footer text is vague and doesn't explain what the feature IS or DOES.

Current footer: "Reminders resume when conditions end."

Users who find this setting don't understand its purpose without trial-and-error or Settings exploration.

## Solution
Replace the vague footer with a clear, feature-focused explanation:

"Automatically pauses reminders during Focus Mode or while driving. Reminders resume when these modes end."

This immediately communicates:
- WHAT Smart Pause does (pauses reminders)
- WHEN it activates (Focus Mode or driving detected)
- WHAT happens when done (reminders resume)

## Impact
- Improves feature discoverability
- Reduces user confusion when they find the setting
- Sets clear expectations without docs or external help

## Type
UX/Copy improvement

## Related Issues
- #433 (friction: Smart Pause section lacks documentation)

---

**Part of 2026-04-30 UX flow audit by Reuben.** Conducted comprehensive audit of onboarding → settings → reminder → rediscovery flows. Identified 10 friction points; opened issues #433-#436 for improvements.