### PR TITLE
Fix watchdog recovery snooze guard to use injected clock

### DIFF
--- a/EyePostureReminder/Services/AppCoordinatorWatchdogRecovery.swift
+++ b/EyePostureReminder/Services/AppCoordinatorWatchdogRecovery.swift
@@ -68,7 +68,7 @@ extension AppCoordinator {
         var fallbackScheduled = false
         if notificationAuthStatus == .authorized,
            settings.notificationFallbackEnabled,
-           (settings.snoozedUntil ?? .distantPast) <= Date(),
+           (settings.snoozedUntil ?? .distantPast) <= now,
            let fallbackType = session.reason?.reminderType {
             await scheduler.rescheduleReminder(for: fallbackType, using: settings)
             fallbackScheduled = true

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorWatchdogHeartbeatTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorWatchdogHeartbeatTests.swift
@@ -331,6 +331,44 @@ final class AppCoordinatorWatchdogHeartbeatTests: XCTestCase {
             "watchdogRecovery must call rescheduleReminder when snooze has expired")
     }
 
+    func test_watchdogRecovery_usesInjectedNowForSnoozeGuard() async throws {
+        // Injected clock says snooze is still active, while wall clock says expired.
+        // Recovery must use the injected time source and skip fallback scheduling.
+        let mockScheduler = MockReminderScheduler()
+        let snoozeCoordinator = AppCoordinator(
+            settings: settings,
+            scheduler: mockScheduler,
+            notificationCenter: notificationCenter,
+            overlayManager: MockOverlayPresenting(),
+            screenTimeTracker: tracker,
+            pauseConditionProvider: MockPauseConditionProvider(),
+            deviceActivityMonitor: deviceActivityMonitor,
+            ipcStore: ipcStore
+        )
+        defer { snoozeCoordinator.stopFallbackTimers() }
+
+        deviceActivityMonitor.stubbedIsAvailable = true
+        notificationCenter.authorizationGranted = true
+        settings.notificationFallbackEnabled = true
+        settings.snoozedUntil = Date(timeIntervalSince1970: 2_000)
+
+        ipcStore.shieldSessionSnapshot = ShieldSessionSnapshot(
+            reasonRaw: ReminderType.eyes.shieldReason.rawValue,
+            durationSeconds: 20,
+            triggeredAt: Date(timeIntervalSince1970: 100)
+        )
+
+        await snoozeCoordinator.refreshAuthStatus()
+        let recovered = await snoozeCoordinator.recoverStaleDeviceActivityWatchdogIfNeeded(
+            now: Date(timeIntervalSince1970: 1_000)
+        )
+        try await Task.sleep(nanoseconds: 150_000_000)
+
+        XCTAssertTrue(recovered)
+        XCTAssertEqual(mockScheduler.rescheduleCallCount, 0,
+            "watchdogRecovery must evaluate snooze using injected now, not wall clock")
+    }
+
     private var heartbeatDetails: [WatchdogHeartbeatDetail] {
         ipcStore.events
             .filter { $0.kind == .watchdogHeartbeat }


### PR DESCRIPTION
## Summary
- use the injected now parameter in recoverStaleDeviceActivityWatchdogIfNeeded(now:) for snooze gating
- add regression coverage proving watchdog recovery does not schedule fallback when snooze is active relative to injected time

Closes #437

## Validation
- ./scripts/build.sh all
