### PR TITLE
Fix: Add [weak self] capture to Task closures in SettingsViewModel (#441)

### DIFF
--- a/EyePostureReminder/ViewModels/SettingsViewModel.swift
+++ b/EyePostureReminder/ViewModels/SettingsViewModel.swift
@@ -271,8 +271,9 @@ final class SettingsViewModel: ObservableObject {
                 oldValue: String(old),
                 newValue: String(newValue)
             ))
-            Task {
-                await scheduler.scheduleReminders(using: settings)
+            Task { [weak self] in
+                guard let self else { return }
+                await self.scheduler.scheduleReminders(using: self.settings)
                 Logger.settings.info("Notification fallback → \(self.settings.notificationFallbackEnabled)")
             }
         }
@@ -303,11 +304,12 @@ final class SettingsViewModel: ObservableObject {
 
     /// Called when the master toggle is flipped.
     func globalToggleChanged() {
-        Task {
-            if settings.globalEnabled {
-                await scheduler.scheduleReminders(using: settings)
+        Task { [weak self] in
+            guard let self else { return }
+            if self.settings.globalEnabled {
+                await self.scheduler.scheduleReminders(using: self.settings)
             } else {
-                scheduler.cancelAllReminders()
+                self.scheduler.cancelAllReminders()
             }
             Logger.settings.info("Master toggle → \(self.settings.globalEnabled)")
         }
@@ -315,8 +317,9 @@ final class SettingsViewModel: ObservableObject {
 
     /// Called when per-type enabled state or interval/duration changes.
     func reminderSettingChanged(for type: ReminderType) {
-        Task {
-            await scheduler.rescheduleReminder(for: type, using: settings)
+        Task { [weak self] in
+            guard let self else { return }
+            await self.scheduler.rescheduleReminder(for: type, using: self.settings)
             Logger.settings.info("Settings updated for type=\(type.rawValue)")
         }
     }
@@ -374,8 +377,9 @@ final class SettingsViewModel: ObservableObject {
         settings.snoozedUntil = nil
         settings.snoozeCount  = 0
         AnalyticsLogger.log(.snoozeCancelled)
-        Task {
-            await scheduler.scheduleReminders(using: settings)
+        Task { [weak self] in
+            guard let self else { return }
+            await self.scheduler.scheduleReminders(using: self.settings)
             Logger.settings.info("Snooze cancelled — reminders rescheduled")
         }
     }


### PR DESCRIPTION
## Summary
Adds missing `[weak self]` capture guards to four Task closures in `SettingsViewModel.swift` to ensure consistency with the project's established pattern where all Task closures on class types use weak capture.

## Changes
- Line 274: notifySettingChanged observer Task
- Line 306: globalToggleChanged method Task  
- Line 318: reminderSettingChanged method Task
- Line 377: cancelSnooze method Task

Each closure now uses `[weak self]` capture followed by `guard let self else { return }` for safe unwrapping.

## Testing
- All 889 existing tests pass
- Pattern fix is mechanical; no new tests required
- Tested on iPhone 17 simulator with iOS 18 runtime

## Fixes
Closes #441