### PR TITLE
Fix overlay swipe dismiss to require clear upward intent

### DIFF
--- a/EyePostureReminder/Views/OverlayView.swift
+++ b/EyePostureReminder/Views/OverlayView.swift
@@ -10,6 +10,8 @@ import UIKit
 /// persistence directly.
 struct OverlayView: View {
 
+    static let swipeDismissMinimumUpwardTravel: CGFloat = 30
+
     let type: ReminderType
     let duration: TimeInterval
     let hapticsEnabled: Bool
@@ -229,10 +231,18 @@ struct OverlayView: View {
 
     /// Swipe-up drag gesture that dismisses the overlay, mirroring the upward slide entrance.
     private var swipeUpDismissGesture: some Gesture {
-        DragGesture(minimumDistance: 30)
+        DragGesture(minimumDistance: Self.swipeDismissMinimumUpwardTravel)
             .onEnded { value in
-                if value.translation.height < 0 { performDismiss(method: .swipe) }
+                if Self.shouldDismissForSwipe(translation: value.translation) {
+                    performDismiss(method: .swipe)
+                }
             }
+    }
+
+    static func shouldDismissForSwipe(translation: CGSize) -> Bool {
+        let upwardTravel = -translation.height
+        guard upwardTravel >= swipeDismissMinimumUpwardTravel else { return false }
+        return upwardTravel > abs(translation.width)
     }
 
     /// Prepares haptic generators, fires entrance animation, and starts the countdown timer.

--- a/Tests/EyePostureReminderTests/Views/OverlayGestureTests.swift
+++ b/Tests/EyePostureReminderTests/Views/OverlayGestureTests.swift
@@ -1,0 +1,17 @@
+@testable import EyePostureReminder
+import XCTest
+
+final class OverlayGestureTests: XCTestCase {
+
+    func test_shouldDismissForSwipe_whenUpwardAndVerticalDominant_returnsTrue() {
+        XCTAssertTrue(OverlayView.shouldDismissForSwipe(translation: CGSize(width: 10, height: -60)))
+    }
+
+    func test_shouldDismissForSwipe_whenMostlyHorizontal_returnsFalse() {
+        XCTAssertFalse(OverlayView.shouldDismissForSwipe(translation: CGSize(width: 90, height: -40)))
+    }
+
+    func test_shouldDismissForSwipe_whenDownward_returnsFalse() {
+        XCTAssertFalse(OverlayView.shouldDismissForSwipe(translation: CGSize(width: 0, height: 40)))
+    }
+}


### PR DESCRIPTION
## Summary\n- tighten OverlayView swipe-to-dismiss logic to avoid accidental diagonal dismisses\n- require upward drag travel threshold and vertical dominance over horizontal movement\n- add focused unit coverage for swipe-dismiss predicate\n\n## Validation\n- ./scripts/build.sh build\n- xcodebuild test -scheme EyePostureReminder -destination "platform=iOS Simulator,name=iPhone 17 Pro" -derivedDataPath DerivedData -only-testing:EyePostureReminderTests/OverlayGestureTests CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO ENABLE_BITCODE=NO ENABLE_APP_INTENTS_METADATA_EXTRACTION=NO ENABLE_APPINTENTS_METADATA_EXTRACTION=NO SWIFT_TREAT_WARNINGS_AS_ERRORS=YES GCC_TREAT_WARNINGS_AS_ERRORS=YES\n\nCloses #442