### PR TITLE
test: harden True Interrupt UITest launch reliability

### DIFF
--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -191,7 +191,6 @@ final class AppCoordinator: ObservableObject {
             #if DEBUG
             if let raw = UserDefaults.standard.string(forKey: AppStorageKey.uiTestScreenTimeStatus),
                let status = ScreenTimeAuthorizationStatus(rawValue: raw) {
-                UserDefaults.standard.removeObject(forKey: AppStorageKey.uiTestScreenTimeStatus)
                 return ScreenTimeAuthorizationStub(status: status)
             }
             #endif

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -105,6 +105,33 @@ final class AppCoordinatorTests: XCTestCase {
         coordinator.stopFallbackTimers()
     }
 
+    func test_init_withUITestScreenTimeStatus_keepsStatusForRelaunches() {
+        UserDefaults.standard.set(
+            ScreenTimeAuthorizationStatus.notDetermined.rawValue,
+            forKey: AppStorageKey.uiTestScreenTimeStatus
+        )
+        defer {
+            UserDefaults.standard.removeObject(forKey: AppStorageKey.uiTestScreenTimeStatus)
+        }
+
+        let mockNotif = MockNotificationCenter()
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: MockAppGroupIPCRecorder()
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        XCTAssertEqual(
+            UserDefaults.standard.string(forKey: AppStorageKey.uiTestScreenTimeStatus),
+            ScreenTimeAuthorizationStatus.notDetermined.rawValue,
+            "UITest status override should remain available for relaunches in the same test session."
+        )
+    }
+
     // MARK: - stopFallbackTimers
 
     func test_stopFallbackTimers_withNoTimersRunning_doesNotCrash() {

--- a/Tests/EyePostureReminderUITests/HomeScreenTests.swift
+++ b/Tests/EyePostureReminderUITests/HomeScreenTests.swift
@@ -9,10 +9,28 @@ final class HomeScreenTests: XCTestCase {
 
     var app: XCUIApplication!
 
+    private func waitForTrueInterruptBanner(timeout: TimeInterval) -> Bool {
+        for attempt in 1...3 {
+            let banner = app.otherElements["home.trueInterrupt.skippedBanner"]
+            if banner.waitForExistence(timeout: timeout) {
+                return true
+            }
+            guard attempt < 3 else { break }
+            app.terminate()
+            app = XCUIApplication()
+            app.launchWithTrueInterruptPending()
+        }
+        return false
+    }
+
     override func setUpWithError() throws {
         continueAfterFailure = false
         app = XCUIApplication()
-        app.launchWithSkippedOnboarding()
+        if name.contains("trueInterrupt") {
+            app.launchWithTrueInterruptPending()
+        } else {
+            app.launchWithSkippedOnboarding()
+        }
     }
 
     override func tearDownWithError() throws {
@@ -185,27 +203,22 @@ final class HomeScreenTests: XCTestCase {
     /// `ScreenTimeAuthorizationStub(.notDetermined)` is injected into `AppCoordinator`
     /// (the real simulator FamilyControls status is `.unavailable`).
     func test_homeScreen_trueInterruptBanner_exists() throws {
-        app.terminate()
-        app = XCUIApplication()
-        app.launchWithTrueInterruptPending()
-
-        let banner = app.otherElements["home.trueInterrupt.skippedBanner"]
         XCTAssertTrue(
-            banner.waitForExistence(timeout: 3),
+            waitForTrueInterruptBanner(timeout: 8),
             "TrueInterruptSkippedBanner must be visible when Screen Time authorization " +
             "is .notDetermined and the banner has not been dismissed."
         )
 
         let setUpButton = app.buttons["home.trueInterrupt.skippedBanner.setUp"]
         XCTAssertTrue(
-            setUpButton.waitForExistence(timeout: 3),
+            setUpButton.waitForExistence(timeout: 5),
             "Set Up CTA must be present in TrueInterruptSkippedBanner."
         )
         XCTAssertTrue(setUpButton.isHittable, "Set Up CTA must be hittable.")
 
         let dismissButton = app.buttons["home.trueInterrupt.skippedBanner.dismiss"]
         XCTAssertTrue(
-            dismissButton.waitForExistence(timeout: 3),
+            dismissButton.waitForExistence(timeout: 5),
             "Dismiss CTA must be present in TrueInterruptSkippedBanner."
         )
         XCTAssertTrue(dismissButton.isHittable, "Dismiss CTA must be hittable.")
@@ -218,20 +231,21 @@ final class HomeScreenTests: XCTestCase {
     ///
     /// Flow: launch with `.notDetermined` state → dismiss banner → pill visible.
     func test_homeScreen_trueInterruptSetupPill_exists() throws {
-        app.terminate()
-        app = XCUIApplication()
-        app.launchWithTrueInterruptPending()
+        XCTAssertTrue(
+            waitForTrueInterruptBanner(timeout: 8),
+            "TrueInterruptSkippedBanner must be visible before dismissing it."
+        )
 
         let dismissButton = app.buttons["home.trueInterrupt.skippedBanner.dismiss"]
         XCTAssertTrue(
-            dismissButton.waitForExistence(timeout: 3),
+            dismissButton.waitForExistence(timeout: 8),
             "Dismiss button must be present before tapping to reveal the setup pill."
         )
         dismissButton.tap()
 
         let pill = app.buttons["home.trueInterrupt.setupPill"]
         XCTAssertTrue(
-            pill.waitForExistence(timeout: 3),
+            pill.waitForExistence(timeout: 8),
             "TrueInterruptSetupPill must appear after the banner is dismissed."
         )
         XCTAssertTrue(pill.isHittable, "TrueInterruptSetupPill must be hittable.")

--- a/Tests/EyePostureReminderUITests/UITestHelpers.swift
+++ b/Tests/EyePostureReminderUITests/UITestHelpers.swift
@@ -63,7 +63,10 @@ extension XCUIApplication {
     /// `TrueInterruptSetupPill` (banner dismissed). The simulator's real FamilyControls status
     /// is `.unavailable`, so this argument is required to reach either element (#399).
     func launchWithTrueInterruptPending() {
-        launchArguments += [TestLaunchArguments.simulateScreenTimeNotDetermined]
+        launchArguments += [
+            TestLaunchArguments.skipOnboarding,
+            TestLaunchArguments.simulateScreenTimeNotDetermined
+        ]
         launch()
     }
 }


### PR DESCRIPTION
## Summary
- keep the UITest Screen Time stub key available across AppCoordinator relaunches in DEBUG
- add regression coverage in AppCoordinatorTests for relaunch-safe UITest status behavior
- harden HomeScreen True Interrupt UITests by:
  - launching trueInterrupt tests directly with the dedicated launch helper
  - adding internal banner wait/relaunch retries
  - increasing timeouts for banner/dismiss/pill assertions
- make launchWithTrueInterruptPending also include skip-onboarding for deterministic entry state

## Linked issues
- Addresses #457
- Related: #455, #456, #458

## Validation
- Passed: targeted AppCoordinatorTests run
- Passed: scripts/build.sh lint
- Passed: scripts/build.sh build
- Failing (pre-existing): scripts/build.sh test fails at DistributionEntitlementsTests path issue tracked in #458
