### PR TITLE
test(ui): trim waits in settings and overlay suites

### DIFF
--- a/Tests/EyePostureReminderUITests/DarkModeUITests.swift
+++ b/Tests/EyePostureReminderUITests/DarkModeUITests.swift
@@ -93,7 +93,7 @@ final class DarkModeUITests: XCTestCase {
 
         let doneButton = app.buttons["overlay.doneButton"]
         XCTAssertTrue(
-            doneButton.waitForHittable(timeout: 5),
+            doneButton.waitForHittable(timeout: 3),
             "Done button must be visible on the overlay in dark mode."
         )
 
@@ -105,7 +105,7 @@ final class DarkModeUITests: XCTestCase {
 
         let supportiveText = app.staticTexts["overlay.supportiveText"]
         XCTAssertTrue(
-            supportiveText.waitForExistence(timeout: 5),
+            supportiveText.waitForExistence(timeout: 3),
             "Supportive text must be visible on the overlay in dark mode."
         )
     }
@@ -120,11 +120,11 @@ final class DarkModeUITests: XCTestCase {
         XCTAssertTrue(app.waitForOverlayReady(), "Eye overlay should be fully loaded in dark mode.")
 
         let doneButton = app.buttons["overlay.doneButton"]
-        XCTAssertTrue(doneButton.tapWhenHittable(timeout: 5))
+        XCTAssertTrue(doneButton.tapWhenHittable(timeout: 3))
 
         let dismissButton = app.buttons["overlay.dismissButton"]
         XCTAssertFalse(
-            dismissButton.waitForExistence(timeout: 5),
+            dismissButton.waitForExistence(timeout: 3),
             "After tapping Done in dark mode, the overlay should be dismissed."
         )
     }
@@ -161,13 +161,13 @@ final class DarkModeUITests: XCTestCase {
 
         let doneButton = app.buttons["overlay.doneButton"]
         XCTAssertTrue(
-            doneButton.waitForHittable(timeout: 5),
+            doneButton.waitForHittable(timeout: 3),
             "Done button must be visible on the posture overlay in dark mode."
         )
 
         let supportiveText = app.staticTexts["overlay.supportiveText"]
         XCTAssertTrue(
-            supportiveText.waitForExistence(timeout: 5),
+            supportiveText.waitForExistence(timeout: 3),
             "Supportive text must be visible on the posture overlay in dark mode."
         )
     }

--- a/Tests/EyePostureReminderUITests/OverlayTests.swift
+++ b/Tests/EyePostureReminderUITests/OverlayTests.swift
@@ -111,7 +111,7 @@ final class OverlayPresentationTests: XCTestCase {
     func test_overlay_onShowOverlayEyes_doneButtonVisible() throws {
         let doneButton = app.buttons["overlay.doneButton"]
         XCTAssertTrue(
-            doneButton.waitForHittable(timeout: 5),
+            doneButton.waitForHittable(timeout: 3),
             "Done button must be visible on the overlay. " +
             "OverlayView must have .accessibilityIdentifier(\"overlay.doneButton\") " +
             "on the primary Done PrimaryButton."
@@ -136,7 +136,7 @@ final class OverlayPresentationTests: XCTestCase {
     /// Taps the Done button and verifies the overlay dismisses (Home screen returns).
     func test_overlay_doneButton_dismissesOverlay() throws {
         let doneButton = app.buttons["overlay.doneButton"]
-        XCTAssertTrue(doneButton.tapWhenHittable(timeout: 5))
+        XCTAssertTrue(doneButton.tapWhenHittable(timeout: 3))
 
         // Wait for the Home screen to reappear — the positive dismiss signal.
         // The overlay dismiss animation takes ~0.3s + asyncAfter delay, so the
@@ -167,19 +167,19 @@ final class OverlayPresentationTests: XCTestCase {
     func test_overlay_settingsLink_opensSettingsWithSnoozeOptions() throws {
         let settingsLink = app.buttons["overlay.settingsLink"]
         XCTAssertTrue(
-            settingsLink.tapWhenHittable(timeout: 5),
+            settingsLink.tapWhenHittable(timeout: 3),
             "Settings link must be visible on the overlay."
         )
 
         let settingsNav = app.navigationBars["Settings"]
         XCTAssertTrue(
-            settingsNav.waitForExistence(timeout: 5),
+            settingsNav.waitForExistence(timeout: 3),
             "Tapping overlay Settings should open the Settings sheet."
         )
 
         let snoozeButton = app.buttons["settings.snooze.5min"]
         XCTAssertTrue(
-            snoozeButton.waitForExistence(timeout: 5),
+            snoozeButton.waitForExistence(timeout: 3),
             "Settings opened from the overlay must expose snooze controls."
         )
     }
@@ -220,7 +220,7 @@ final class OverlayPostureTests: XCTestCase {
     func test_overlay_postureVariant_doneButtonVisible() throws {
         let doneButton = app.buttons["overlay.doneButton"]
         XCTAssertTrue(
-            doneButton.waitForHittable(timeout: 5),
+            doneButton.waitForHittable(timeout: 3),
             "Done button must be visible on the posture overlay."
         )
     }
@@ -241,11 +241,11 @@ final class OverlayPostureTests: XCTestCase {
     /// Taps Done on the posture overlay and verifies it dismisses.
     func test_overlay_postureVariant_doneButtonDismissesOverlay() throws {
         let doneButton = app.buttons["overlay.doneButton"]
-        XCTAssertTrue(doneButton.tapWhenHittable(timeout: 5))
+        XCTAssertTrue(doneButton.tapWhenHittable(timeout: 3))
 
         let dismissButton = app.buttons["overlay.dismissButton"]
         XCTAssertFalse(
-            dismissButton.waitForExistence(timeout: 5),
+            dismissButton.waitForExistence(timeout: 3),
             "After tapping Done on posture overlay, the overlay should be dismissed."
         )
     }

--- a/Tests/EyePostureReminderUITests/SettingsFlowTests.swift
+++ b/Tests/EyePostureReminderUITests/SettingsFlowTests.swift
@@ -610,7 +610,7 @@ private extension SettingsFlowTests {
         }
         for _ in 0..<maxSwipes {
             app.swipeUp()
-            if element.waitForExistence(timeout: 1.5) {
+            if element.exists || element.waitForExistence(timeout: 0.6) {
                 return
             }
         }

--- a/Tests/EyePostureReminderUITests/UITestHelpers.swift
+++ b/Tests/EyePostureReminderUITests/UITestHelpers.swift
@@ -88,20 +88,26 @@ extension XCUIApplication {
     /// This reduces flakes where one element is queried before the accessibility tree
     /// has fully stabilized after launch.
     @discardableResult
-    func waitForOverlayReady(timeout: TimeInterval = 5) -> Bool {
+    func waitForOverlayReady(timeout: TimeInterval = 3) -> Bool {
         let doneButton = buttons["overlay.doneButton"]
         let dismissButton = buttons["overlay.dismissButton"]
         let supportiveText = staticTexts["overlay.supportiveText"]
-        return doneButton.waitForHittable(timeout: timeout)
-            && dismissButton.waitForHittable(timeout: timeout)
-            && supportiveText.waitForExistence(timeout: timeout)
+        let deadline = Date().addingTimeInterval(timeout)
+
+        func remaining() -> TimeInterval {
+            max(0.1, deadline.timeIntervalSinceNow)
+        }
+
+        guard doneButton.waitForHittable(timeout: remaining()) else { return false }
+        guard dismissButton.waitForHittable(timeout: remaining()) else { return false }
+        return supportiveText.waitForExistence(timeout: remaining())
     }
 }
 
 extension XCUIElement {
     /// Waits until the element both exists and is hittable.
     @discardableResult
-    func waitForHittable(timeout: TimeInterval = 5) -> Bool {
+    func waitForHittable(timeout: TimeInterval = 3) -> Bool {
         guard waitForExistence(timeout: timeout) else { return false }
         let predicate = NSPredicate(format: "hittable == true")
         let expectation = XCTNSPredicateExpectation(predicate: predicate, object: self)
@@ -110,7 +116,7 @@ extension XCUIElement {
 
     /// Taps an element after waiting for a hittable state.
     @discardableResult
-    func tapWhenHittable(timeout: TimeInterval = 5) -> Bool {
+    func tapWhenHittable(timeout: TimeInterval = 3) -> Bool {
         guard waitForHittable(timeout: timeout) else { return false }
         tap()
         return true


### PR DESCRIPTION
## Summary
- reduce default UI helper wait budgets from 5s to 3s for hittable/tap/overlay readiness paths
- make overlay readiness use a shared total timeout budget rather than 3 full sequential waits
- speed up settings scroll-to-element loop by checking immediate existence and reducing per-swipe wait
- reduce explicit 5s waits/taps to 3s in Overlay and DarkMode UI suites

## Validation
- bash scripts/build.sh all
- bash scripts/build.sh uitest --only-testing EyePostureReminderUITests/SettingsFlowTests/test_settings_snoozeButtons_existAndTap --only-testing EyePostureReminderUITests/DarkModeUITests/test_darkMode_overlayShowsExpectedElements