### PR TITLE
ci: align Xcode version and harden TestFlight selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ concurrency:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  XCODE_VERSION: "26.4"
+  XCODE_VERSION: "16.4"
   SCHEME: "EyePostureReminder"
   # No .xcodeproj — project uses Swift Package Manager.
   # xcodebuild resolves the package directly from Package.swift.

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -40,7 +40,7 @@ permissions:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  XCODE_VERSION: "26.4"
+  XCODE_VERSION: "16.4"
   SCHEME: "EyePostureReminder"
   DERIVED_DATA_PATH: "${{ github.workspace }}/DerivedData"
 
@@ -80,7 +80,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Select Xcode ${{ env.XCODE_VERSION }}
-        run: sudo xcode-select -switch /Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer
+        run: |
+          XCODE_PATH="/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer"
+          if [[ -d "$XCODE_PATH" ]]; then
+            sudo xcode-select -switch "$XCODE_PATH"
+          else
+            echo "Xcode_${{ env.XCODE_VERSION }}.app not found; using current selection: $(xcode-select -p)"
+          fi
 
       # ── Versioning ────────────────────────────────────────────────────────
       - name: Set marketing version

--- a/UITests/project.yml
+++ b/UITests/project.yml
@@ -15,7 +15,7 @@ options:
   bundleIdPrefix: com.yashasg
   deploymentTarget:
     iOS: "16.0"
-  xcodeVersion: "26.4"
+  xcodeVersion: "16.4"
   minimumXcodeGenVersion: "2.40.0"
   generateEmptyDirectories: false
 

--- a/project.yml
+++ b/project.yml
@@ -31,7 +31,7 @@ options:
   bundleIdPrefix: com.yashasg.eyeposturereminder
   deploymentTarget:
     iOS: "16.0"
-  xcodeVersion: "26.4"
+  xcodeVersion: "16.4"
   minimumXcodeGenVersion: "2.40.0"
   generateEmptyDirectories: false
 


### PR DESCRIPTION
## Summary
- align workflow and XcodeGen config from 26.4 to 16.4
- add fallback selection logic to TestFlight workflow so missing Xcode app does not hard-fail deploy
- keep CI/TestFlight behavior consistent for xcode-select handling

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test (rerun due intermittent simulator crash; final run passed)

Closes #471
