### PR TITLE
feat: add hosted privacy policy link in Settings

### DIFF
--- a/EyePostureReminder/Views/SettingsView.swift
+++ b/EyePostureReminder/Views/SettingsView.swift
@@ -58,6 +58,7 @@ struct SettingsView: View {
 
     @Binding var isPresented: Bool
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.openURL) private var openURL
 
     @State private var showTerms = false
     @State private var showPrivacy = false
@@ -75,6 +76,7 @@ struct SettingsView: View {
     @State private var savedBannerTask: Task<Void, Never>?
 
     private let accessibilityNotificationPoster: AccessibilityNotificationPosting
+    private let hostedPrivacyPolicyURL = URL(string: "https://github.com/yashasg/fantastic-octo-fortnight/blob/main/docs/legal/PRIVACY.md")!
 
     init(
         isPresented: Binding<Bool>,
@@ -261,6 +263,18 @@ struct SettingsView: View {
                 .foregroundStyle(AppColor.primaryRest)
                 .accessibilityHint(Text("settings.legal.privacy.hint", bundle: .module))
                 .accessibilityIdentifier("settings.legal.privacy")
+                .listRowBackground(AppColor.surface)
+                .listRowSeparatorTint(AppColor.separatorSoft)
+
+                Button {
+                    openURL(hostedPrivacyPolicyURL)
+                } label: {
+                    Text("Hosted Privacy Policy (Web)")
+                }
+                .font(AppFont.body)
+                .foregroundStyle(AppColor.primaryRest)
+                .accessibilityHint(Text("Opens the public privacy policy URL in your browser."))
+                .accessibilityIdentifier("settings.legal.privacyHosted")
                 .listRowBackground(AppColor.surface)
                 .listRowSeparatorTint(AppColor.separatorSoft)
 

--- a/docs/app-store-submission-status.md
+++ b/docs/app-store-submission-status.md
@@ -98,7 +98,7 @@ Legend: ✅ Done · ⚠️ In progress / partial · ❌ Not started · 🔒 Bloc
 
 ## Recommended Next Actions
 
-1. **Unblock #185** — host `docs/legal/PRIVACY.md` at a public HTTPS URL (GitHub Pages is sufficient).
+1. **Close #185 follow-through** — hosted privacy URL is now available at `https://github.com/yashasg/fantastic-octo-fortnight/blob/main/docs/legal/PRIVACY.md`; remaining manual step is adding this URL in App Store Connect metadata.
 2. **Unblock #196** — upload `docs/legal/TERMS.md` content to App Store Connect License Agreement field.
 3. **Capture screenshots** — 5 screens on iPhone 15 Pro + Pro Max.
 4. **Export app icon** — 1024×1024 PNG, no alpha.


### PR DESCRIPTION
## Summary
- add a Hosted Privacy Policy (Web) button in Settings legal section
- wire the button to the public HTTPS privacy policy URL in this repository
- update app-store-submission-status with hosted URL and remaining App Store Connect step

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test (rerun after intermittent simulator crash; final run passed)

Refs #185
