### PR TITLE
Phase A SOLID: inject AppCoordinator UI-test status store seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -116,3 +116,4 @@ Orchestration log recorded at 2026-04-30T09:27:10Z. Fix approved and documented 
 
 - For service callbacks consumed by `@MainActor` coordinators, declare callback properties as `@MainActor` function types at the protocol boundary (e.g., `(@MainActor (ReminderType) -> Void)?`) to get compile-time isolation guarantees and remove `MainActor.assumeIsolated` crash traps.
 - Conforming mocks/no-op stubs must match the actor-annotated callback signatures; this keeps tests compile-safe while preserving behavior.
+- For UI-test-only persisted overrides, inject a dedicated `UserDefaults` instance into resolver paths instead of reading `UserDefaults.standard` directly; this removes hidden globals and allows isolated suite-based tests.

--- a/.squad/skills/userdefaults-di-seam/SKILL.md
+++ b/.squad/skills/userdefaults-di-seam/SKILL.md
@@ -1,0 +1,18 @@
+# Skill: UserDefaults DI Seam for Test Overrides
+
+## Pattern
+When a service needs to read a test-only override from `UserDefaults`, inject the defaults instance instead of calling `UserDefaults.standard` in resolver logic.
+
+## Steps
+1. Add an initializer parameter with a production-safe default:
+   - `uiTestStatusStore: UserDefaults = .standard`
+2. Thread it into the resolver/helper that currently reads from global defaults.
+3. In tests, create an isolated suite:
+   - `UserDefaults(suiteName: "...")`
+   - `removePersistentDomain(forName:)` before/after the test.
+4. Assert behavior through public service state, not private resolver internals.
+
+## Why
+- Removes hidden global coupling.
+- Prevents cross-test contamination.
+- Keeps behavior unchanged in production by preserving `.standard` as the default.

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -181,6 +181,7 @@ final class AppCoordinator: ObservableObject {
         screenTimeTracker: ScreenTimeTracking? = nil,
         pauseConditionProvider: PauseConditionProviding? = nil,
         screenTimeAuthorization: ScreenTimeAuthorizationProviding? = nil,
+        uiTestStatusStore: UserDefaults = .standard,
         deviceActivityMonitor: DeviceActivityMonitorProviding? = nil,
         ipcStore: AppGroupIPCProviding = AppGroupIPCStore(),
         watchdogHeartbeatGraceInterval: TimeInterval = 10
@@ -193,7 +194,10 @@ final class AppCoordinator: ObservableObject {
         self.scheduler = Self.resolveScheduler(scheduler)
         self.notificationCenter = notificationCenter
         self.overlayManager = Self.resolveOverlayManager(overlayManager)
-        self.screenTimeAuthorization = Self.resolveScreenTimeAuthorization(screenTimeAuthorization)
+        self.screenTimeAuthorization = Self.resolveScreenTimeAuthorization(
+            screenTimeAuthorization,
+            uiTestStatusStore: uiTestStatusStore
+        )
         self.deviceActivityMonitor = Self.resolveDeviceActivityMonitor(deviceActivityMonitor)
         self.ipcStore = ipcStore
         self.watchdogHeartbeatGraceInterval = watchdogHeartbeatGraceInterval
@@ -603,7 +607,8 @@ private extension AppCoordinator {
     }
 
     static func resolveScreenTimeAuthorization(
-        _ screenTimeAuthorization: ScreenTimeAuthorizationProviding?
+        _ screenTimeAuthorization: ScreenTimeAuthorizationProviding?,
+        uiTestStatusStore: UserDefaults
     ) -> ScreenTimeAuthorizationProviding {
         guard let screenTimeAuthorization else {
             #if DEBUG
@@ -613,7 +618,7 @@ private extension AppCoordinator {
             if CommandLine.arguments.contains("--simulate-screen-time-not-determined") {
                 return ScreenTimeAuthorizationStub(status: .notDetermined)
             }
-            if let raw = UserDefaults.standard.string(forKey: AppStorageKey.uiTestScreenTimeStatus),
+            if let raw = uiTestStatusStore.string(forKey: AppStorageKey.uiTestScreenTimeStatus),
                let status = ScreenTimeAuthorizationStatus(rawValue: raw) {
                 return ScreenTimeAuthorizationStub(status: status)
             }

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestStatusStoreTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestStatusStoreTests.swift
@@ -1,0 +1,62 @@
+@testable import EyePostureReminder
+import XCTest
+
+@MainActor
+final class AppCoordinatorUITestStatusStoreTests: XCTestCase {
+
+    func test_init_withInjectedUITestStatusStore_usesStoredStatusForStubResolution() {
+        let suiteName = "AppCoordinatorUITestStatusStoreTests.\(#function)"
+        guard let isolatedDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Expected isolated UserDefaults suite")
+            return
+        }
+        isolatedDefaults.removePersistentDomain(forName: suiteName)
+        defer { isolatedDefaults.removePersistentDomain(forName: suiteName) }
+
+        isolatedDefaults.set(
+            ScreenTimeAuthorizationStatus.notDetermined.rawValue,
+            forKey: AppStorageKey.uiTestScreenTimeStatus
+        )
+
+        let mockNotif = MockNotificationCenter()
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            uiTestStatusStore: isolatedDefaults,
+            ipcStore: MockAppGroupIPCRecorder()
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        let stub = coordinator.screenTimeAuthorization as? ScreenTimeAuthorizationStub
+        XCTAssertEqual(stub?.authorizationStatus, .notDetermined)
+    }
+
+    func test_init_withInjectedUITestStatusStore_invalidRawValue_fallsBackToNoop() {
+        let suiteName = "AppCoordinatorUITestStatusStoreTests.\(#function)"
+        guard let isolatedDefaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Expected isolated UserDefaults suite")
+            return
+        }
+        isolatedDefaults.removePersistentDomain(forName: suiteName)
+        defer { isolatedDefaults.removePersistentDomain(forName: suiteName) }
+
+        isolatedDefaults.set("not-a-valid-status", forKey: AppStorageKey.uiTestScreenTimeStatus)
+
+        let mockNotif = MockNotificationCenter()
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            uiTestStatusStore: isolatedDefaults,
+            ipcStore: MockAppGroupIPCRecorder()
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        XCTAssertTrue(coordinator.screenTimeAuthorization is ScreenTimeAuthorizationNoop)
+    }
+}


### PR DESCRIPTION
## Summary
- inject uiTestStatusStore: UserDefaults = .standard into AppCoordinator
- route Screen Time UI-test status override resolution through the injected store instead of hardcoded UserDefaults.standard
- add focused unit tests for injected-store stub resolution and invalid-value fallback

## Validation
- ./scripts/build.sh build ✅
- ./scripts/build.sh test ✅
- ./scripts/build.sh lint ⚠️ fails on pre-existing SettingsView.swift violations

Refs #462