### PR TITLE
Phase A #462: Inject AppDelegate launch context seams

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -121,3 +121,4 @@ Orchestration log recorded at 2026-04-30T09:27:10Z. Fix approved and documented 
 - Key paths for this pattern: `EyePostureReminder/Services/AppCoordinator.swift` (`resolveScreenTimeAuthorization`) and `Tests/EyePostureReminderTests/Services/AppCoordinatorUITestLaunchContextTests.swift`.
 - For `@MainActor` coordinators, avoid actor-isolated static values in default initializer arguments; use optional injected args and resolve to static defaults inside `init` to keep DI seams compile-safe in Swift 6.
 - For app-lifecycle seams around crash-prone system singletons, inject an optional protocol dependency and resolve the real singleton lazily at callback time (`didFinishLaunching`) instead of initializer default arguments.
+- For AppDelegate UI-test bootstrap logic, inject both `launchArguments` and a `UserDefaults` instance; this removes hidden global reads (`CommandLine`/`.standard`) and enables deterministic, isolated seam tests.

--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -12,13 +12,19 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
 
     private let notificationCenter: UserNotificationCenterDelegating?
     private let registerMetricKitSubscriber: () -> Void
+    private let launchArguments: [String]
+    private let uiTestDefaults: UserDefaults
 
     init(
         notificationCenter: UserNotificationCenterDelegating? = nil,
-        registerMetricKitSubscriber: @escaping () -> Void = { MetricKitSubscriber.shared.register() }
+        registerMetricKitSubscriber: @escaping () -> Void = { MetricKitSubscriber.shared.register() },
+        launchArguments: [String] = CommandLine.arguments,
+        uiTestDefaults: UserDefaults = .standard
     ) {
         self.notificationCenter = notificationCenter
         self.registerMetricKitSubscriber = registerMetricKitSubscriber
+        self.launchArguments = launchArguments
+        self.uiTestDefaults = uiTestDefaults
         super.init()
 #if DEBUG
         preSeedUITestDefaults()
@@ -37,18 +43,17 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     /// prevents `TrueInterruptSkippedBanner` from ever rendering on the first
     /// cold launch (#457).
     private func preSeedUITestDefaults() {
-        let args = CommandLine.arguments
-        if args.contains("--simulate-screen-time-not-determined") {
-            UserDefaults.standard.set(
+        if launchArguments.contains("--simulate-screen-time-not-determined") {
+            uiTestDefaults.set(
                 ScreenTimeAuthorizationStatus.notDetermined.rawValue,
                 forKey: AppStorageKey.uiTestScreenTimeStatus
             )
             // Ensure the banner-dismissed flag is clear so the banner renders.
-            UserDefaults.standard.set(false, forKey: AppStorageKey.trueInterruptSkippedBannerDismissed)
+            uiTestDefaults.set(false, forKey: AppStorageKey.trueInterruptSkippedBannerDismissed)
         } else {
             // Remove any stale stub key so non-True-Interrupt launches use the
             // real ScreenTimeAuthorizationNoop and don't accidentally show the banner.
-            UserDefaults.standard.removeObject(forKey: AppStorageKey.uiTestScreenTimeStatus)
+            uiTestDefaults.removeObject(forKey: AppStorageKey.uiTestScreenTimeStatus)
         }
     }
 #endif
@@ -97,8 +102,8 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     /// builds, closing the production-settings-reset vulnerability (re: #350/#405).
 #if DEBUG
     private func applyUITestLaunchArguments() {
-        let args = CommandLine.arguments
-        let defaults = UserDefaults.standard
+        let args = launchArguments
+        let defaults = uiTestDefaults
         defaults.removeObject(forKey: AppStorageKey.uiTestOverlayType)
         if args.contains("--skip-onboarding") {
             defaults.set(true, forKey: AppStorageKey.hasSeenOnboarding)

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -159,6 +159,37 @@ final class AppDelegateTests: XCTestCase {
         )
     }
 
+#if DEBUG
+    func test_init_preSeedsScreenTimeStatus_usingInjectedLaunchArgumentsAndDefaults() throws {
+        let defaults = try makeIsolatedDefaults(suffix: #function)
+        defaults.removeObject(forKey: AppStorageKey.uiTestScreenTimeStatus)
+        defaults.set(true, forKey: AppStorageKey.trueInterruptSkippedBannerDismissed)
+
+        _ = AppDelegate(
+            launchArguments: ["--simulate-screen-time-not-determined"],
+            uiTestDefaults: defaults
+        )
+
+        XCTAssertEqual(
+            defaults.string(forKey: AppStorageKey.uiTestScreenTimeStatus),
+            ScreenTimeAuthorizationStatus.notDetermined.rawValue
+        )
+        XCTAssertFalse(defaults.bool(forKey: AppStorageKey.trueInterruptSkippedBannerDismissed))
+    }
+
+    func test_init_withoutSimulateFlag_clearsInjectedScreenTimeStatusKey() throws {
+        let defaults = try makeIsolatedDefaults(suffix: #function)
+        defaults.set("stale", forKey: AppStorageKey.uiTestScreenTimeStatus)
+
+        _ = AppDelegate(
+            launchArguments: ["--skip-onboarding"],
+            uiTestDefaults: defaults
+        )
+
+        XCTAssertNil(defaults.string(forKey: AppStorageKey.uiTestScreenTimeStatus))
+    }
+#endif
+
     // MARK: - Category-identifier routing logic (ReminderType parsing)
 
     /// The two valid reminder category identifiers must parse to the correct types.
@@ -254,5 +285,17 @@ final class AppDelegateTests: XCTestCase {
         // but `scheduleReminders` must complete without crashing.
         // The coordinator operates in screen-time mode so no UNNotification is scheduled.
         XCTAssertNil(settings.snoozedUntil, "scheduleReminders must not set a snooze when none was active")
+    }
+
+    private func makeIsolatedDefaults(suffix: String) throws -> UserDefaults {
+        let suiteName = "AppDelegateTests.\(suffix).\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            throw XCTSkip("Failed to create isolated UserDefaults suite")
+        }
+        defaults.removePersistentDomain(forName: suiteName)
+        addTeardownBlock {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        return defaults
     }
 }


### PR DESCRIPTION
## Summary
- inject launchArguments and uiTestDefaults into AppDelegate with production-safe defaults
- route DEBUG UI-test bootstrap paths through injected dependencies instead of global CommandLine/UserDefaults.standard reads
- add focused AppDelegate seam tests using isolated suite defaults

## Why this micro-slice
This is the smallest remaining DI/SRP seam in app lifecycle code adjacent to PR #509. It removes hidden globals from one bounded callback path without changing runtime behavior.

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Closes #462
