### PR TITLE
refactor: inject DateProviding seam into SettingsViewModel (#462)

### DIFF
--- a/EyePostureReminder/Utilities/DateProviding.swift
+++ b/EyePostureReminder/Utilities/DateProviding.swift
@@ -1,0 +1,22 @@
+// DateProviding.swift
+
+import Foundation
+
+// MARK: - DateProviding
+
+/// Abstracts `Date()` wall-clock reads for testability.
+///
+/// Inject `SystemDateProvider` in production (the default). Inject a
+/// `MockDateProvider` in unit tests to control the current time precisely
+/// without sleeping or using approximate-delta assertions.
+protocol DateProviding {
+    /// The current wall-clock date.
+    var now: Date { get }
+}
+
+// MARK: - SystemDateProvider
+
+/// Production implementation — delegates directly to `Date()`.
+struct SystemDateProvider: DateProviding {
+    var now: Date { Date() }
+}

--- a/EyePostureReminder/ViewModels/SettingsViewModel.swift
+++ b/EyePostureReminder/ViewModels/SettingsViewModel.swift
@@ -114,6 +114,7 @@ final class SettingsViewModel: ObservableObject {
 
     let settings: SettingsStore
     private let scheduler: ReminderScheduling
+    private let dateProvider: DateProviding
     private var cancellables: Set<AnyCancellable> = []
 
     // MARK: - Computed State (M2.3)
@@ -121,7 +122,7 @@ final class SettingsViewModel: ObservableObject {
     /// `true` while a snooze is active (snoozedUntil is a future date).
     var isSnoozeActive: Bool {
         guard let until = settings.snoozedUntil else { return false }
-        return until > Date()
+        return until > dateProvider.now
     }
 
     /// `true` when the user is allowed to apply another snooze.
@@ -294,11 +295,13 @@ final class SettingsViewModel: ObservableObject {
     init(
         settings: SettingsStore,
         scheduler: ReminderScheduling,
-        maxSnoozeCount: Int = AppConfig.load().features.maxSnoozeCount
+        maxSnoozeCount: Int = AppConfig.load().features.maxSnoozeCount,
+        dateProvider: DateProviding = SystemDateProvider()
     ) {
         self.settings  = settings
         self.scheduler = scheduler
         self.maxConsecutiveSnoozes = maxSnoozeCount
+        self.dateProvider = dateProvider
         settings.objectWillChange
             .sink { [weak self] in self?.objectWillChange.send() }
             .store(in: &cancellables)
@@ -342,7 +345,7 @@ final class SettingsViewModel: ObservableObject {
             return
         }
         let endDate = option.endDate
-        guard endDate > Date() else {
+        guard endDate > dateProvider.now else {
             // Guard against clock skew or NTP drift producing a past end date;
             // applying a past snoozedUntil would be cleared immediately by
             // scheduleReminders() making snooze appear broken.
@@ -377,7 +380,7 @@ final class SettingsViewModel: ObservableObject {
             return
         }
         let analyticsCode = Self.snoozeOptions.first(where: { $0.minutes == minutes })?.analyticsCode ?? "custom"
-        settings.snoozedUntil = Date().addingTimeInterval(TimeInterval(minutes * 60))
+        settings.snoozedUntil = dateProvider.now.addingTimeInterval(TimeInterval(minutes * 60))
         settings.snoozeCount += 1
         scheduler.cancelAllReminders()
         AnalyticsLogger.log(.snoozeActivated(durationOption: analyticsCode))

--- a/Tests/EyePostureReminderTests/Mocks/MockDateProvider.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockDateProvider.swift
@@ -1,0 +1,16 @@
+// MockDateProvider.swift
+
+import Foundation
+@testable import EyePostureReminder
+
+/// Test double for `DateProviding`.
+///
+/// Set `now` to any fixed `Date` before the call under test to make
+/// time-sensitive assertions deterministic.
+final class MockDateProvider: DateProviding {
+    var now: Date
+
+    init(now: Date = Date()) {
+        self.now = now
+    }
+}

--- a/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift
@@ -30,6 +30,15 @@ final class SettingsViewModelExtendedTests: XCTestCase {
         SettingsViewModel(settings: settings, scheduler: mockScheduler, maxSnoozeCount: maxSnoozeCount)
     }
 
+    private func makeSUT(maxSnoozeCount: Int = 2, dateProvider: DateProviding) -> SettingsViewModel {
+        SettingsViewModel(
+            settings: settings,
+            scheduler: mockScheduler,
+            maxSnoozeCount: maxSnoozeCount,
+            dateProvider: dateProvider
+        )
+    }
+
     // MARK: - SnoozeOption.allCases
 
     func test_snoozeOptions_countIsThree() {
@@ -366,6 +375,53 @@ final class SettingsViewModelExtendedTests: XCTestCase {
         XCTAssertEqual(
             mockScheduler.scheduleRemindersCallCount, 0,
             "scheduleReminders must not be called when ViewModel is deallocated before Task body executes"
+        )
+    }
+
+    // MARK: - DateProviding seam (deterministic snooze tests)
+
+    func test_isSnoozeActive_withMockedNow_exactlyAtExpiry_returnsFalse() {
+        let fixedNow = Date(timeIntervalSince1970: 1_000_000)
+        let dateProvider = MockDateProvider(now: fixedNow)
+        let sut = makeSUT(dateProvider: dateProvider)
+        // snoozedUntil == now → not active (snooze has expired)
+        settings.snoozedUntil = fixedNow
+        XCTAssertFalse(sut.isSnoozeActive,
+            "A snoozedUntil equal to the current time must not be considered active")
+    }
+
+    func test_isSnoozeActive_withMockedNow_oneSecondBeforeExpiry_returnsTrue() {
+        let fixedNow = Date(timeIntervalSince1970: 1_000_000)
+        let dateProvider = MockDateProvider(now: fixedNow)
+        let sut = makeSUT(dateProvider: dateProvider)
+        // snoozedUntil is 1 second in the future relative to mocked now
+        settings.snoozedUntil = fixedNow.addingTimeInterval(1)
+        XCTAssertTrue(sut.isSnoozeActive,
+            "A snoozedUntil one second in the future must be considered active")
+    }
+
+    func test_isSnoozeActive_withMockedNow_oneSecondPastExpiry_returnsFalse() {
+        let fixedNow = Date(timeIntervalSince1970: 1_000_000)
+        let dateProvider = MockDateProvider(now: fixedNow)
+        let sut = makeSUT(dateProvider: dateProvider)
+        settings.snoozedUntil = fixedNow.addingTimeInterval(-1)
+        XCTAssertFalse(sut.isSnoozeActive,
+            "A snoozedUntil one second in the past must not be considered active")
+    }
+
+    @available(*, deprecated, message: "Tests legacy snooze(for:) date-provider seam")
+    func test_snoozeForLegacy_persistsNowPlusDuration_usingMockedDate() throws {
+        let fixedNow = Date(timeIntervalSince1970: 1_000_000)
+        let dateProvider = MockDateProvider(now: fixedNow)
+        let sut = makeSUT(dateProvider: dateProvider)
+        sut.snooze(for: 5)
+        let snoozedUntil = try XCTUnwrap(settings.snoozedUntil)
+        let expected = fixedNow.addingTimeInterval(5 * 60)
+        XCTAssertEqual(
+            snoozedUntil.timeIntervalSince1970,
+            expected.timeIntervalSince1970,
+            accuracy: 0.001,
+            "snooze(for:5) must persist exactly now + 5 min using the injected date provider"
         )
     }
 }


### PR DESCRIPTION
## Summary

Injects a `DateProviding` protocol into `SettingsViewModel` to remove implicit `Date()` calls in snooze-related logic — part of the #462 Phase A DI/SRP cleanup.

### Problem
`SettingsViewModel.isSnoozeActive`, `snooze(option:)` guard, and `snooze(for:)` all called `Date()` directly. This makes it impossible to write deterministic unit tests for snooze expiry without sleeping or using approximate delta assertions.

### Changes
- `EyePostureReminder/Utilities/DateProviding.swift` — new `DateProviding` protocol + `SystemDateProvider` production implementation
- `EyePostureReminder/ViewModels/SettingsViewModel.swift` — inject `dateProvider: DateProviding = SystemDateProvider()`; replace `Date()` in `isSnoozeActive`, `snooze(option:)` guard, and `snooze(for:)`
- `Tests/.../Mocks/MockDateProvider.swift` — new controllable test double
- `Tests/.../SettingsViewModelExtendedTests.swift` — 4 focused deterministic tests (exact expiry boundary, 1s before/after, legacy bridge)

### Behavior
No behavior change in production. `SystemDateProvider` delegates to `Date()` — identical runtime behavior.

### Validation
- `./scripts/build.sh build` ✓
- `./scripts/build.sh test` ✓

Closes part of #462