### PR TITLE
refactor: use dateProvider in cancelAllReminders (#462)

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -48,6 +48,7 @@
 - For app lifecycle wiring, prefer injecting a narrow `MetricKitSubscribing` dependency into `AppDelegate` and lazily fallback to `MetricKitSubscriber.shared` in `didFinishLaunching`; this removes closure indirection and keeps registration assertions simple in delegate seam tests.
 - For telemetry services that log heavily, inject a narrow logger protocol with a production `Logger.lifecycle` adapter; this keeps runtime behavior unchanged while letting unit tests assert side-effect logging without touching `os.Logger` globals (`EyePostureReminder/Services/MetricKitSubscriber.swift`, `Tests/EyePostureReminderTests/Services/MetricKitSubscriberTests.swift`).
 - For watchdog/lifecycle time checks, prefer a zero-arg production path that reads from injected `DateProviding`, then keep an explicit `now` overload for precise unit tests; this removes hidden `Date()` globals without losing targeted deterministic coverage (`EyePostureReminder/Services/AppCoordinatorWatchdogRecovery.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorWatchdogHeartbeatTests.swift`).
+- For snooze guards outside explicit `now` overloads, compare against injected `dateProvider.now` instead of `Date()` (for example in `cancelAllReminders`) and test both “wall-clock active but injected expired” and inverse cases to prove DI seam usage.
 
 ## 2026-05-03T10:08:22Z: #462 Phase A DI/SRP — DateProviding Seam Micro-Slice (COMPLETED)
 

--- a/.squad/skills/date-provider-default-seam/SKILL.md
+++ b/.squad/skills/date-provider-default-seam/SKILL.md
@@ -13,6 +13,7 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - Inject `DateProviding` at the owning service/coordinator.
 - Add a zero-argument method that calls the explicit overload with `dateProvider.now`.
 - Keep `func method(now: Date)` for deterministic test control.
+- For guard logic without overloads (e.g., snooze-active checks), route comparisons through `dateProvider.now` and assert both injected-now inversion cases in tests.
 
 ## Benefits
 - Production path no longer depends on implicit `Date()` globals.
@@ -22,3 +23,5 @@ Use when a service method currently takes `now: Date = Date()` and production co
 ## Example
 - `EyePostureReminder/Services/AppCoordinatorWatchdogRecovery.swift`
 - `Tests/EyePostureReminderTests/Services/AppCoordinatorWatchdogHeartbeatTests.swift`
+- `EyePostureReminder/Services/AppCoordinator+ReminderScheduling.swift`
+- `Tests/EyePostureReminderTests/Services/AppCoordinatorExtendedTests.swift`

--- a/EyePostureReminder/Services/AppCoordinator+ReminderScheduling.swift
+++ b/EyePostureReminder/Services/AppCoordinator+ReminderScheduling.swift
@@ -60,7 +60,7 @@ extension AppCoordinator: ReminderScheduling {
         // while staying in the foreground throughout the snooze period.
         // #73: Also schedule the silent background notification so a backgrounded
         // app can wake even if the in-process task is killed by the OS.
-        if let snoozeEnd = settings.snoozedUntil, snoozeEnd > Date() {
+        if let snoozeEnd = settings.snoozedUntil, snoozeEnd > dateProvider.now {
             scheduleSnoozeWakeTask(at: snoozeEnd)
             if notificationAuthStatus == .authorized {
                 Task { [weak self] in await self?.scheduleSnoozeWakeNotification(at: snoozeEnd) }

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorExtendedTests.swift
@@ -37,7 +37,8 @@ final class AppCoordinatorExtendedTests: XCTestCase {
         notifCenter: MockNotificationCenter = MockNotificationCenter(),
         screenTimeTracker screenTimeTrackerArg: MockScreenTimeTracker? = nil,
         pauseConditionProvider pauseArg: PauseConditionProviding? = nil,
-        ipcStore ipcStoreArg: MockAppGroupIPCRecorder? = nil
+        ipcStore ipcStoreArg: MockAppGroupIPCRecorder? = nil,
+        dateProvider: DateProviding = SystemDateProvider()
     ) -> (
         coordinator: AppCoordinator,
         overlay: MockOverlayPresenting,
@@ -55,7 +56,8 @@ final class AppCoordinatorExtendedTests: XCTestCase {
             overlayManager: overlay,
             screenTimeTracker: tracker,
             pauseConditionProvider: pause,
-            ipcStore: ipcStore
+            ipcStore: ipcStore,
+            dateProvider: dateProvider
         )
         return (coordinator, overlay, tracker, notifCenter)
     }
@@ -461,6 +463,32 @@ final class AppCoordinatorExtendedTests: XCTestCase {
         defer { coordinator.stopFallbackTimers() }
 
         coordinator.cancelAllReminders()
+    }
+
+    func test_cancelAllReminders_withFutureSnoozeAccordingToDateProvider_armsSnoozeWakeTask() {
+        let mockDateProvider = MockDateProvider(now: Date(timeIntervalSinceNow: -3600))
+        settings.snoozedUntil = Date(timeIntervalSinceNow: -10)
+        let (coordinator, _, _, _) = makeCoordinator(dateProvider: mockDateProvider)
+        defer { coordinator.stopFallbackTimers() }
+
+        coordinator.cancelAllReminders()
+
+        XCTAssertNotNil(
+            coordinator.snoozeWakeTask,
+            "cancelAllReminders should evaluate snooze activity using injected DateProviding")
+    }
+
+    func test_cancelAllReminders_withExpiredSnoozeAccordingToDateProvider_doesNotArmSnoozeWakeTask() {
+        let mockDateProvider = MockDateProvider(now: Date(timeIntervalSinceNow: 3600))
+        settings.snoozedUntil = Date(timeIntervalSinceNow: 10)
+        let (coordinator, _, _, _) = makeCoordinator(dateProvider: mockDateProvider)
+        defer { coordinator.stopFallbackTimers() }
+
+        coordinator.cancelAllReminders()
+
+        XCTAssertNil(
+            coordinator.snoozeWakeTask,
+            "cancelAllReminders should skip snooze wake when injected DateProviding marks snooze expired")
     }
 
     /// Regression test for #267: `cancelAllReminders()` must clear the overlay


### PR DESCRIPTION
Summary: route AppCoordinator cancelAllReminders snooze-active check through injected dateProvider.now; preserve behavior; add focused unit tests for injected-clock inversion cases. Validation: ./scripts/build.sh build and ./scripts/build.sh test. Refs #462.