### PR TITLE
#462 Phase A: inject date seam into SettingsViewModel snooze option path

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -49,6 +49,7 @@
 - For telemetry services that log heavily, inject a narrow logger protocol with a production `Logger.lifecycle` adapter; this keeps runtime behavior unchanged while letting unit tests assert side-effect logging without touching `os.Logger` globals (`EyePostureReminder/Services/MetricKitSubscriber.swift`, `Tests/EyePostureReminderTests/Services/MetricKitSubscriberTests.swift`).
 - For watchdog/lifecycle time checks, prefer a zero-arg production path that reads from injected `DateProviding`, then keep an explicit `now` overload for precise unit tests; this removes hidden `Date()` globals without losing targeted deterministic coverage (`EyePostureReminder/Services/AppCoordinatorWatchdogRecovery.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorWatchdogHeartbeatTests.swift`).
 - For snooze guards outside explicit `now` overloads, compare against injected `dateProvider.now` instead of `Date()` (for example in `cancelAllReminders`) and test both “wall-clock active but injected expired” and inverse cases to prove DI seam usage.
+- For enum-driven snooze date math, provide `endDate(referenceDate:)` and keep `endDate` as a convenience wrapper; this lets production call sites use injected clocks without breaking existing API use sites (`EyePostureReminder/ViewModels/SettingsViewModel.swift`).
 
 ## 2026-05-03T10:08:22Z: #462 Phase A DI/SRP — DateProviding Seam Micro-Slice (COMPLETED)
 
@@ -74,3 +75,21 @@
 - `.squad/log/2026-05-03T10-08-22Z-462-next-microslice.md`
 
 **Decision Filed:** `.squad/decisions/decisions.md` — DateProviding seam pattern and Phase A rationale
+
+## 2026-05-03T11:05:00Z: #462 Phase A DI/SRP — SettingsViewModel SnoozeOption Date Seam (COMPLETED)
+
+**Task:** Execute next smallest #462 Phase A DI/SRP micro-slice from latest origin/main, validate tests, open PR
+
+**Slice:** Route `snooze(option:)` end-date computation through injected `DateProviding`
+
+**Branch:** basher/462-phasea-settingsviewmodel-store-seam  
+**Commit:** 23a658a  
+**PR:** https://github.com/yashasg/fantastic-octo-fortnight/pull/518
+
+**Changes:**
+- SettingsViewModel: Added `SnoozeOption.endDate(referenceDate:)` and switched `snooze(option:)` to use `dateProvider.now`
+- SettingsViewModelExtendedTests: Added deterministic seam tests for `.oneHour` and `.restOfDay`
+- Skill: Updated `.squad/skills/date-provider-default-seam/SKILL.md` with enum helper seam pattern
+
+**Validation:** ✅ `./scripts/build.sh build` and `./scripts/build.sh test` passed  
+**Status:** READY FOR NEXT PHASE A SLICE

--- a/.squad/skills/date-provider-default-seam/SKILL.md
+++ b/.squad/skills/date-provider-default-seam/SKILL.md
@@ -14,6 +14,7 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - Add a zero-argument method that calls the explicit overload with `dateProvider.now`.
 - Keep `func method(now: Date)` for deterministic test control.
 - For guard logic without overloads (e.g., snooze-active checks), route comparisons through `dateProvider.now` and assert both injected-now inversion cases in tests.
+- For enum or helper structs that currently compute dates from `Date()`, add a `referenceDate` overload and keep the old computed property as a convenience wrapper.
 
 ## Benefits
 - Production path no longer depends on implicit `Date()` globals.
@@ -25,3 +26,5 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - `Tests/EyePostureReminderTests/Services/AppCoordinatorWatchdogHeartbeatTests.swift`
 - `EyePostureReminder/Services/AppCoordinator+ReminderScheduling.swift`
 - `Tests/EyePostureReminderTests/Services/AppCoordinatorExtendedTests.swift`
+- `EyePostureReminder/ViewModels/SettingsViewModel.swift`
+- `Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift`

--- a/EyePostureReminder/ViewModels/SettingsViewModel.swift
+++ b/EyePostureReminder/ViewModels/SettingsViewModel.swift
@@ -42,12 +42,18 @@ final class SettingsViewModel: ObservableObject {
         }
 
         /// The absolute `Date` at which this snooze should expire.
+        /// Uses wall-clock `Date()` for convenience call sites.
         var endDate: Date {
+            endDate(referenceDate: Date())
+        }
+
+        /// Computes the absolute snooze expiry date from an injected reference date.
+        func endDate(referenceDate: Date) -> Date {
             switch self {
             case .fiveMinutes:
-                return Date().addingTimeInterval(5 * 60)
+                return referenceDate.addingTimeInterval(5 * 60)
             case .oneHour:
-                return Date().addingTimeInterval(60 * 60)
+                return referenceDate.addingTimeInterval(60 * 60)
             case .restOfDay:
                 // End of the current calendar day (midnight tonight).
                 // `calendar.date(byAdding:)` never returns nil for valid inputs,
@@ -57,17 +63,17 @@ final class SettingsViewModel: ObservableObject {
                 return calendar.date(
                     byAdding: .day,
                     value: 1,
-                    to: calendar.startOfDay(for: Date())
+                    to: calendar.startOfDay(for: referenceDate)
                 ) ?? {
                     // Unreachable in practice; guard against unexpected nil with a
                     // warning rather than silently computing the wrong end time.
                     Logger.settings.warning(
                         "SnoozeOption.restOfDay: calendar.date returned nil — falling back to DateComponents midnight"
                     )
-                    var comps = calendar.dateComponents([.year, .month, .day], from: Date())
+                    var comps = calendar.dateComponents([.year, .month, .day], from: referenceDate)
                     comps.day = (comps.day ?? 0) + 1
                     comps.hour = 0; comps.minute = 0; comps.second = 0
-                    return calendar.date(from: comps) ?? Date().addingTimeInterval(86400)
+                    return calendar.date(from: comps) ?? referenceDate.addingTimeInterval(86400)
                 }()
             }
         }
@@ -344,7 +350,7 @@ final class SettingsViewModel: ObservableObject {
             Logger.settings.info("Snooze limit reached — ignoring snooze request")
             return
         }
-        let endDate = option.endDate
+        let endDate = option.endDate(referenceDate: dateProvider.now)
         guard endDate > dateProvider.now else {
             // Guard against clock skew or NTP drift producing a past end date;
             // applying a past snoozedUntil would be cleared immediately by

--- a/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift
@@ -424,4 +424,41 @@ final class SettingsViewModelExtendedTests: XCTestCase {
             "snooze(for:5) must persist exactly now + 5 min using the injected date provider"
         )
     }
+
+    func test_snoozeOptionOneHour_persistsNowPlusDuration_usingMockedDate() throws {
+        let fixedNow = Date(timeIntervalSince1970: 1_000_000)
+        let dateProvider = MockDateProvider(now: fixedNow)
+        let sut = makeSUT(dateProvider: dateProvider)
+
+        sut.snooze(option: .oneHour)
+
+        let snoozedUntil = try XCTUnwrap(settings.snoozedUntil)
+        let expected = fixedNow.addingTimeInterval(60 * 60)
+        XCTAssertEqual(
+            snoozedUntil.timeIntervalSince1970,
+            expected.timeIntervalSince1970,
+            accuracy: 0.001,
+            "snooze(option:.oneHour) must use injected date provider now"
+        )
+    }
+
+    func test_snoozeOptionRestOfDay_usesInjectedReferenceDateForMidnightCutoff() throws {
+        let fixedNow = Date(timeIntervalSince1970: 1_000_000)
+        let dateProvider = MockDateProvider(now: fixedNow)
+        let sut = makeSUT(dateProvider: dateProvider)
+
+        sut.snooze(option: .restOfDay)
+
+        let calendar = Calendar.current
+        let expected = try XCTUnwrap(
+            calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: fixedNow))
+        )
+        let snoozedUntil = try XCTUnwrap(settings.snoozedUntil)
+        XCTAssertEqual(
+            snoozedUntil.timeIntervalSince1970,
+            expected.timeIntervalSince1970,
+            accuracy: 0.001,
+            "restOfDay must compute midnight from the injected current date"
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- route SettingsViewModel.snooze(option:) through injected dateProvider.now
- add SnoozeOption.endDate(referenceDate:) while preserving existing endDate convenience property
- add focused deterministic tests for .oneHour and .restOfDay option expiry math

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462