### PR TITLE
#462 Phase A: DateProviding seam for debounced performReschedule guard

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -50,6 +50,7 @@
 - For watchdog/lifecycle time checks, prefer a zero-arg production path that reads from injected `DateProviding`, then keep an explicit `now` overload for precise unit tests; this removes hidden `Date()` globals without losing targeted deterministic coverage (`EyePostureReminder/Services/AppCoordinatorWatchdogRecovery.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorWatchdogHeartbeatTests.swift`).
 - For snooze guards outside explicit `now` overloads, compare against injected `dateProvider.now` instead of `Date()` (for example in `cancelAllReminders`) and test both “wall-clock active but injected expired” and inverse cases to prove DI seam usage.
 - For enum-driven snooze date math, provide `endDate(referenceDate:)` and keep `endDate` as a convenience wrapper; this lets production call sites use injected clocks without breaking existing API use sites (`EyePostureReminder/ViewModels/SettingsViewModel.swift`).
+- For debounced reschedule flows, route the final guard (`performReschedule`) through injected `dateProvider.now` and assert inversion tests through the public `reschedule(for:)` entrypoint to prove the debounce path honors DI seams.
 
 ## 2026-05-03T10:08:22Z: #462 Phase A DI/SRP — DateProviding Seam Micro-Slice (COMPLETED)
 

--- a/.squad/skills/date-provider-default-seam/SKILL.md
+++ b/.squad/skills/date-provider-default-seam/SKILL.md
@@ -14,6 +14,7 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - Add a zero-argument method that calls the explicit overload with `dateProvider.now`.
 - Keep `func method(now: Date)` for deterministic test control.
 - For guard logic without overloads (e.g., snooze-active checks), route comparisons through `dateProvider.now` and assert both injected-now inversion cases in tests.
+- For debounced workflows (`reschedule(for:)` → delayed `performReschedule`), put the snooze/time guard in the delayed method behind `dateProvider.now` and verify via the public entrypoint after waiting beyond debounce.
 - For enum or helper structs that currently compute dates from `Date()`, add a `referenceDate` overload and keep the old computed property as a convenience wrapper.
 
 ## Benefits

--- a/EyePostureReminder/Services/AppCoordinator+Helpers.swift
+++ b/EyePostureReminder/Services/AppCoordinator+Helpers.swift
@@ -212,7 +212,7 @@ extension AppCoordinator {
     func performReschedule(for type: ReminderType) async {
         // #74: Skip tracker restart when snooze is active — settings changes
         // during a snooze must not override the explicit pauseAll() applied at snooze start.
-        guard (settings.snoozedUntil ?? .distantPast) <= Date() else {
+        guard (settings.snoozedUntil ?? .distantPast) <= dateProvider.now else {
             Logger.scheduling.debug("performReschedule skipped — snooze still active")
             return
         }

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorExtendedTests.swift
@@ -610,6 +610,48 @@ final class AppCoordinatorExtendedTests: XCTestCase {
             "startFallbackTimers must call startMonitoring() on the ScreenTimeTracker")
     }
 
+    func test_reschedule_withSnoozeActiveAccordingToDateProvider_skipsPerformReschedule() async throws {
+        let mockTracker = MockScreenTimeTracker()
+        let mockDateProvider = MockDateProvider(now: Date(timeIntervalSince1970: 1_000))
+        settings.eyesEnabled = true
+        settings.snoozedUntil = Date(timeIntervalSince1970: 2_000)
+        let (coordinator, _, _, _) = makeCoordinator(
+            screenTimeTracker: mockTracker,
+            dateProvider: mockDateProvider
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        await coordinator.reschedule(for: .eyes)
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        let setThresholdCount = mockTracker.setThresholdCalls.filter { $0.type == .eyes }.count
+        XCTAssertEqual(
+            setThresholdCount,
+            0,
+            "reschedule(for:) must honor injected DateProviding and skip performReschedule while snooze is active")
+    }
+
+    func test_reschedule_withExpiredSnoozeAccordingToDateProvider_runsPerformReschedule() async throws {
+        let mockTracker = MockScreenTimeTracker()
+        let mockDateProvider = MockDateProvider(now: Date(timeIntervalSince1970: 3_000))
+        settings.eyesEnabled = true
+        settings.snoozedUntil = Date(timeIntervalSince1970: 2_000)
+        let (coordinator, _, _, _) = makeCoordinator(
+            screenTimeTracker: mockTracker,
+            dateProvider: mockDateProvider
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        await coordinator.reschedule(for: .eyes)
+        try await Task.sleep(nanoseconds: 500_000_000)
+
+        let setThresholdCount = mockTracker.setThresholdCalls.filter { $0.type == .eyes }.count
+        XCTAssertEqual(
+            setThresholdCount,
+            1,
+            "reschedule(for:) must run performReschedule when injected DateProviding marks snooze expired")
+    }
+
     // MARK: - P0-3: reschedule debounce cancellation
 
     /// A rapid second `reschedule(for:)` must cancel the first debounced task so that


### PR DESCRIPTION
Summary:\n- route AppCoordinator performReschedule(for:) snooze guard through injected dateProvider.now instead of direct Date()\n- add focused seam tests proving reschedule(for:) debounce path honors injected clock for both active and expired snooze states\n- append Basher learnings and date-provider seam skill note\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462