### PR TITLE
#462 Phase A: DateProviding seam for clearExpiredSnoozeIfNeeded

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -51,6 +51,7 @@
 - For snooze guards outside explicit `now` overloads, compare against injected `dateProvider.now` instead of `Date()` (for example in `cancelAllReminders`) and test both “wall-clock active but injected expired” and inverse cases to prove DI seam usage.
 - For enum-driven snooze date math, provide `endDate(referenceDate:)` and keep `endDate` as a convenience wrapper; this lets production call sites use injected clocks without breaking existing API use sites (`EyePostureReminder/ViewModels/SettingsViewModel.swift`).
 - For debounced reschedule flows, route the final guard (`performReschedule`) through injected `dateProvider.now` and assert inversion tests through the public `reschedule(for:)` entrypoint to prove the debounce path honors DI seams.
+- For lifecycle cleanup hooks like `clearExpiredSnoozeIfNeeded`, route stale-state guards through injected `dateProvider.now` and add inversion tests (wall-clock stale vs injected future, and the reverse) to prove the seam is actually used.
 
 ## 2026-05-03T10:08:22Z: #462 Phase A DI/SRP — DateProviding Seam Micro-Slice (COMPLETED)
 

--- a/.squad/skills/date-provider-default-seam/SKILL.md
+++ b/.squad/skills/date-provider-default-seam/SKILL.md
@@ -16,6 +16,7 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - For guard logic without overloads (e.g., snooze-active checks), route comparisons through `dateProvider.now` and assert both injected-now inversion cases in tests.
 - For debounced workflows (`reschedule(for:)` → delayed `performReschedule`), put the snooze/time guard in the delayed method behind `dateProvider.now` and verify via the public entrypoint after waiting beyond debounce.
 - For enum or helper structs that currently compute dates from `Date()`, add a `referenceDate` overload and keep the old computed property as a convenience wrapper.
+- For lifecycle cleanup hooks (for example `clearExpiredSnoozeIfNeeded`), evaluate stale-state guards with `dateProvider.now` and add inversion tests where wall-clock and injected clock disagree.
 
 ## Benefits
 - Production path no longer depends on implicit `Date()` globals.
@@ -29,3 +30,5 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - `Tests/EyePostureReminderTests/Services/AppCoordinatorExtendedTests.swift`
 - `EyePostureReminder/ViewModels/SettingsViewModel.swift`
 - `Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift`
+- `EyePostureReminder/Services/AppCoordinator.swift`
+- `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -519,7 +519,7 @@ final class AppCoordinator: ObservableObject {
     /// `snoozedUntil` (left by a swiped-away snooze-wake notification on a
     /// killed app) is cleaned up before `scheduleReminders()` runs.
     func clearExpiredSnoozeIfNeeded() async {
-        guard let snoozeEnd = settings.snoozedUntil, snoozeEnd <= Date() else { return }
+        guard let snoozeEnd = settings.snoozedUntil, snoozeEnd <= dateProvider.now else { return }
         settings.snoozedUntil = nil
         settings.snoozeCount  = 0
         AnalyticsLogger.log(.snoozeExpired)

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -532,6 +532,58 @@ final class AppCoordinatorTests: XCTestCase {
         XCTAssertNil(settings.snoozedUntil)
     }
 
+    func test_clearExpiredSnoozeIfNeeded_usesInjectedDateProvider_whenWallClockPastButInjectedFuture() async {
+        let mockDateProvider = MockDateProvider(now: Date(timeIntervalSinceNow: -3_600))
+        let mockNotif = MockNotificationCenter()
+        let coordinator = AppCoordinator(
+            settings: settings,
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: MockAppGroupIPCRecorder(),
+            dateProvider: mockDateProvider
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        let wallClockPast = Date(timeIntervalSinceNow: -60)
+        settings.snoozedUntil = wallClockPast
+        settings.snoozeCount = 2
+
+        await coordinator.clearExpiredSnoozeIfNeeded()
+
+        XCTAssertEqual(
+            settings.snoozedUntil,
+            wallClockPast,
+            "clearExpiredSnoozeIfNeeded should use injected DateProviding instead of wall clock")
+        XCTAssertEqual(settings.snoozeCount, 2)
+    }
+
+    func test_clearExpiredSnoozeIfNeeded_usesInjectedDateProvider_whenWallClockFutureButInjectedExpired() async {
+        let mockDateProvider = MockDateProvider(now: Date(timeIntervalSinceNow: 3_600))
+        let mockNotif = MockNotificationCenter()
+        let coordinator = AppCoordinator(
+            settings: settings,
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: MockAppGroupIPCRecorder(),
+            dateProvider: mockDateProvider
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        settings.snoozedUntil = Date(timeIntervalSinceNow: 60)
+        settings.snoozeCount = 2
+
+        await coordinator.clearExpiredSnoozeIfNeeded()
+
+        XCTAssertNil(
+            settings.snoozedUntil,
+            "clearExpiredSnoozeIfNeeded should clear snooze when injected DateProviding marks it expired")
+        XCTAssertEqual(settings.snoozeCount, 0)
+    }
+
     func test_scheduleReminders_snoozeWakeNotification_isSilent() async {
         // Arrange: inject auth-authorized mock so the silent notification is actually scheduled.
         let mockNotif = MockNotificationCenter()


### PR DESCRIPTION
Summary:\n- route AppCoordinator.clearExpiredSnoozeIfNeeded() snooze-expiry guard through injected dateProvider.now instead of Date()\n- add focused inversion tests proving the lifecycle cleanup hook uses injected clock semantics\n- append Basher learning and update date-provider seam skill\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462