### PR TITLE
#462 Phase A: thread UI-test mode via launch-arg seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -52,6 +52,7 @@
 - For enum-driven snooze date math, provide `endDate(referenceDate:)` and keep `endDate` as a convenience wrapper; this lets production call sites use injected clocks without breaking existing API use sites (`EyePostureReminder/ViewModels/SettingsViewModel.swift`).
 - For debounced reschedule flows, route the final guard (`performReschedule`) through injected `dateProvider.now` and assert inversion tests through the public `reschedule(for:)` entrypoint to prove the debounce path honors DI seams.
 - For lifecycle cleanup hooks like `clearExpiredSnoozeIfNeeded`, route stale-state guards through injected `dateProvider.now` and add inversion tests (wall-clock stale vs injected future, and the reverse) to prove the seam is actually used.
+- For UI-test mode gating, resolve the mode once from injected `launchArguments` (`uiTestMode ?? isUITestMode(launchArguments:)`) and thread it into *all* service resolvers (tracker + pause manager) so tests can deterministically control launch behavior without hidden `CommandLine` globals.
 
 ## 2026-05-03T10:08:22Z: #462 Phase A DI/SRP — DateProviding Seam Micro-Slice (COMPLETED)
 

--- a/.squad/skills/launch-context-di-seam/SKILL.md
+++ b/.squad/skills/launch-context-di-seam/SKILL.md
@@ -16,6 +16,7 @@ Use this when service or coordinator logic branches on process launch context
 - Keep behavior unchanged by preserving the same default values used before extraction.
 - For `@MainActor` coordinators, use optional init params for actor-isolated defaults and resolve to static values inside `init` (avoids Swift 6 nonisolated default-argument errors).
 - When launch-arg branches need service mutation (e.g., reset defaults / short overlay durations), inject a tiny factory closure (`makeSettingsStore`) instead of constructing concrete services inline.
+- If multiple resolver branches depend on UI-test mode, compute `let resolvedUITestMode = uiTestMode ?? isUITestMode(launchArguments:)` once in `init` and pass that value into each resolver to prevent mixed global/injected behavior.
 
 ## Examples
 - `AppCoordinator.init(..., processEnvironment: [String: String] = ProcessInfo.processInfo.environment, launchArguments: [String] = CommandLine.arguments, ...)`
@@ -27,3 +28,4 @@ Use this when service or coordinator logic branches on process launch context
 - Reading launch context globals directly inside static resolvers.
 - Overriding global process state in tests instead of injecting explicit values.
 - Constructing concrete stores/services directly inside launch handlers (`SettingsStore()`) when a factory seam can preserve behavior and improve testability.
+- Mixing an injected UI-test mode for one resolver with a static global (`AppCoordinator.isUITestMode`) in another resolver.

--- a/EyePostureReminder/Services/AppCoordinator+UITestMode.swift
+++ b/EyePostureReminder/Services/AppCoordinator+UITestMode.swift
@@ -16,12 +16,20 @@ extension AppCoordinator {
     /// `#if DEBUG` ensures this `CommandLine` inspection is compiled out of Release/TestFlight
     /// builds, preventing accidental onboarding state resets in production (re: #350/#405).
 #if DEBUG
-    static let isUITestMode: Bool = CommandLine.arguments.contains("--skip-onboarding") ||
-                                    CommandLine.arguments.contains("--reset-onboarding") ||
-                                    CommandLine.arguments.contains("--show-overlay-eyes") ||
-                                    CommandLine.arguments.contains("--show-overlay-posture") ||
-                                    CommandLine.arguments.contains("--simulate-screen-time-not-determined")
+    static let isUITestMode: Bool = isUITestMode(launchArguments: CommandLine.arguments)
+
+    static func isUITestMode(launchArguments: [String]) -> Bool {
+        launchArguments.contains("--skip-onboarding") ||
+            launchArguments.contains("--reset-onboarding") ||
+            launchArguments.contains("--show-overlay-eyes") ||
+            launchArguments.contains("--show-overlay-posture") ||
+            launchArguments.contains("--simulate-screen-time-not-determined")
+    }
 #else
     static let isUITestMode: Bool = false
+
+    static func isUITestMode(launchArguments: [String]) -> Bool {
+        false
+    }
 #endif
 }

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -209,16 +209,19 @@ final class AppCoordinator: ObservableObject {
         self.ipcStore = ipcStore
         self.dateProvider = dateProvider
         self.watchdogHeartbeatGraceInterval = watchdogHeartbeatGraceInterval
+        let resolvedUITestMode = uiTestMode ?? Self.isUITestMode(launchArguments: launchArguments)
+
         // In UI test mode, use no-op stubs for services that register UIKit lifecycle
         // observers and start 1-second timers — they prevent XCUITest from settling
         // the accessibility tree between interactions, causing stale element reads.
         self.screenTimeTracker = Self.resolveScreenTimeTracker(
             screenTimeTracker,
-            uiTestMode: uiTestMode ?? AppCoordinator.isUITestMode
+            uiTestMode: resolvedUITestMode
         )
         self.pauseConditionManager = Self.resolvePauseConditionManager(
             pauseConditionProvider,
-            settings: self.settings
+            settings: self.settings,
+            uiTestMode: resolvedUITestMode
         )
         Logger.lifecycle.info("AppCoordinator initialised")
         recordWatchdogHeartbeat(.coordinatorInitialized)
@@ -659,10 +662,11 @@ private extension AppCoordinator {
 
     static func resolvePauseConditionManager(
         _ pauseConditionProvider: PauseConditionProviding?,
-        settings: SettingsStore
+        settings: SettingsStore,
+        uiTestMode: Bool
     ) -> PauseConditionProviding {
         guard let pauseConditionProvider else {
-            return AppCoordinator.isUITestMode
+            return uiTestMode
                 ? NoopPauseConditionManager()
                 : PauseConditionManager(
                     settings: settings,

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestModeResolverTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestModeResolverTests.swift
@@ -4,6 +4,25 @@ import XCTest
 @MainActor
 final class AppCoordinatorUITestModeResolverTests: XCTestCase {
 
+    func test_isUITestMode_withMatchingLaunchArgument_returnsTrue() {
+        XCTAssertTrue(AppCoordinator.isUITestMode(launchArguments: ["--show-overlay-eyes"]))
+    }
+
+    func test_init_withUITestLaunchArgument_andNoTracker_resolvesNoopScreenTimeTracker() {
+        let mockNotif = MockNotificationCenter()
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            pauseConditionProvider: MockPauseConditionProvider(),
+            launchArguments: ["--skip-onboarding"],
+            ipcStore: MockAppGroupIPCRecorder()
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        XCTAssertTrue(coordinator.screenTimeTracker is NoopScreenTimeTracker)
+    }
+
     func test_init_withInjectedUITestModeTrue_andNoTracker_resolvesNoopScreenTimeTracker() {
         let mockNotif = MockNotificationCenter()
         let coordinator = AppCoordinator(
@@ -34,5 +53,19 @@ final class AppCoordinatorUITestModeResolverTests: XCTestCase {
         defer { coordinator.stopFallbackTimers() }
 
         XCTAssertTrue(coordinator.screenTimeTracker === injectedTracker)
+    }
+
+    func test_init_withInjectedUITestModeTrue_andNoPauseProvider_resolvesNoopPauseConditionManager() {
+        let mockNotif = MockNotificationCenter()
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            uiTestMode: true,
+            ipcStore: MockAppGroupIPCRecorder()
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        XCTAssertTrue(coordinator.pauseConditionManager is NoopPauseConditionManager)
     }
 }


### PR DESCRIPTION
## Summary
- resolve UI-test mode from injected launch arguments via AppCoordinator.isUITestMode(launchArguments:)
- compute resolvedUITestMode once in AppCoordinator.init and pass it to both tracker and pause-condition resolvers
- add focused resolver tests for launch-arg detection and no-op pause manager resolution

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462