### PR TITLE
#462 Phase A: use DateProviding in handleNotification snooze guard

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -96,3 +96,10 @@
 
 **Validation:** ✅ `./scripts/build.sh build` and `./scripts/build.sh test` passed  
 **Status:** READY FOR NEXT PHASE A SLICE
+
+## 2026-05-03T11:30:00Z: #462 Phase A DI/SRP — handleNotification Snooze Guard Date Seam (IN PROGRESS)
+
+- Learned pattern: notification-delivery snooze guards should compare against injected `dateProvider.now` instead of `Date()` so suppression behavior is deterministic in unit tests.
+- Architecture decision: keep behavior identical by changing only the guard expression in `AppCoordinator.handleNotification(for:)` and proving seam usage with wall-clock/injected-clock inversion tests.
+- User preference reinforced: keep micro-slices surgical (single DI seam + focused tests + full `./scripts/build.sh build` and `./scripts/build.sh test` validation).
+- Key file paths: `EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`, `.squad/skills/date-provider-default-seam/SKILL.md`.

--- a/.squad/skills/date-provider-default-seam/SKILL.md
+++ b/.squad/skills/date-provider-default-seam/SKILL.md
@@ -17,6 +17,7 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - For debounced workflows (`reschedule(for:)` → delayed `performReschedule`), put the snooze/time guard in the delayed method behind `dateProvider.now` and verify via the public entrypoint after waiting beyond debounce.
 - For enum or helper structs that currently compute dates from `Date()`, add a `referenceDate` overload and keep the old computed property as a convenience wrapper.
 - For lifecycle cleanup hooks (for example `clearExpiredSnoozeIfNeeded`), evaluate stale-state guards with `dateProvider.now` and add inversion tests where wall-clock and injected clock disagree.
+- For notification-delivery snooze guards (`handleNotification`), evaluate suppression with `dateProvider.now` so reminder delivery respects injected time seams in deterministic tests.
 
 ## Benefits
 - Production path no longer depends on implicit `Date()` globals.

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -473,7 +473,7 @@ final class AppCoordinator: ObservableObject {
     /// If no window scene is active yet (notification-tap race), the overlay is
     /// queued and presented when `presentPendingOverlayIfNeeded()` is called.
     func handleNotification(for type: ReminderType) {
-        guard (settings.snoozedUntil ?? .distantPast) <= Date() else {
+        guard (settings.snoozedUntil ?? .distantPast) <= dateProvider.now else {
             Logger.scheduling.info("Ignoring \(type.rawValue) notification while snooze is active")
             return
         }

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -351,6 +351,62 @@ final class AppCoordinatorTests: XCTestCase {
             "Ignored notifications during active snooze must not reset tracker state")
     }
 
+    func test_handleNotification_usesInjectedDateProvider_whenWallClockFutureButInjectedExpired() {
+        let mockDateProvider = MockDateProvider(now: Date(timeIntervalSinceNow: 3_600))
+        let mockNotif = MockNotificationCenter()
+        let tracker = MockScreenTimeTracker()
+        let coordinator = AppCoordinator(
+            settings: settings,
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            overlayManager: MockOverlayPresenting(),
+            screenTimeTracker: tracker,
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: MockAppGroupIPCRecorder(),
+            dateProvider: mockDateProvider
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        settings.snoozedUntil = Date(timeIntervalSinceNow: 300)
+        settings.snoozeCount = 2
+
+        coordinator.handleNotification(for: .eyes)
+
+        XCTAssertEqual(settings.snoozeCount, 0)
+        XCTAssertEqual(
+            tracker.resetCalls,
+            [.eyes],
+            "handleNotification should evaluate snooze with injected DateProviding")
+    }
+
+    func test_handleNotification_usesInjectedDateProvider_whenWallClockPastButInjectedFuture() {
+        let mockDateProvider = MockDateProvider(now: Date(timeIntervalSinceNow: -3_600))
+        let mockNotif = MockNotificationCenter()
+        let tracker = MockScreenTimeTracker()
+        let coordinator = AppCoordinator(
+            settings: settings,
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            overlayManager: MockOverlayPresenting(),
+            screenTimeTracker: tracker,
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: MockAppGroupIPCRecorder(),
+            dateProvider: mockDateProvider
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        settings.snoozedUntil = Date(timeIntervalSinceNow: -60)
+        settings.snoozeCount = 2
+
+        coordinator.handleNotification(for: .eyes)
+
+        XCTAssertEqual(
+            settings.snoozeCount,
+            2,
+            "handleNotification should continue suppressing reminders when injected DateProviding reports active snooze")
+        XCTAssertTrue(tracker.resetCalls.isEmpty)
+    }
+
     // MARK: - cancelAllReminders with active snooze
 
     func test_cancelAllReminders_withActiveSnooze_clearQueueStillCalled() {


### PR DESCRIPTION
## Summary
- route AppCoordinator.handleNotification(for:) snooze suppression guard through injected dateProvider.now
- add focused inversion unit tests proving injected clock is authoritative when wall clock disagrees
- update Basher learnings and DateProviding skill note for this seam pattern

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Closes #462