### PR TITLE
#462 Phase A: inject AppDelegate notification center fallback factory

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -53,6 +53,7 @@
 - For debounced reschedule flows, route the final guard (`performReschedule`) through injected `dateProvider.now` and assert inversion tests through the public `reschedule(for:)` entrypoint to prove the debounce path honors DI seams.
 - For lifecycle cleanup hooks like `clearExpiredSnoozeIfNeeded`, route stale-state guards through injected `dateProvider.now` and add inversion tests (wall-clock stale vs injected future, and the reverse) to prove the seam is actually used.
 - For UI-test mode gating, resolve the mode once from injected `launchArguments` (`uiTestMode ?? isUITestMode(launchArguments:)`) and thread it into *all* service resolvers (tracker + pause manager) so tests can deterministically control launch behavior without hidden `CommandLine` globals.
+- For app-launch delegate wiring, inject a `makeNotificationCenter` fallback factory and resolve it only when explicit `notificationCenter` injection is absent; this keeps production singleton behavior while enabling deterministic fallback-path tests.
 
 ## 2026-05-03T10:08:22Z: #462 Phase A DI/SRP — DateProviding Seam Micro-Slice (COMPLETED)
 

--- a/.squad/skills/launch-context-di-seam/SKILL.md
+++ b/.squad/skills/launch-context-di-seam/SKILL.md
@@ -17,15 +17,18 @@ Use this when service or coordinator logic branches on process launch context
 - For `@MainActor` coordinators, use optional init params for actor-isolated defaults and resolve to static values inside `init` (avoids Swift 6 nonisolated default-argument errors).
 - When launch-arg branches need service mutation (e.g., reset defaults / short overlay durations), inject a tiny factory closure (`makeSettingsStore`) instead of constructing concrete services inline.
 - If multiple resolver branches depend on UI-test mode, compute `let resolvedUITestMode = uiTestMode ?? isUITestMode(launchArguments:)` once in `init` and pass that value into each resolver to prevent mixed global/injected behavior.
+- For singleton-backed callbacks (e.g., app launch wiring), inject a zero-arg factory (`makeNotificationCenter`) and use it only on the fallback path so tests can validate callback behavior without invoking fragile system singletons directly.
 
 ## Examples
 - `AppCoordinator.init(..., processEnvironment: [String: String] = ProcessInfo.processInfo.environment, launchArguments: [String] = CommandLine.arguments, ...)`
 - `resolveScreenTimeAuthorization(..., processEnvironment:, launchArguments:)` in `EyePostureReminder/Services/AppCoordinator.swift`.
 - Focused coverage in `Tests/EyePostureReminderTests/Services/AppCoordinatorUITestLaunchContextTests.swift`.
 - `AppDelegate.init(..., makeSettingsStore: @escaping @MainActor () -> SettingsStore = { SettingsStore() })` with usage in `applyUITestLaunchArguments()` and seam coverage in `Tests/EyePostureReminderTests/Services/AppDelegateTests.swift`.
+- `AppDelegate.init(..., makeNotificationCenter: @escaping () -> UserNotificationCenterDelegating = { UNUserNotificationCenter.current() })` with fallback-path coverage in `test_didFinishLaunching_withNilNotificationCenter_usesInjectedFactory`.
 
 ## Anti-Patterns
 - Reading launch context globals directly inside static resolvers.
 - Overriding global process state in tests instead of injecting explicit values.
 - Constructing concrete stores/services directly inside launch handlers (`SettingsStore()`) when a factory seam can preserve behavior and improve testability.
 - Mixing an injected UI-test mode for one resolver with a static global (`AppCoordinator.isUITestMode`) in another resolver.
+- Resolving singleton callbacks inline (`UNUserNotificationCenter.current()`) when a tiny fallback factory seam would make the same code deterministic in unit tests.

--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -14,6 +14,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     private let metricKitSubscriber: MetricKitSubscribing?
     private let launchArguments: [String]
     private let uiTestDefaults: UserDefaults
+    private let makeNotificationCenter: () -> UserNotificationCenterDelegating
     private let makeSettingsStore: @MainActor () -> SettingsStore
 
     init(
@@ -21,12 +22,14 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         metricKitSubscriber: MetricKitSubscribing? = nil,
         launchArguments: [String] = CommandLine.arguments,
         uiTestDefaults: UserDefaults = .standard,
+        makeNotificationCenter: @escaping () -> UserNotificationCenterDelegating = { UNUserNotificationCenter.current() },
         makeSettingsStore: @escaping @MainActor () -> SettingsStore = { SettingsStore() }
     ) {
         self.notificationCenter = notificationCenter
         self.metricKitSubscriber = metricKitSubscriber
         self.launchArguments = launchArguments
         self.uiTestDefaults = uiTestDefaults
+        self.makeNotificationCenter = makeNotificationCenter
         self.makeSettingsStore = makeSettingsStore
         super.init()
 #if DEBUG
@@ -67,7 +70,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-        let notificationCenter = notificationCenter ?? UNUserNotificationCenter.current()
+        let notificationCenter = notificationCenter ?? makeNotificationCenter()
         notificationCenter.delegate = self
         installUncaughtExceptionHandler()
         (metricKitSubscriber ?? MetricKitSubscriber.shared).register()

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -167,6 +167,27 @@ final class AppDelegateTests: XCTestCase {
         )
     }
 
+    func test_didFinishLaunching_withNilNotificationCenter_usesInjectedFactory() {
+        let factoryCenter = MockUserNotificationCenter()
+        let mockMetricKitSubscriber = MockMetricKitSubscriber()
+        var makeNotificationCenterCallCount = 0
+        let sut = AppDelegate(
+            notificationCenter: nil,
+            metricKitSubscriber: mockMetricKitSubscriber,
+            makeNotificationCenter: {
+                makeNotificationCenterCallCount += 1
+                return factoryCenter
+            }
+        )
+
+        let didFinish = sut.application(UIApplication.shared, didFinishLaunchingWithOptions: nil)
+
+        XCTAssertTrue(didFinish)
+        XCTAssertEqual(makeNotificationCenterCallCount, 1)
+        XCTAssertTrue(factoryCenter.delegate === sut)
+        XCTAssertEqual(mockMetricKitSubscriber.registerCallCount, 1)
+    }
+
 #if DEBUG
     func test_init_preSeedsScreenTimeStatus_usingInjectedLaunchArgumentsAndDefaults() throws {
         let defaults = try makeIsolatedDefaults(suffix: #function)


### PR DESCRIPTION
Summary:\n- add a tiny DI seam in AppDelegate by injecting makeNotificationCenter and using it only for fallback resolution\n- keep existing behavior by defaulting the factory to UNUserNotificationCenter.current()\n- add focused test coverage for nil notification-center fallback path\n- update Basher history and launch-context DI skill notes\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462