### PR TITLE
refactor: date seam for pause resume snooze guard (#462)

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -54,6 +54,7 @@
 - For lifecycle cleanup hooks like `clearExpiredSnoozeIfNeeded`, route stale-state guards through injected `dateProvider.now` and add inversion tests (wall-clock stale vs injected future, and the reverse) to prove the seam is actually used.
 - For UI-test mode gating, resolve the mode once from injected `launchArguments` (`uiTestMode ?? isUITestMode(launchArguments:)`) and thread it into *all* service resolvers (tracker + pause manager) so tests can deterministically control launch behavior without hidden `CommandLine` globals.
 - For app-launch delegate wiring, inject a `makeNotificationCenter` fallback factory and resolve it only when explicit `notificationCenter` injection is absent; this keeps production singleton behavior while enabling deterministic fallback-path tests.
+- For pause-condition resume callbacks, evaluate snooze guards with injected `dateProvider.now` and assert inversion cases by firing `MockPauseConditionProvider.simulatePauseStateChange(false)` while wall-clock and injected clocks disagree.
 
 ## 2026-05-03T10:08:22Z: #462 Phase A DI/SRP — DateProviding Seam Micro-Slice (COMPLETED)
 

--- a/.squad/skills/date-provider-default-seam/SKILL.md
+++ b/.squad/skills/date-provider-default-seam/SKILL.md
@@ -18,6 +18,7 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - For enum or helper structs that currently compute dates from `Date()`, add a `referenceDate` overload and keep the old computed property as a convenience wrapper.
 - For lifecycle cleanup hooks (for example `clearExpiredSnoozeIfNeeded`), evaluate stale-state guards with `dateProvider.now` and add inversion tests where wall-clock and injected clock disagree.
 - For notification-delivery snooze guards (`handleNotification`), evaluate suppression with `dateProvider.now` so reminder delivery respects injected time seams in deterministic tests.
+- For pause-condition resume guards (`onPauseStateChanged` resume path), evaluate snooze checks with `dateProvider.now` and assert inversion tests by simulating pause-clear callbacks.
 
 ## Benefits
 - Production path no longer depends on implicit `Date()` globals.

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -273,7 +273,7 @@ final class AppCoordinator: ObservableObject {
                 self.pendingOverlay = nil
                 Logger.scheduling.info("PauseConditionManager: pausing reminders (active condition)")
             } else {
-                guard (self.settings.snoozedUntil ?? .distantPast) <= Date() else {
+                guard (self.settings.snoozedUntil ?? .distantPast) <= self.dateProvider.now else {
                     Logger.scheduling.debug(
                         "PauseConditionManager: pause cleared but snooze still active — not resuming")
                     return

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -472,6 +472,58 @@ final class AppCoordinatorTests: XCTestCase {
             "AppCoordinator.init must call startMonitoring() on the injected PauseConditionProviding")
     }
 
+    func test_pauseConditionResume_usesInjectedDateProvider_whenWallClockFutureButInjectedExpired() {
+        let mockDateProvider = MockDateProvider(now: Date(timeIntervalSinceNow: 3_600))
+        let mockNotif = MockNotificationCenter()
+        let mockPause = MockPauseConditionProvider()
+        let mockTracker = MockScreenTimeTracker()
+        settings.snoozedUntil = Date(timeIntervalSinceNow: 300)
+
+        let coordinator = AppCoordinator(
+            settings: settings,
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            screenTimeTracker: mockTracker,
+            pauseConditionProvider: mockPause,
+            ipcStore: MockAppGroupIPCRecorder(),
+            dateProvider: mockDateProvider
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        mockPause.simulatePauseStateChange(false)
+
+        XCTAssertEqual(
+            mockTracker.resumeAllCallCount,
+            1,
+            "Pause clear should resume when injected DateProviding marks snooze expired")
+    }
+
+    func test_pauseConditionResume_usesInjectedDateProvider_whenWallClockPastButInjectedFuture() {
+        let mockDateProvider = MockDateProvider(now: Date(timeIntervalSinceNow: -3_600))
+        let mockNotif = MockNotificationCenter()
+        let mockPause = MockPauseConditionProvider()
+        let mockTracker = MockScreenTimeTracker()
+        settings.snoozedUntil = Date(timeIntervalSinceNow: -60)
+
+        let coordinator = AppCoordinator(
+            settings: settings,
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            screenTimeTracker: mockTracker,
+            pauseConditionProvider: mockPause,
+            ipcStore: MockAppGroupIPCRecorder(),
+            dateProvider: mockDateProvider
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        mockPause.simulatePauseStateChange(false)
+
+        XCTAssertEqual(
+            mockTracker.resumeAllCallCount,
+            0,
+            "Pause clear should stay paused when injected DateProviding marks snooze active")
+    }
+
     // MARK: - Issue #438: AppCoordinator teardown must stop PauseCondition monitoring
 
     func test_stopFallbackTimers_callsStopMonitoringOnPauseConditionProvider() {


### PR DESCRIPTION
## Summary
- route pause-clear snooze guard in AppCoordinator through dateProvider.now instead of Date()
- add focused unit tests for injected-clock inversion scenarios on pause resume callback
- preserve runtime behavior; this is a tiny Phase A DI/SRP seam only

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462