### PR TITLE
refactor: date seam for scheduleReminders snooze guard (#462)

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -105,3 +105,11 @@
 - Architecture decision: keep behavior identical by changing only the guard expression in `AppCoordinator.handleNotification(for:)` and proving seam usage with wall-clock/injected-clock inversion tests.
 - User preference reinforced: keep micro-slices surgical (single DI seam + focused tests + full `./scripts/build.sh build` and `./scripts/build.sh test` validation).
 - Key file paths: `EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`, `.squad/skills/date-provider-default-seam/SKILL.md`.
+
+
+## 2026-05-03T11:52:28Z: #462 Phase A DI/SRP — scheduleReminders Snooze Guard Date Seam (COMPLETED)
+
+- Learned pattern: entrypoint snooze guards in `scheduleReminders()` should compare `snoozedUntil` against injected `dateProvider.now`, not `Date()`, to keep launch-time scheduling deterministic.
+- Architecture decision: preserve behavior by changing only the snooze guard expression and adding wall-clock/injected-clock inversion tests that assert both continue-scheduling and suppress-scheduling paths.
+- User preference reinforced: keep each #462 slice surgical (single DI seam + focused tests + full `./scripts/build.sh build` and `./scripts/build.sh test`).
+- Key file paths: `EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`, `.squad/skills/date-provider-default-seam/SKILL.md`.

--- a/.squad/skills/date-provider-default-seam/SKILL.md
+++ b/.squad/skills/date-provider-default-seam/SKILL.md
@@ -19,6 +19,7 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - For lifecycle cleanup hooks (for example `clearExpiredSnoozeIfNeeded`), evaluate stale-state guards with `dateProvider.now` and add inversion tests where wall-clock and injected clock disagree.
 - For notification-delivery snooze guards (`handleNotification`), evaluate suppression with `dateProvider.now` so reminder delivery respects injected time seams in deterministic tests.
 - For pause-condition resume guards (`onPauseStateChanged` resume path), evaluate snooze checks with `dateProvider.now` and assert inversion tests by simulating pause-clear callbacks.
+- For launch-time scheduler snooze guards (`scheduleReminders`), compare against `dateProvider.now` and add inversion tests for wall-clock future/injected expired and wall-clock past/injected active.
 
 ## Benefits
 - Production path no longer depends on implicit `Date()` globals.

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -362,7 +362,7 @@ final class AppCoordinator: ObservableObject {
 
         // P1-1: Snooze guard — check before doing anything else.
         if let snoozeEnd = settings.snoozedUntil {
-            if snoozeEnd > Date() {
+            if snoozeEnd > dateProvider.now {
                 // Snooze still active — pause screen-time tracking and arm wake.
                 screenTimeTracker.pauseAll()
                 scheduler.cancelAllReminders()

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -731,6 +731,72 @@ final class AppCoordinatorTests: XCTestCase {
             "Snooze-wake notification must have no sound (silent)")
     }
 
+    func test_scheduleReminders_usesInjectedDateProvider_whenWallClockFutureButInjectedExpired() async {
+        let mockDateProvider = MockDateProvider(now: Date(timeIntervalSinceNow: 3_600))
+        let mockNotif = MockNotificationCenter()
+        mockNotif.authorizationGranted = true
+        let coordinator = AppCoordinator(
+            settings: settings,
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            overlayManager: MockOverlayPresenting(),
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: MockAppGroupIPCRecorder(),
+            dateProvider: mockDateProvider
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        settings.globalEnabled = true
+        settings.eyesEnabled = true
+        settings.postureEnabled = false
+        settings.snoozedUntil = Date(timeIntervalSinceNow: 300)
+        settings.snoozeCount = 2
+
+        await coordinator.scheduleReminders()
+
+        XCTAssertNil(settings.snoozedUntil)
+        XCTAssertEqual(settings.snoozeCount, 0)
+        XCTAssertEqual(
+            reminderRequests(from: mockNotif).count,
+            1,
+            "scheduleReminders should clear stale snooze and continue scheduling when injected DateProviding marks it expired")
+    }
+
+    func test_scheduleReminders_usesInjectedDateProvider_whenWallClockPastButInjectedFuture() async {
+        let mockDateProvider = MockDateProvider(now: Date(timeIntervalSinceNow: -3_600))
+        let mockNotif = MockNotificationCenter()
+        mockNotif.authorizationGranted = true
+        let tracker = MockScreenTimeTracker()
+        let coordinator = AppCoordinator(
+            settings: settings,
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            overlayManager: MockOverlayPresenting(),
+            screenTimeTracker: tracker,
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: MockAppGroupIPCRecorder(),
+            dateProvider: mockDateProvider
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        let wallClockPast = Date(timeIntervalSinceNow: -60)
+        settings.globalEnabled = true
+        settings.eyesEnabled = true
+        settings.postureEnabled = false
+        settings.snoozedUntil = wallClockPast
+        settings.snoozeCount = 2
+
+        await coordinator.scheduleReminders()
+
+        XCTAssertEqual(settings.snoozedUntil, wallClockPast)
+        XCTAssertEqual(settings.snoozeCount, 2)
+        XCTAssertEqual(tracker.pauseAllCallCount, 1)
+        XCTAssertTrue(
+            reminderRequests(from: mockNotif).isEmpty,
+            "scheduleReminders should suppress periodic requests when injected DateProviding marks snooze active")
+    }
+
     // MARK: - Background Scheduling Regression (P0)
     //
     // P0: background reminders were disabled — the app only reminded users while foregrounded


### PR DESCRIPTION
## Summary\n- route AppCoordinator.scheduleReminders snooze-active guard through injected dateProvider.now\n- add focused inversion tests proving schedule path uses injected clock while preserving behavior\n- update Basher history + DateProviding skill notes for this micro-slice\n\n## Validation\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462