### PR TITLE
refactor: use injected clock in foreground snooze guard

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -55,6 +55,7 @@
 - For UI-test mode gating, resolve the mode once from injected `launchArguments` (`uiTestMode ?? isUITestMode(launchArguments:)`) and thread it into *all* service resolvers (tracker + pause manager) so tests can deterministically control launch behavior without hidden `CommandLine` globals.
 - For app-launch delegate wiring, inject a `makeNotificationCenter` fallback factory and resolve it only when explicit `notificationCenter` injection is absent; this keeps production singleton behavior while enabling deterministic fallback-path tests.
 - For pause-condition resume callbacks, evaluate snooze guards with injected `dateProvider.now` and assert inversion cases by firing `MockPauseConditionProvider.simulatePauseStateChange(false)` while wall-clock and injected clocks disagree.
+- For foreground lifecycle snooze handling (`handleForegroundTransition`), compare expiry against `dateProvider.now` (not `Date()`) and cover both wall-clock/injected-clock inversion cases to keep resume behavior deterministic.
 
 ## 2026-05-03T10:08:22Z: #462 Phase A DI/SRP — DateProviding Seam Micro-Slice (COMPLETED)
 

--- a/.squad/skills/date-provider-default-seam/SKILL.md
+++ b/.squad/skills/date-provider-default-seam/SKILL.md
@@ -20,6 +20,7 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - For notification-delivery snooze guards (`handleNotification`), evaluate suppression with `dateProvider.now` so reminder delivery respects injected time seams in deterministic tests.
 - For pause-condition resume guards (`onPauseStateChanged` resume path), evaluate snooze checks with `dateProvider.now` and assert inversion tests by simulating pause-clear callbacks.
 - For launch-time scheduler snooze guards (`scheduleReminders`), compare against `dateProvider.now` and add inversion tests for wall-clock future/injected expired and wall-clock past/injected active.
+- For foreground-transition snooze guards (`handleForegroundTransition`), compare expiry against `dateProvider.now` and assert inversion tests where wall-clock and injected clocks disagree.
 
 ## Benefits
 - Production path no longer depends on implicit `Date()` globals.
@@ -35,3 +36,4 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - `Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift`
 - `EyePostureReminder/Services/AppCoordinator.swift`
 - `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`
+- `Tests/EyePostureReminderTests/Services/AppCoordinatorExtendedTests.swift`

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -545,7 +545,7 @@ final class AppCoordinator: ObservableObject {
 
         // P1-1: Handle snooze state on foreground.
         if let snoozeEnd = settings.snoozedUntil {
-            if snoozeEnd <= Date() {
+            if snoozeEnd <= dateProvider.now {
                 // Snooze expired while backgrounded — clear and reschedule.
                 settings.snoozedUntil = nil
                 settings.snoozeCount  = 0

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorExtendedTests.swift
@@ -587,6 +587,38 @@ final class AppCoordinatorExtendedTests: XCTestCase {
         await coordinator.handleForegroundTransition()
     }
 
+    func test_handleForegroundTransition_usesInjectedDateProvider_whenWallClockPastButInjectedFuture() async {
+        let wallClockPast = Date(timeIntervalSinceNow: -60)
+        let mockDateProvider = MockDateProvider(now: Date(timeIntervalSinceNow: -3_600))
+        settings.snoozedUntil = wallClockPast
+        settings.snoozeCount = 1
+        let (coordinator, _, _, _) = makeCoordinator(dateProvider: mockDateProvider)
+        defer { coordinator.stopFallbackTimers() }
+
+        await coordinator.handleForegroundTransition()
+
+        XCTAssertEqual(
+            settings.snoozedUntil,
+            wallClockPast,
+            "handleForegroundTransition should keep snooze active when injected DateProviding reports future")
+        XCTAssertEqual(settings.snoozeCount, 1)
+    }
+
+    func test_handleForegroundTransition_usesInjectedDateProvider_whenWallClockFutureButInjectedExpired() async {
+        let mockDateProvider = MockDateProvider(now: Date(timeIntervalSinceNow: 3_600))
+        settings.snoozedUntil = Date(timeIntervalSinceNow: 60)
+        settings.snoozeCount = 1
+        let (coordinator, _, _, _) = makeCoordinator(dateProvider: mockDateProvider)
+        defer { coordinator.stopFallbackTimers() }
+
+        await coordinator.handleForegroundTransition()
+
+        XCTAssertNil(
+            settings.snoozedUntil,
+            "handleForegroundTransition should clear snooze when injected DateProviding marks it expired")
+        XCTAssertEqual(settings.snoozeCount, 0)
+    }
+
     // MARK: - startFallbackTimers
 
     func test_startFallbackTimers_doesNotCrash() {


### PR DESCRIPTION
## Summary
- switch handleForegroundTransition() snooze expiry guard from Date() to injected dateProvider.now
- add focused inversion tests proving wall-clock/injected-clock disagreements use the DI seam
- update Basher learnings + DateProviding skill notes

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462