### PR TITLE
refactor: inject clock in app session-end duration

### DIFF
--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -598,7 +598,7 @@ final class AppCoordinator: ObservableObject {
     func appWillResignActive() {
         // ScreenTimeTracker observes willResignActiveNotification directly and
         // resets all elapsed counters — no explicit action needed here.
-        let sessionDuration = sessionStartTime.map { Date().timeIntervalSince($0) } ?? 0
+        let sessionDuration = sessionStartTime.map { dateProvider.now.timeIntervalSince($0) } ?? 0
         AnalyticsLogger.log(.appSessionEnd(sessionDurationS: sessionDuration))
         sessionStartTime = nil
         recordWatchdogHeartbeat(.appBackground)

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -167,6 +167,48 @@ final class AppCoordinatorTests: XCTestCase {
         sut.appWillResignActive()
     }
 
+    func test_appWillResignActive_usesInjectedDateProvider_forSessionDuration() async {
+        let mockDateProvider = MockDateProvider(now: Date())
+        let mockNotif = MockNotificationCenter()
+        mockNotif.authorizationGranted = true
+        let coordinator = AppCoordinator(
+            settings: settings,
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            overlayManager: MockOverlayPresenting(),
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: MockAppGroupIPCRecorder(),
+            dateProvider: mockDateProvider
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        settings.globalEnabled = true
+        settings.eyesEnabled = true
+        settings.postureEnabled = false
+
+        var captured: [AnalyticsEvent] = []
+        AnalyticsLogger.testEventHandler = { captured.append($0) }
+        defer { AnalyticsLogger.testEventHandler = nil }
+
+        await coordinator.scheduleReminders()
+        mockDateProvider.now = Date(timeIntervalSinceNow: -3_600)
+
+        coordinator.appWillResignActive()
+
+        let sessionDurations = captured.compactMap { event -> TimeInterval? in
+            if case let .appSessionEnd(sessionDurationS) = event {
+                return sessionDurationS
+            }
+            return nil
+        }
+        XCTAssertEqual(sessionDurations.count, 1)
+        XCTAssertLessThan(
+            sessionDurations[0],
+            -3_000,
+            "appWillResignActive should source session duration from injected DateProviding")
+    }
+
     // MARK: - ReminderScheduling conformance (crash-safety)
 
     func test_cancelAllReminders_doesNotCrash() {


### PR DESCRIPTION
Summary:\n- route AppCoordinator.appWillResignActive() session-duration math through injected DateProviding\n- preserve runtime behavior while removing one remaining wall-clock read in lifecycle telemetry\n- add a focused unit test proving appSessionEnd uses the injected clock\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462