### PR TITLE
refactor: inject clock for schedule session start

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -56,6 +56,7 @@
 - For app-launch delegate wiring, inject a `makeNotificationCenter` fallback factory and resolve it only when explicit `notificationCenter` injection is absent; this keeps production singleton behavior while enabling deterministic fallback-path tests.
 - For pause-condition resume callbacks, evaluate snooze guards with injected `dateProvider.now` and assert inversion cases by firing `MockPauseConditionProvider.simulatePauseStateChange(false)` while wall-clock and injected clocks disagree.
 - For foreground lifecycle snooze handling (`handleForegroundTransition`), compare expiry against `dateProvider.now` (not `Date()`) and cover both wall-clock/injected-clock inversion cases to keep resume behavior deterministic.
+- For cold-launch session telemetry, set `sessionStartTime` from injected `dateProvider.now` in `scheduleReminders()` so downstream `appSessionEnd` duration remains deterministic even when tests pin the clock to non-wall time.
 
 ## 2026-05-03T10:08:22Z: #462 Phase A DI/SRP — DateProviding Seam Micro-Slice (COMPLETED)
 

--- a/.squad/skills/date-provider-default-seam/SKILL.md
+++ b/.squad/skills/date-provider-default-seam/SKILL.md
@@ -21,6 +21,7 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - For pause-condition resume guards (`onPauseStateChanged` resume path), evaluate snooze checks with `dateProvider.now` and assert inversion tests by simulating pause-clear callbacks.
 - For launch-time scheduler snooze guards (`scheduleReminders`), compare against `dateProvider.now` and add inversion tests for wall-clock future/injected expired and wall-clock past/injected active.
 - For foreground-transition snooze guards (`handleForegroundTransition`), compare expiry against `dateProvider.now` and assert inversion tests where wall-clock and injected clocks disagree.
+- For lifecycle session metrics initialized during scheduling, seed `sessionStartTime` from `dateProvider.now` (not `Date()`) so `appSessionEnd` duration assertions stay deterministic under injected clocks.
 
 ## Benefits
 - Production path no longer depends on implicit `Date()` globals.

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -423,7 +423,7 @@ final class AppCoordinator: ObservableObject {
         // re-entry from snooze-cancel or snooze-wake paths that call scheduleReminders()
         // while a session is already in progress.
         if sessionStartTime == nil {
-            sessionStartTime = Date()
+            sessionStartTime = dateProvider.now
             let latency = foregroundEntryTime.map { Date().timeIntervalSince($0) } ?? 0
             AnalyticsLogger.log(.appLaunchReadiness(.init(
                 launchType: pendingLaunchType,

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -209,6 +209,50 @@ final class AppCoordinatorTests: XCTestCase {
             "appWillResignActive should source session duration from injected DateProviding")
     }
 
+    func test_scheduleReminders_usesInjectedDateProvider_forSessionStartTimestamp() async {
+        let sessionStart = Date(timeIntervalSince1970: 946_684_800)
+        let mockDateProvider = MockDateProvider(now: sessionStart)
+        let mockNotif = MockNotificationCenter()
+        mockNotif.authorizationGranted = true
+        let coordinator = AppCoordinator(
+            settings: settings,
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            overlayManager: MockOverlayPresenting(),
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: MockAppGroupIPCRecorder(),
+            dateProvider: mockDateProvider
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        settings.globalEnabled = true
+        settings.eyesEnabled = true
+        settings.postureEnabled = false
+
+        var captured: [AnalyticsEvent] = []
+        AnalyticsLogger.testEventHandler = { captured.append($0) }
+        defer { AnalyticsLogger.testEventHandler = nil }
+
+        await coordinator.scheduleReminders()
+        mockDateProvider.now = sessionStart.addingTimeInterval(10)
+
+        coordinator.appWillResignActive()
+
+        let sessionDurations = captured.compactMap { event -> TimeInterval? in
+            if case let .appSessionEnd(sessionDurationS) = event {
+                return sessionDurationS
+            }
+            return nil
+        }
+        XCTAssertEqual(sessionDurations.count, 1)
+        XCTAssertEqual(
+            sessionDurations[0],
+            10,
+            accuracy: 0.001,
+            "scheduleReminders should source session start from injected DateProviding")
+    }
+
     // MARK: - ReminderScheduling conformance (crash-safety)
 
     func test_cancelAllReminders_doesNotCrash() {


### PR DESCRIPTION
## Summary
- route AppCoordinator.scheduleReminders() cold-launch sessionStartTime assignment through injected dateProvider.now
- preserve runtime behavior while removing one hidden wall-clock read
- add focused unit coverage proving session duration uses injected start timestamp

## Testing
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462