### PR TITLE
#462 Phase A: inject foreground sessionStart clock seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -115,3 +115,10 @@
 - Architecture decision: preserve behavior by changing only the snooze guard expression and adding wall-clock/injected-clock inversion tests that assert both continue-scheduling and suppress-scheduling paths.
 - User preference reinforced: keep each #462 slice surgical (single DI seam + focused tests + full `./scripts/build.sh build` and `./scripts/build.sh test`).
 - Key file paths: `EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`, `.squad/skills/date-provider-default-seam/SKILL.md`.
+
+## 2026-05-03T12:32:00Z: #462 Phase A DI/SRP — Foreground SessionStart Clock Seam (COMPLETED)
+
+- Learned pattern: warm-foreground session telemetry must seed `sessionStartTime` from injected `dateProvider.now` (not `Date()`) to keep `appSessionEnd` durations deterministic.
+- Architecture decision: preserve behavior by changing only `handleForegroundTransition` session-start initialization and proving seam usage with a focused `appSessionEnd` duration assertion.
+- Validation: `./scripts/build.sh build` and `./scripts/build.sh test` passed after the change.
+- Key file paths: `EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`.

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -569,7 +569,7 @@ final class AppCoordinator: ObservableObject {
         // #65: Record session start so appSessionEnd can compute duration correctly
         // on subsequent foreground returns (scheduleReminders is not re-called here).
         if sessionStartTime == nil {
-            sessionStartTime = Date()
+            sessionStartTime = dateProvider.now
             let latency = foregroundEntryTime.map { Date().timeIntervalSince($0) } ?? 0
             AnalyticsLogger.log(.appLaunchReadiness(.init(
                 launchType: pendingLaunchType,

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -253,6 +253,46 @@ final class AppCoordinatorTests: XCTestCase {
             "scheduleReminders should source session start from injected DateProviding")
     }
 
+    func test_handleForegroundTransition_usesInjectedDateProvider_forSessionStartTimestamp() async {
+        let sessionStart = Date(timeIntervalSince1970: 946_684_800)
+        let mockDateProvider = MockDateProvider(now: sessionStart)
+        let mockNotif = MockNotificationCenter()
+        mockNotif.authorizationGranted = true
+        let coordinator = AppCoordinator(
+            settings: settings,
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            overlayManager: MockOverlayPresenting(),
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: MockAppGroupIPCRecorder(),
+            dateProvider: mockDateProvider
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        var captured: [AnalyticsEvent] = []
+        AnalyticsLogger.testEventHandler = { captured.append($0) }
+        defer { AnalyticsLogger.testEventHandler = nil }
+
+        await coordinator.handleForegroundTransition()
+        mockDateProvider.now = sessionStart.addingTimeInterval(10)
+
+        coordinator.appWillResignActive()
+
+        let sessionDurations = captured.compactMap { event -> TimeInterval? in
+            if case let .appSessionEnd(sessionDurationS) = event {
+                return sessionDurationS
+            }
+            return nil
+        }
+        XCTAssertEqual(sessionDurations.count, 1)
+        XCTAssertEqual(
+            sessionDurations[0],
+            10,
+            accuracy: 0.001,
+            "handleForegroundTransition should source session start from injected DateProviding")
+    }
+
     // MARK: - ReminderScheduling conformance (crash-safety)
 
     func test_cancelAllReminders_doesNotCrash() {


### PR DESCRIPTION
## Summary
- route AppCoordinator.handleForegroundTransition() session start seeding through injected dateProvider.now
- preserve behavior while removing remaining warm-foreground wall-clock dependency
- add focused unit test proving appSessionEnd duration is deterministic from foreground path

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462
