### PR TITLE
#462 Phase A: inject AppDelegate MetricKit fallback factory

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -57,6 +57,7 @@
 - For pause-condition resume callbacks, evaluate snooze guards with injected `dateProvider.now` and assert inversion cases by firing `MockPauseConditionProvider.simulatePauseStateChange(false)` while wall-clock and injected clocks disagree.
 - For foreground lifecycle snooze handling (`handleForegroundTransition`), compare expiry against `dateProvider.now` (not `Date()`) and cover both wall-clock/injected-clock inversion cases to keep resume behavior deterministic.
 - For cold-launch session telemetry, set `sessionStartTime` from injected `dateProvider.now` in `scheduleReminders()` so downstream `appSessionEnd` duration remains deterministic even when tests pin the clock to non-wall time.
+- For AppDelegate lifecycle registration seams, inject a `makeMetricKitSubscriber` fallback factory and resolve it only when explicit `metricKitSubscriber` injection is absent; this removes direct `MetricKitSubscriber.shared` coupling and enables deterministic fallback-path tests.
 
 ## 2026-05-03T10:08:22Z: #462 Phase A DI/SRP — DateProviding Seam Micro-Slice (COMPLETED)
 

--- a/.squad/skills/metrickit-manager-di/SKILL.md
+++ b/.squad/skills/metrickit-manager-di/SKILL.md
@@ -15,6 +15,7 @@ Use this when a service calls `MXMetricManager.shared` directly, but the behavio
 - Inject the protocol into the service initializer with `MXMetricManager.shared` as the default.
 - Keep singleton entrypoints (like `static let shared`) for production wiring.
 - If app lifecycle code triggers registration, inject a `MetricKitSubscribing` seam at the delegate boundary and lazily fallback to `MetricKitSubscriber.shared` at callback time.
+- If delegate code needs a production fallback, inject `makeMetricKitSubscriber` and resolve it only when explicit subscriber injection is absent so fallback paths are unit-testable.
 
 ## Examples
 - `EyePostureReminder/Services/MetricKitSubscriber.swift`

--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -15,6 +15,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     private let launchArguments: [String]
     private let uiTestDefaults: UserDefaults
     private let makeNotificationCenter: () -> UserNotificationCenterDelegating
+    private let makeMetricKitSubscriber: () -> MetricKitSubscribing
     private let makeSettingsStore: @MainActor () -> SettingsStore
 
     init(
@@ -23,6 +24,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         launchArguments: [String] = CommandLine.arguments,
         uiTestDefaults: UserDefaults = .standard,
         makeNotificationCenter: @escaping () -> UserNotificationCenterDelegating = { UNUserNotificationCenter.current() },
+        makeMetricKitSubscriber: @escaping () -> MetricKitSubscribing = { MetricKitSubscriber.shared },
         makeSettingsStore: @escaping @MainActor () -> SettingsStore = { SettingsStore() }
     ) {
         self.notificationCenter = notificationCenter
@@ -30,6 +32,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         self.launchArguments = launchArguments
         self.uiTestDefaults = uiTestDefaults
         self.makeNotificationCenter = makeNotificationCenter
+        self.makeMetricKitSubscriber = makeMetricKitSubscriber
         self.makeSettingsStore = makeSettingsStore
         super.init()
 #if DEBUG
@@ -73,7 +76,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         let notificationCenter = notificationCenter ?? makeNotificationCenter()
         notificationCenter.delegate = self
         installUncaughtExceptionHandler()
-        (metricKitSubscriber ?? MetricKitSubscriber.shared).register()
+        (metricKitSubscriber ?? makeMetricKitSubscriber()).register()
 #if DEBUG
         applyUITestLaunchArguments()
 #endif

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -188,6 +188,26 @@ final class AppDelegateTests: XCTestCase {
         XCTAssertEqual(mockMetricKitSubscriber.registerCallCount, 1)
     }
 
+    func test_didFinishLaunching_withNilMetricKitSubscriber_usesInjectedFactory() {
+        let mockCenter = MockUserNotificationCenter()
+        let factoryMetricKitSubscriber = MockMetricKitSubscriber()
+        var makeMetricKitSubscriberCallCount = 0
+        let sut = AppDelegate(
+            notificationCenter: mockCenter,
+            metricKitSubscriber: nil,
+            makeMetricKitSubscriber: {
+                makeMetricKitSubscriberCallCount += 1
+                return factoryMetricKitSubscriber
+            }
+        )
+
+        let didFinish = sut.application(UIApplication.shared, didFinishLaunchingWithOptions: nil)
+
+        XCTAssertTrue(didFinish)
+        XCTAssertEqual(makeMetricKitSubscriberCallCount, 1)
+        XCTAssertEqual(factoryMetricKitSubscriber.registerCallCount, 1)
+    }
+
 #if DEBUG
     func test_init_preSeedsScreenTimeStatus_usingInjectedLaunchArgumentsAndDefaults() throws {
         let defaults = try makeIsolatedDefaults(suffix: #function)


### PR DESCRIPTION
Summary:\n- inject makeMetricKitSubscriber into AppDelegate with production default MetricKitSubscriber.shared\n- use injected factory only when metricKitSubscriber injection is nil\n- add focused unit test for the fallback factory registration path\n\nTesting:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462