### PR TITLE
#462 Phase A: route AppCoordinator foreground timing through DateProviding

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -123,3 +123,10 @@
 - Architecture decision: preserve behavior by changing only `handleForegroundTransition` session-start initialization and proving seam usage with a focused `appSessionEnd` duration assertion.
 - Validation: `./scripts/build.sh build` and `./scripts/build.sh test` passed after the change.
 - Key file paths: `EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`.
+
+## 2026-05-03T12:50:00Z: #462 Phase A DI/SRP — Foreground Launch Readiness Clock Seam (COMPLETED)
+
+- Learned pattern: for launch-readiness analytics, both foreground-entry capture and latency delta should use injected `dateProvider.now` so timing remains deterministic in tests.
+- Architecture decision: preserve behavior by replacing only `Date()` reads in `AppCoordinator` foreground/session analytics paths and asserting a single focused latency seam test.
+- Validation: `./scripts/build.sh build` and `./scripts/build.sh test` passed after the change.
+- Key file paths: `EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`, `.squad/skills/date-provider-default-seam/SKILL.md`.

--- a/.squad/skills/date-provider-default-seam/SKILL.md
+++ b/.squad/skills/date-provider-default-seam/SKILL.md
@@ -22,6 +22,7 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - For launch-time scheduler snooze guards (`scheduleReminders`), compare against `dateProvider.now` and add inversion tests for wall-clock future/injected expired and wall-clock past/injected active.
 - For foreground-transition snooze guards (`handleForegroundTransition`), compare expiry against `dateProvider.now` and assert inversion tests where wall-clock and injected clocks disagree.
 - For lifecycle session metrics initialized during scheduling, seed `sessionStartTime` from `dateProvider.now` (not `Date()`) so `appSessionEnd` duration assertions stay deterministic under injected clocks.
+- For launch-readiness latency metrics, capture foreground-entry timestamps and latency deltas from the same injected `dateProvider.now` seam; in tests, advance `MockDateProvider.now` during an awaited dependency callback to prove wall-clock time is not used.
 
 ## Benefits
 - Production path no longer depends on implicit `Date()` globals.

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -357,7 +357,7 @@ final class AppCoordinator: ObservableObject {
         // Cold-launch proxy: handleForegroundTransition() sets this for warm paths.
         // For true cold launch (EyePostureReminderApp .task), capture the time here.
         if foregroundEntryTime == nil {
-            foregroundEntryTime = Date()
+            foregroundEntryTime = dateProvider.now
         }
 
         // P1-1: Snooze guard — check before doing anything else.
@@ -424,7 +424,8 @@ final class AppCoordinator: ObservableObject {
         // while a session is already in progress.
         if sessionStartTime == nil {
             sessionStartTime = dateProvider.now
-            let latency = foregroundEntryTime.map { Date().timeIntervalSince($0) } ?? 0
+            let now = dateProvider.now
+            let latency = foregroundEntryTime.map { now.timeIntervalSince($0) } ?? 0
             AnalyticsLogger.log(.appLaunchReadiness(.init(
                 launchType: pendingLaunchType,
                 notificationAuth: notificationAuthCode(from: notificationAuthStatus),
@@ -435,7 +436,7 @@ final class AppCoordinator: ObservableObject {
             AnalyticsLogger.log(.appSessionStart(
                 eyeEnabled: settings.isEnabled(for: .eyes),
                 postureEnabled: settings.isEnabled(for: .posture),
-                snoozeActive: settings.snoozedUntil.map { $0 > Date() } ?? false
+                snoozeActive: settings.snoozedUntil.map { $0 > now } ?? false
             ))
             foregroundEntryTime = nil
             pendingLaunchType = .cold
@@ -536,7 +537,7 @@ final class AppCoordinator: ObservableObject {
     /// `UIApplication.didBecomeActiveNotification` — no explicit timer
     /// restart is required here.
     func handleForegroundTransition() async {
-        foregroundEntryTime = Date()
+        foregroundEntryTime = dateProvider.now
         pendingLaunchType = .warm
         await refreshAuthStatus()
         let recoveryNeeded = await recoverStaleDeviceActivityWatchdogIfNeeded()
@@ -570,7 +571,8 @@ final class AppCoordinator: ObservableObject {
         // on subsequent foreground returns (scheduleReminders is not re-called here).
         if sessionStartTime == nil {
             sessionStartTime = dateProvider.now
-            let latency = foregroundEntryTime.map { Date().timeIntervalSince($0) } ?? 0
+            let now = dateProvider.now
+            let latency = foregroundEntryTime.map { now.timeIntervalSince($0) } ?? 0
             AnalyticsLogger.log(.appLaunchReadiness(.init(
                 launchType: pendingLaunchType,
                 notificationAuth: notificationAuthCode(from: notificationAuthStatus),
@@ -581,7 +583,7 @@ final class AppCoordinator: ObservableObject {
             AnalyticsLogger.log(.appSessionStart(
                 eyeEnabled: settings.isEnabled(for: .eyes),
                 postureEnabled: settings.isEnabled(for: .posture),
-                snoozeActive: settings.snoozedUntil.map { $0 > Date() } ?? false
+                snoozeActive: settings.snoozedUntil.map { $0 > now } ?? false
             ))
             foregroundEntryTime = nil
             pendingLaunchType = .cold

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -293,6 +293,45 @@ final class AppCoordinatorTests: XCTestCase {
             "handleForegroundTransition should source session start from injected DateProviding")
     }
 
+    func test_handleForegroundTransition_usesInjectedDateProvider_forLaunchReadinessLatency() async {
+        let foregroundStart = Date(timeIntervalSince1970: 1_000)
+        let mockDateProvider = MockDateProvider(now: foregroundStart)
+        let notificationCenter = HookedAuthorizationNotificationCenter {
+            mockDateProvider.now = foregroundStart.addingTimeInterval(42)
+        }
+        let coordinator = AppCoordinator(
+            settings: settings,
+            scheduler: ReminderScheduler(notificationCenter: notificationCenter),
+            notificationCenter: notificationCenter,
+            overlayManager: MockOverlayPresenting(),
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: MockAppGroupIPCRecorder(),
+            dateProvider: mockDateProvider
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        var captured: [AnalyticsEvent] = []
+        AnalyticsLogger.testEventHandler = { captured.append($0) }
+        defer { AnalyticsLogger.testEventHandler = nil }
+
+        await coordinator.handleForegroundTransition()
+
+        let latencies = captured.compactMap { event -> TimeInterval? in
+            if case let .appLaunchReadiness(payload) = event {
+                return payload.latencyS
+            }
+            return nil
+        }
+
+        XCTAssertEqual(latencies.count, 1)
+        XCTAssertEqual(
+            latencies[0],
+            42,
+            accuracy: 0.001,
+            "handleForegroundTransition should derive readiness latency from injected DateProviding")
+    }
+
     // MARK: - ReminderScheduling conformance (crash-safety)
 
     func test_cancelAllReminders_doesNotCrash() {
@@ -1165,5 +1204,28 @@ final class AppCoordinatorTests: XCTestCase {
             eyesCount,
             countAfterSchedule,
             "Foreground threshold fire must reschedule the background notification to reset its interval from now")
+    }
+}
+
+private final class HookedAuthorizationNotificationCenter: NotificationScheduling {
+    private let onGetAuthorizationStatus: () -> Void
+
+    init(onGetAuthorizationStatus: @escaping () -> Void) {
+        self.onGetAuthorizationStatus = onGetAuthorizationStatus
+    }
+
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool { true }
+
+    func add(_ request: UNNotificationRequest) async throws {}
+
+    func removePendingNotificationRequests(withIdentifiers identifiers: [String]) {}
+
+    func removeAllPendingNotificationRequests() {}
+
+    func getPendingNotificationRequests() async -> [UNNotificationRequest] { [] }
+
+    func getAuthorizationStatus() async -> UNAuthorizationStatus {
+        onGetAuthorizationStatus()
+        return .authorized
     }
 }


### PR DESCRIPTION
Summary:
- replace remaining foreground lifecycle Date() reads in AppCoordinator with injected dateProvider.now
- use a single now snapshot for launch-readiness latency and appSessionStart snooze flag evaluation
- add a focused unit test proving foreground launch-readiness latency uses the injected clock seam

Validation:
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462