### PR TITLE
refactor: inject lifecycle notification center seam in AppCoordinator

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -130,3 +130,4 @@
 - Architecture decision: preserve behavior by replacing only `Date()` reads in `AppCoordinator` foreground/session analytics paths and asserting a single focused latency seam test.
 - Validation: `./scripts/build.sh build` and `./scripts/build.sh test` passed after the change.
 - Key file paths: `EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`, `.squad/skills/date-provider-default-seam/SKILL.md`.
+- For AppCoordinator notification-driven rerouting, inject a dedicated `NotificationCenter` dependency for observer registration/removal instead of using `NotificationCenter.default`; this preserves production behavior while isolating tests from global observer cross-talk.

--- a/.squad/skills/notification-center-observer-seam/SKILL.md
+++ b/.squad/skills/notification-center-observer-seam/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: "notification-center-observer-seam"
+description: "Inject NotificationCenter for observer lifecycle wiring while preserving production defaults"
+domain: "testing"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+Use when a service/coordinator registers observers via `NotificationCenter.default` and tests need deterministic isolation from global observer state.
+
+## Pattern
+- Add a `NotificationCenter` dependency with default `.default` in the initializer.
+- Store it on the type and use it for both `addObserver` and `removeObserver`.
+- In tests, inject a fresh `NotificationCenter()` and post notifications there.
+- Add one negative assertion proving `NotificationCenter.default` does not drive behavior when a custom center is injected.
+
+## Benefits
+- Preserves runtime behavior in production.
+- Removes hidden global coupling.
+- Prevents cross-test interference from shared notification observers.

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -83,6 +83,7 @@ final class AppCoordinator: ObservableObject {
     /// app extensions and watchdog diagnostics can observe the selected path.
     let ipcStore: AppGroupIPCProviding
     let dateProvider: DateProviding
+    private let lifecycleNotificationCenter: NotificationCenter
     private var trueInterruptEnabledObserver: NSObjectProtocol?
     let watchdogHeartbeatGraceInterval: TimeInterval
 
@@ -188,6 +189,7 @@ final class AppCoordinator: ObservableObject {
         uiTestMode: Bool? = nil,
         deviceActivityMonitor: DeviceActivityMonitorProviding? = nil,
         ipcStore: AppGroupIPCProviding = AppGroupIPCStore(),
+        lifecycleNotificationCenter: NotificationCenter = .default,
         watchdogHeartbeatGraceInterval: TimeInterval = 10,
         dateProvider: DateProviding = SystemDateProvider()
     ) {
@@ -208,6 +210,7 @@ final class AppCoordinator: ObservableObject {
         self.deviceActivityMonitor = Self.resolveDeviceActivityMonitor(deviceActivityMonitor)
         self.ipcStore = ipcStore
         self.dateProvider = dateProvider
+        self.lifecycleNotificationCenter = lifecycleNotificationCenter
         self.watchdogHeartbeatGraceInterval = watchdogHeartbeatGraceInterval
         let resolvedUITestMode = uiTestMode ?? Self.isUITestMode(launchArguments: launchArguments)
 
@@ -283,7 +286,7 @@ final class AppCoordinator: ObservableObject {
             }
         }
         self.pauseConditionManager.startMonitoring()
-        self.trueInterruptEnabledObserver = NotificationCenter.default.addObserver(
+        self.trueInterruptEnabledObserver = lifecycleNotificationCenter.addObserver(
             forName: AppGroupIPCStore.trueInterruptEnabledDidChangeNotification,
             object: nil,
             queue: nil
@@ -299,7 +302,7 @@ final class AppCoordinator: ObservableObject {
         snoozeWakeTask?.cancel()
         deviceActivityMonitorTask?.cancel()
         if let trueInterruptEnabledObserver {
-            NotificationCenter.default.removeObserver(trueInterruptEnabledObserver)
+            lifecycleNotificationCenter.removeObserver(trueInterruptEnabledObserver)
         }
     }
 

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorNotificationFallbackTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorNotificationFallbackTests.swift
@@ -11,6 +11,7 @@ final class AppCoordinatorNotificationFallbackTests: XCTestCase {
     private var tracker: MockScreenTimeTracker!
     private var deviceActivityMonitor: MockDeviceActivityMonitorProviding!
     private var ipcStore: MockAppGroupIPCRecorder!
+    private var trueInterruptNotificationCenter: NotificationCenter!
     private var coordinator: AppCoordinator!
 
     override func setUp() async throws {
@@ -22,6 +23,7 @@ final class AppCoordinatorNotificationFallbackTests: XCTestCase {
         tracker = MockScreenTimeTracker()
         deviceActivityMonitor = MockDeviceActivityMonitorProviding()
         ipcStore = MockAppGroupIPCRecorder()
+        trueInterruptNotificationCenter = NotificationCenter()
         coordinator = AppCoordinator(
             settings: settings,
             scheduler: ReminderScheduler(notificationCenter: notificationCenter),
@@ -30,13 +32,15 @@ final class AppCoordinatorNotificationFallbackTests: XCTestCase {
             screenTimeTracker: tracker,
             pauseConditionProvider: MockPauseConditionProvider(),
             deviceActivityMonitor: deviceActivityMonitor,
-            ipcStore: ipcStore
+            ipcStore: ipcStore,
+            lifecycleNotificationCenter: trueInterruptNotificationCenter
         )
     }
 
     override func tearDown() async throws {
         coordinator.stopFallbackTimers()
         coordinator = nil
+        trueInterruptNotificationCenter = nil
         ipcStore = nil
         deviceActivityMonitor = nil
         tracker = nil
@@ -156,7 +160,7 @@ final class AppCoordinatorNotificationFallbackTests: XCTestCase {
         notificationCenter.reset()
         let fallbackEventCountBeforePost = ipcStore.events.filter { $0.kind == .notificationFallbackScheduled }.count
 
-        NotificationCenter.default.post(
+        trueInterruptNotificationCenter.post(
             name: AppGroupIPCStore.trueInterruptEnabledDidChangeNotification,
             object: nil,
             userInfo: [AppGroupIPCStore.trueInterruptEnabledValueUserInfoKey: false]
@@ -180,7 +184,7 @@ final class AppCoordinatorNotificationFallbackTests: XCTestCase {
         deviceActivityMonitor.stubbedIsAvailable = true
         ipcStore.trueInterruptEnabled = true
         ipcStore.selectApps()
-        NotificationCenter.default.post(
+        trueInterruptNotificationCenter.post(
             name: AppGroupIPCStore.trueInterruptEnabledDidChangeNotification,
             object: nil,
             userInfo: [AppGroupIPCStore.trueInterruptEnabledValueUserInfoKey: true]
@@ -202,7 +206,7 @@ final class AppCoordinatorNotificationFallbackTests: XCTestCase {
         XCTAssertTrue(ipcStore.recordedKinds.contains(.shieldPathSelected))
 
         ipcStore.trueInterruptEnabled = false
-        NotificationCenter.default.post(
+        trueInterruptNotificationCenter.post(
             name: AppGroupIPCStore.trueInterruptEnabledDidChangeNotification,
             object: nil,
             userInfo: [AppGroupIPCStore.trueInterruptEnabledValueUserInfoKey: false]
@@ -215,6 +219,25 @@ final class AppCoordinatorNotificationFallbackTests: XCTestCase {
         XCTAssertEqual(notificationCenter.addedRequests.count, 2)
         let event = try XCTUnwrap(ipcStore.events.last { $0.kind == .notificationFallbackScheduled })
         XCTAssertEqual(event.detail, "true_interrupt_disabled")
+    }
+
+    func test_trueInterruptEnabledChangeNotification_ignoresDefaultCenterWhenInjectedCenterUsed() async {
+        deviceActivityMonitor.stubbedIsAvailable = false
+        ipcStore.trueInterruptEnabled = false
+        await coordinator.refreshAuthStatus()
+        notificationCenter.reset()
+        let fallbackEventCountBeforePost = ipcStore.events.filter { $0.kind == .notificationFallbackScheduled }.count
+
+        NotificationCenter.default.post(
+            name: AppGroupIPCStore.trueInterruptEnabledDidChangeNotification,
+            object: nil,
+            userInfo: [AppGroupIPCStore.trueInterruptEnabledValueUserInfoKey: false]
+        )
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        let fallbackEventCountAfterPost = ipcStore.events.filter { $0.kind == .notificationFallbackScheduled }.count
+        XCTAssertEqual(notificationCenter.addedRequests.count, 0)
+        XCTAssertEqual(fallbackEventCountAfterPost, fallbackEventCountBeforePost)
     }
 
     func test_scheduleReminders_usesCapturedFallbackDetail_whenIPCMutatesDuringScheduling() async throws {


### PR DESCRIPTION
Summary:\n- inject lifecycleNotificationCenter into AppCoordinator with production default .default\n- use injected center for true-interrupt observer add/remove lifecycle\n- update notification fallback tests to post via injected center and add one focused default-center isolation test\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462