### PR TITLE
Phase A micro-slice: ScreenTimeTracker notification center seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -35,6 +35,7 @@
 
 ## Learnings
 
+- For service lifecycle observers, inject a dedicated `NotificationCenter` dependency and route both registration/removal through it; add paired tests proving custom-center delivery and default-center isolation to avoid global observer cross-talk (`EyePostureReminder/Services/ScreenTimeTracker.swift`, `Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift`).
 - For service callbacks consumed by `@MainActor` coordinators, declare callback properties as `@MainActor` function types at the protocol boundary (e.g., `(@MainActor (ReminderType) -> Void)?`) to get compile-time isolation guarantees and remove `MainActor.assumeIsolated` crash traps.
 - Conforming mocks/no-op stubs must match the actor-annotated callback signatures; this keeps tests compile-safe while preserving behavior.
 - For UI-test-only persisted overrides, inject a dedicated `UserDefaults` instance into resolver paths instead of reading `UserDefaults.standard` directly; this removes hidden globals and allows isolated suite-based tests.
@@ -58,6 +59,7 @@
 - For foreground lifecycle snooze handling (`handleForegroundTransition`), compare expiry against `dateProvider.now` (not `Date()`) and cover both wall-clock/injected-clock inversion cases to keep resume behavior deterministic.
 - For cold-launch session telemetry, set `sessionStartTime` from injected `dateProvider.now` in `scheduleReminders()` so downstream `appSessionEnd` duration remains deterministic even when tests pin the clock to non-wall time.
 - For AppDelegate lifecycle registration seams, inject a `makeMetricKitSubscriber` fallback factory and resolve it only when explicit `metricKitSubscriber` injection is absent; this removes direct `MetricKitSubscriber.shared` coupling and enables deterministic fallback-path tests.
+- For service lifecycle observers, inject a dedicated `NotificationCenter` dependency and route both registration/removal through it; add paired tests proving custom-center delivery and default-center isolation to avoid global observer cross-talk (`EyePostureReminder/Services/ScreenTimeTracker.swift`, `Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift`).
 
 ## 2026-05-03T10:08:22Z: #462 Phase A DI/SRP — DateProviding Seam Micro-Slice (COMPLETED)
 

--- a/.squad/skills/notification-center-observer-seam/SKILL.md
+++ b/.squad/skills/notification-center-observer-seam/SKILL.md
@@ -19,3 +19,10 @@ Use when a service/coordinator registers observers via `NotificationCenter.defau
 - Preserves runtime behavior in production.
 - Removes hidden global coupling.
 - Prevents cross-test interference from shared notification observers.
+
+## Example
+- `EyePostureReminder/Services/AppCoordinator.swift` + `Tests/EyePostureReminderTests/Services/AppCoordinatorNotificationFallbackTests.swift`
+- `EyePostureReminder/Services/ScreenTimeTracker.swift` + `Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift` (lifecycle observer seam + default-center isolation test)
+## Example
+- `EyePostureReminder/Services/AppCoordinator.swift` + `Tests/EyePostureReminderTests/Services/AppCoordinatorNotificationFallbackTests.swift`
+- `EyePostureReminder/Services/ScreenTimeTracker.swift` + `Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift` (lifecycle observer seam + default-center isolation test)

--- a/EyePostureReminder/Services/ScreenTimeTracker.swift
+++ b/EyePostureReminder/Services/ScreenTimeTracker.swift
@@ -73,6 +73,7 @@ final class ScreenTimeTracker: ScreenTimeTracking {
     /// Non-nil while we are within the grace period after `willResignActive`.
     /// Cancelled if the app returns to active before the grace period expires.
     private var resetTask: Task<Void, Never>?
+    private let lifecycleNotificationCenter: NotificationCenter
 
     // MARK: - Callback
 
@@ -82,10 +83,16 @@ final class ScreenTimeTracker: ScreenTimeTracking {
 
     // MARK: - Init
 
-    /// - Parameter resetGracePeriod: Seconds to wait after `willResignActive` before
-    ///   clearing counters. Must be ≥ 0. Defaults to 5.0 s for production use; pass a
-    ///   smaller value in tests to exercise grace-period behaviour without long sleeps.
-    init(resetGracePeriod: TimeInterval = 5.0) {
+    /// - Parameters:
+    ///   - resetGracePeriod: Seconds to wait after `willResignActive` before
+    ///     clearing counters. Must be ≥ 0. Defaults to 5.0 s for production use; pass a
+    ///     smaller value in tests to exercise grace-period behaviour without long sleeps.
+    ///   - lifecycleNotificationCenter: Notification center used for app lifecycle observer
+    ///     registration/removal. Defaults to `.default` for production behavior.
+    init(
+        resetGracePeriod: TimeInterval = 5.0,
+        lifecycleNotificationCenter: NotificationCenter = .default
+    ) {
         if resetGracePeriod < 0 {
             Logger.scheduling.warning(
                 "ScreenTimeTracker: ignoring negative resetGracePeriod (\(resetGracePeriod)) — using 0"
@@ -94,6 +101,7 @@ final class ScreenTimeTracker: ScreenTimeTracking {
         } else {
             self.resetGracePeriod = resetGracePeriod
         }
+        self.lifecycleNotificationCenter = lifecycleNotificationCenter
         for type in ReminderType.allCases {
             elapsed[type] = 0
         }
@@ -101,7 +109,7 @@ final class ScreenTimeTracker: ScreenTimeTracking {
     }
 
     deinit {
-        NotificationCenter.default.removeObserver(self)
+        lifecycleNotificationCenter.removeObserver(self)
         tickTimer?.invalidate()
         resetTask?.cancel()
     }
@@ -205,13 +213,13 @@ final class ScreenTimeTracker: ScreenTimeTracking {
     // MARK: - Private: Lifecycle Observers
 
     private func registerLifecycleObservers() {
-        NotificationCenter.default.addObserver(
+        lifecycleNotificationCenter.addObserver(
             self,
             selector: #selector(handleDidBecomeActive),
             name: UIApplication.didBecomeActiveNotification,
             object: nil
         )
-        NotificationCenter.default.addObserver(
+        lifecycleNotificationCenter.addObserver(
             self,
             selector: #selector(handleWillResignActive),
             name: UIApplication.willResignActiveNotification,

--- a/Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift
@@ -716,3 +716,34 @@ extension ScreenTimeTrackerTests {
         XCTAssertEqual(callCount, 1, "After reset-to-zero, callback should require full threshold accumulation")
     }
 }
+
+// MARK: - Lifecycle Notification Center DI Seam
+
+extension ScreenTimeTrackerTests {
+    func test_customLifecycleNotificationCenter_drivesObserverCallbacks() async {
+        let lifecycleCenter = NotificationCenter()
+        let tracker = ScreenTimeTracker(lifecycleNotificationCenter: lifecycleCenter)
+        defer { tracker.stop() }
+
+        let fired = expectation(description: "threshold reached via injected lifecycle center")
+        tracker.setThreshold(2, for: .eyes)
+        tracker.onThresholdReached = { type in
+            if type == .eyes { fired.fulfill() }
+        }
+
+        lifecycleCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        await fulfillment(of: [fired], timeout: 3.0)
+    }
+
+    func test_customLifecycleNotificationCenter_ignoresDefaultCenterPosts() async {
+        let lifecycleCenter = NotificationCenter()
+        let tracker = ScreenTimeTracker(lifecycleNotificationCenter: lifecycleCenter)
+        defer { tracker.stop() }
+
+        tracker.setThreshold(2, for: .eyes)
+        tracker.onThresholdReached = { _ in XCTFail("Default notification center should not trigger tracker callbacks") }
+
+        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+        try? await Task.sleep(nanoseconds: 2_500_000_000)
+    }
+}


### PR DESCRIPTION
## Summary
- inject lifecycleNotificationCenter into ScreenTimeTracker (default .default)
- route lifecycle observer add/remove through injected center
- add focused tests proving injected-center delivery and default-center isolation

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462