### PR TITLE
Phase A micro-slice: LiveCarPlayDetector notification seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -133,3 +133,9 @@
 - Validation: `./scripts/build.sh build` and `./scripts/build.sh test` passed after the change.
 - Key file paths: `EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`, `.squad/skills/date-provider-default-seam/SKILL.md`.
 - For AppCoordinator notification-driven rerouting, inject a dedicated `NotificationCenter` dependency for observer registration/removal instead of using `NotificationCenter.default`; this preserves production behavior while isolating tests from global observer cross-talk.
+
+## Learnings
+
+- LiveCarPlayDetector Phase A seam: inject notificationCenter plus deterministic isCarPlayActiveProvider and verify injected-center route-change delivery plus default-center isolation to remove global observer coupling without changing runtime defaults.
+- For `@MainActor` detector callbacks driven by nonisolated `NotificationCenter` closures, inject a state-provider closure seam and mark it `nonisolated(unsafe)` so observer handlers stay compile-safe in Swift 6 while production behavior remains unchanged (`EyePostureReminder/Services/PauseConditionManager.swift`).
+- For NotificationCenter observer seams in services, keep one positive test on the injected center and one negative test on `NotificationCenter.default` to prove isolation from global callbacks (`Tests/EyePostureReminderTests/Services/LiveCarPlayDetectorTests.swift`).

--- a/.squad/skills/notification-center-observer-seam/SKILL.md
+++ b/.squad/skills/notification-center-observer-seam/SKILL.md
@@ -9,20 +9,20 @@ source: "earned"
 ## Context
 Use when a service/coordinator registers observers via `NotificationCenter.default` and tests need deterministic isolation from global observer state.
 
-## Pattern
+## Patterns
 - Add a `NotificationCenter` dependency with default `.default` in the initializer.
 - Store it on the type and use it for both `addObserver` and `removeObserver`.
+- For observer callbacks that read runtime state, inject a tiny state-provider closure (or protocol) so tests can drive callback outcomes deterministically.
+- In `@MainActor` types where callback closures are nonisolated/sendable, keep provider seams compile-safe (for example with `nonisolated(unsafe)` immutable closure storage) and dispatch UI-state mutations back to main.
 - In tests, inject a fresh `NotificationCenter()` and post notifications there.
 - Add one negative assertion proving `NotificationCenter.default` does not drive behavior when a custom center is injected.
 
-## Benefits
-- Preserves runtime behavior in production.
-- Removes hidden global coupling.
-- Prevents cross-test interference from shared notification observers.
+## Examples
+- `EyePostureReminder/Services/AppCoordinator.swift` + `Tests/EyePostureReminderTests/Services/AppCoordinatorNotificationFallbackTests.swift`
+- `EyePostureReminder/Services/ScreenTimeTracker.swift` + `Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift`
+- `EyePostureReminder/Services/PauseConditionManager.swift` (`LiveCarPlayDetector`) + `Tests/EyePostureReminderTests/Services/LiveCarPlayDetectorTests.swift`
 
-## Example
-- `EyePostureReminder/Services/AppCoordinator.swift` + `Tests/EyePostureReminderTests/Services/AppCoordinatorNotificationFallbackTests.swift`
-- `EyePostureReminder/Services/ScreenTimeTracker.swift` + `Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift` (lifecycle observer seam + default-center isolation test)
-## Example
-- `EyePostureReminder/Services/AppCoordinator.swift` + `Tests/EyePostureReminderTests/Services/AppCoordinatorNotificationFallbackTests.swift`
-- `EyePostureReminder/Services/ScreenTimeTracker.swift` + `Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift` (lifecycle observer seam + default-center isolation test)
+## Anti-Patterns
+- Registering on `NotificationCenter.default` and removing on a different center.
+- Testing observer logic by posting only to `.default` while production code uses an injected center.
+- Coupling observer callbacks directly to hard-to-control system singletons when a tiny seam would make behavior deterministic.

--- a/EyePostureReminder/Services/PauseConditionManager.swift
+++ b/EyePostureReminder/Services/PauseConditionManager.swift
@@ -109,18 +109,28 @@ final class LiveCarPlayDetector: CarPlayDetecting {
     private(set) var isCarPlayActive: Bool = false
     var onCarPlayChanged: ((Bool) -> Void)?
 
+    private let notificationCenter: NotificationCenter
+    nonisolated(unsafe) private let isCarPlayActiveProvider: () -> Bool
     private var observer: NSObjectProtocol?
 
-    func startMonitoring() {
-        isCarPlayActive = checkCarPlay()
+    init(
+        notificationCenter: NotificationCenter = .default,
+        isCarPlayActiveProvider: @escaping () -> Bool = LiveCarPlayDetector.defaultIsCarPlayActive
+    ) {
+        self.notificationCenter = notificationCenter
+        self.isCarPlayActiveProvider = isCarPlayActiveProvider
+    }
 
-        observer = NotificationCenter.default.addObserver(
+    func startMonitoring() {
+        isCarPlayActive = isCarPlayActiveProvider()
+
+        observer = notificationCenter.addObserver(
             forName: AVAudioSession.routeChangeNotification,
             object: nil,
             queue: nil
         ) { [weak self] _ in
             guard let self else { return }
-            let active = self.checkCarPlay()
+            let active = self.isCarPlayActiveProvider()
             // Use [weak self] on the inner dispatch to prevent a stale-write race:
             // if stopMonitoring() + startMonitoring() run while this block is queued,
             // the freshly-initialised isCarPlayActive must not be overwritten. Fixes #492.
@@ -134,14 +144,14 @@ final class LiveCarPlayDetector: CarPlayDetecting {
 
     func stopMonitoring() {
         if let observer {
-            NotificationCenter.default.removeObserver(observer)
+            notificationCenter.removeObserver(observer)
         }
         observer = nil
     }
 
     // nonisolated: required because NotificationCenter.addObserver(forName:queue:) closure
     // is not actor-isolated; the callback dispatches back to main for state mutation.
-    nonisolated private func checkCarPlay() -> Bool {
+    nonisolated private static func defaultIsCarPlayActive() -> Bool {
         // .carPlay port may not be exposed in all SDK configurations; match via raw value.
         let carPlayPort = AVAudioSession.Port(rawValue: "CarPlay")
         let outputs = AVAudioSession.sharedInstance().currentRoute.outputs

--- a/Tests/EyePostureReminderTests/Services/LiveCarPlayDetectorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/LiveCarPlayDetectorTests.swift
@@ -1,0 +1,61 @@
+@testable import EyePostureReminder
+import AVFoundation
+import XCTest
+
+@MainActor
+final class LiveCarPlayDetectorTests: XCTestCase {
+
+    func test_startMonitoring_seedsInitialStateFromInjectedProvider() {
+        let notificationCenter = NotificationCenter()
+        let detector = LiveCarPlayDetector(
+            notificationCenter: notificationCenter,
+            isCarPlayActiveProvider: { true }
+        )
+
+        detector.startMonitoring()
+
+        XCTAssertTrue(detector.isCarPlayActive)
+        detector.stopMonitoring()
+    }
+
+    func test_routeChange_onInjectedNotificationCenter_updatesStateAndFiresCallback() {
+        let notificationCenter = NotificationCenter()
+        var isCarPlayConnected = false
+        let detector = LiveCarPlayDetector(
+            notificationCenter: notificationCenter,
+            isCarPlayActiveProvider: { isCarPlayConnected }
+        )
+        let callbackFired = expectation(description: "onCarPlayChanged called")
+        var callbackValues: [Bool] = []
+        detector.onCarPlayChanged = { active in
+            callbackValues.append(active)
+            callbackFired.fulfill()
+        }
+
+        detector.startMonitoring()
+        isCarPlayConnected = true
+        notificationCenter.post(name: AVAudioSession.routeChangeNotification, object: nil)
+
+        wait(for: [callbackFired], timeout: 1.0)
+        XCTAssertTrue(detector.isCarPlayActive)
+        XCTAssertEqual(callbackValues, [true])
+        detector.stopMonitoring()
+    }
+
+    func test_routeChange_onDefaultNotificationCenter_isIgnoredWhenCustomCenterInjected() {
+        let notificationCenter = NotificationCenter()
+        var isCarPlayConnected = false
+        let detector = LiveCarPlayDetector(
+            notificationCenter: notificationCenter,
+            isCarPlayActiveProvider: { isCarPlayConnected }
+        )
+
+        detector.startMonitoring()
+        isCarPlayConnected = true
+        NotificationCenter.default.post(name: AVAudioSession.routeChangeNotification, object: nil)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.05))
+
+        XCTAssertFalse(detector.isCarPlayActive)
+        detector.stopMonitoring()
+    }
+}


### PR DESCRIPTION
## Summary
- inject NotificationCenter dependency into LiveCarPlayDetector (default .default)
- inject isCarPlayActiveProvider seam for deterministic callback-state evaluation
- add focused tests for injected-center delivery and default-center isolation

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462