### PR TITLE
#462 Phase A: use instance UI-test mode in auth refresh

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -145,3 +145,4 @@
 - Keep launch-argument DI tests focused on fallback/bypass behavior: one test proves provider invocation when explicit args are absent, and one proves explicit args bypass provider.
 - User preference reinforced: Phase A slices stay surgical (single DI/SRP seam + focused tests + full `./scripts/build.sh build` and `./scripts/build.sh test`).
 - Key file paths: `EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorUITestLaunchContextTests.swift`, `.squad/skills/launch-context-di-seam/SKILL.md`.
+- For AppCoordinator UI-test guards, persist the resolved `uiTestMode` from init in an instance property and use it in lifecycle methods (e.g., `refreshAuthStatus`) instead of static `AppCoordinator.isUITestMode`; this keeps launch-context DI deterministic for each coordinator instance while preserving behavior.

--- a/.squad/skills/launch-context-di-seam/SKILL.md
+++ b/.squad/skills/launch-context-di-seam/SKILL.md
@@ -20,6 +20,7 @@ Use this when service or coordinator logic branches on process launch context
 - For singleton-backed callbacks (e.g., app launch wiring), inject a zero-arg factory (`makeNotificationCenter`) and use it only on the fallback path so tests can validate callback behavior without invoking fragile system singletons directly.
 - For launch-argument consumers in delegates/services, use `launchArguments: [String]? = nil` with an injected `launchArgumentsProvider` fallback closure so tests can verify both fallback and explicit-argument bypass paths deterministically.
 - For coordinators that consume launch arguments in multiple places, resolve once (`let resolvedLaunchArguments = launchArguments ?? launchArgumentsProvider()`) and thread the resolved value through each branch to avoid mixed injected/global behavior.
+- For coordinator lifecycle methods that branch on UI-test mode after init (for example `refreshAuthStatus`), persist the resolved init value in an instance property and guard on that property instead of static globals.
 
 ## Examples
 - `AppCoordinator.init(..., processEnvironment: [String: String] = ProcessInfo.processInfo.environment, launchArguments: [String]? = nil, launchArgumentsProvider: @escaping () -> [String] = { CommandLine.arguments }, ...)`

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -83,6 +83,7 @@ final class AppCoordinator: ObservableObject {
     /// app extensions and watchdog diagnostics can observe the selected path.
     let ipcStore: AppGroupIPCProviding
     let dateProvider: DateProviding
+    private let isUITestModeEnabled: Bool
     private let lifecycleNotificationCenter: NotificationCenter
     private var trueInterruptEnabledObserver: NSObjectProtocol?
     let watchdogHeartbeatGraceInterval: TimeInterval
@@ -215,6 +216,7 @@ final class AppCoordinator: ObservableObject {
         self.lifecycleNotificationCenter = lifecycleNotificationCenter
         self.watchdogHeartbeatGraceInterval = watchdogHeartbeatGraceInterval
         let resolvedUITestMode = uiTestMode ?? Self.isUITestMode(launchArguments: resolvedLaunchArguments)
+        self.isUITestModeEnabled = resolvedUITestMode
 
         // In UI test mode, use no-op stubs for services that register UIKit lifecycle
         // observers and start 1-second timers — they prevent XCUITest from settling
@@ -332,7 +334,7 @@ final class AppCoordinator: ObservableObject {
         // Skip the system async call in UI test mode — it suspends the main actor,
         // which can prevent a Toggle binding update from executing before XCUITest
         // reads the element's accessibility value immediately after tap().
-        guard !AppCoordinator.isUITestMode else { return }
+        guard !isUITestModeEnabled else { return }
         notificationAuthStatus = await notificationCenter.getAuthorizationStatus()
         Logger.lifecycle.debug("Notification auth status: \(self.notificationAuthStatus.rawValue)")
     }

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestModeResolverTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestModeResolverTests.swift
@@ -68,4 +68,40 @@ final class AppCoordinatorUITestModeResolverTests: XCTestCase {
 
         XCTAssertTrue(coordinator.pauseConditionManager is NoopPauseConditionManager)
     }
+
+    func test_refreshAuthStatus_withInjectedUITestModeTrue_skipsAuthFetch() async {
+        let mockNotif = MockNotificationCenter()
+        mockNotif.authorizationGranted = false
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            pauseConditionProvider: MockPauseConditionProvider(),
+            uiTestMode: true,
+            ipcStore: MockAppGroupIPCRecorder()
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        await coordinator.refreshAuthStatus()
+
+        XCTAssertEqual(coordinator.notificationAuthStatus, .notDetermined)
+    }
+
+    func test_refreshAuthStatus_withInjectedUITestModeFalse_fetchesAuthStatus() async {
+        let mockNotif = MockNotificationCenter()
+        mockNotif.authorizationGranted = false
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            pauseConditionProvider: MockPauseConditionProvider(),
+            uiTestMode: false,
+            ipcStore: MockAppGroupIPCRecorder()
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        await coordinator.refreshAuthStatus()
+
+        XCTAssertEqual(coordinator.notificationAuthStatus, .denied)
+    }
 }


### PR DESCRIPTION
## Summary
- store resolved uiTestMode in AppCoordinator as an instance property
- use that instance-scoped value in refreshAuthStatus() instead of static AppCoordinator.isUITestMode
- add focused tests covering injected uiTestMode true/false behavior for auth refresh

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462
