### PR TITLE
#462 Phase A: inject AppStateProviding seam into ScreenTimeTracker.startIfActive()

### DIFF
--- a/EyePostureReminder/Services/ScreenTimeTracker.swift
+++ b/EyePostureReminder/Services/ScreenTimeTracker.swift
@@ -1,6 +1,18 @@
 import os
 import UIKit
 
+// MARK: - AppStateProviding
+
+/// Abstracts `UIApplication.shared.applicationState` for testability.
+///
+/// Injected into `ScreenTimeTracker` so `startIfActive()` behavior can be
+/// exercised without depending on the real UIApplication singleton.
+protocol AppStateProviding {
+    var applicationState: UIApplication.State { get }
+}
+
+extension UIApplication: AppStateProviding {}
+
 /// Tracks continuous screen-on time per `ReminderType` and fires a callback
 /// when a type's threshold is reached.
 ///
@@ -74,6 +86,7 @@ final class ScreenTimeTracker: ScreenTimeTracking {
     /// Cancelled if the app returns to active before the grace period expires.
     private var resetTask: Task<Void, Never>?
     private let lifecycleNotificationCenter: NotificationCenter
+    private let appStateProvider: AppStateProviding
 
     // MARK: - Callback
 
@@ -89,9 +102,13 @@ final class ScreenTimeTracker: ScreenTimeTracking {
     ///     smaller value in tests to exercise grace-period behaviour without long sleeps.
     ///   - lifecycleNotificationCenter: Notification center used for app lifecycle observer
     ///     registration/removal. Defaults to `.default` for production behavior.
+    ///   - appStateProvider: Provides `UIApplication.applicationState` for `startIfActive()`.
+    ///     Defaults to `UIApplication.shared`. Inject a mock to drive active/background behavior
+    ///     in unit tests without depending on the real UIApplication singleton.
     init(
         resetGracePeriod: TimeInterval = 5.0,
-        lifecycleNotificationCenter: NotificationCenter = .default
+        lifecycleNotificationCenter: NotificationCenter = .default,
+        appStateProvider: AppStateProviding? = nil
     ) {
         if resetGracePeriod < 0 {
             Logger.scheduling.warning(
@@ -102,6 +119,7 @@ final class ScreenTimeTracker: ScreenTimeTracking {
             self.resetGracePeriod = resetGracePeriod
         }
         self.lifecycleNotificationCenter = lifecycleNotificationCenter
+        self.appStateProvider = appStateProvider ?? UIApplication.shared
         for type in ReminderType.allCases {
             elapsed[type] = 0
         }
@@ -182,7 +200,7 @@ final class ScreenTimeTracker: ScreenTimeTracking {
     /// foreground — `didBecomeActiveNotification` won't fire again until the
     /// next lifecycle cycle, so this ensures counting begins immediately.
     func startIfActive() {
-        if UIApplication.shared.applicationState == .active {
+        if appStateProvider.applicationState == .active {
             startTicking()
         }
     }

--- a/Tests/EyePostureReminderTests/Mocks/MockAppStateProvider.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockAppStateProvider.swift
@@ -1,0 +1,17 @@
+@testable import EyePostureReminder
+import UIKit
+
+/// In-memory stub of `AppStateProviding` for unit tests.
+///
+/// Returns a fixed `UIApplication.State` supplied at creation time. Create a
+/// new instance per test to ensure isolation.
+final class MockAppStateProvider: AppStateProviding {
+
+    private let _applicationState: UIApplication.State
+
+    init(state: UIApplication.State) {
+        _applicationState = state
+    }
+
+    var applicationState: UIApplication.State { _applicationState }
+}

--- a/Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift
@@ -10,10 +10,9 @@ import XCTest
 /// 2. **Timer-driven** — async tests that post lifecycle notifications so the
 ///    real 1-second `Timer` fires and asserts threshold-callback behavior.
 ///
-/// Note: `startIfActive()` checks `UIApplication.shared.applicationState`. In the
-/// test runner the state is `.background`, so it does **not** start the timer.
-/// Instead these tests post `UIApplication.didBecomeActiveNotification` directly
-/// to drive `handleDidBecomeActive` → `startTicking()`.
+/// `startIfActive()` now uses the injected `appStateProvider` seam; tests below
+/// exercise both `.active` (timer starts → threshold fires) and `.background`
+/// (no-op) paths deterministically without depending on the real UIApplication.
 ///
 /// The class is `@MainActor` so that `NotificationCenter.default.post` calls are
 /// made from the main thread, ensuring `Timer.scheduledTimer` is scheduled on
@@ -183,6 +182,50 @@ final class ScreenTimeTrackerTests: XCTestCase {
     func test_startIfActive_calledTwice_doesNotCrash() {
         sut.startIfActive()
         sut.startIfActive()
+    }
+
+    // MARK: - startIfActive — AppStateProviding seam
+
+    /// Injecting `.active` state triggers `startTicking()`: threshold fires within 2 s.
+    func test_startIfActive_withActiveState_startsTimer() async {
+        let center = NotificationCenter()
+        let tracker = ScreenTimeTracker(
+            resetGracePeriod: 5.0,
+            lifecycleNotificationCenter: center,
+            appStateProvider: MockAppStateProvider(state: .active)
+        )
+        defer { tracker.stop() }
+
+        tracker.setThreshold(1.0, for: .eyes)
+        let exp = expectation(description: "threshold fires via startIfActive with .active state")
+        tracker.onThresholdReached = { type in
+            if type == .eyes { exp.fulfill() }
+        }
+
+        tracker.startIfActive()
+
+        await fulfillment(of: [exp], timeout: 4.0)
+    }
+
+    /// Injecting `.background` state keeps timer stopped: threshold must NOT fire.
+    func test_startIfActive_withBackgroundState_doesNotStartTimer() async {
+        let center = NotificationCenter()
+        let tracker = ScreenTimeTracker(
+            resetGracePeriod: 5.0,
+            lifecycleNotificationCenter: center,
+            appStateProvider: MockAppStateProvider(state: .background)
+        )
+        defer { tracker.stop() }
+
+        tracker.setThreshold(1.0, for: .eyes)
+        var fired = false
+        tracker.onThresholdReached = { _ in fired = true }
+
+        tracker.startIfActive()
+
+        // Allow 2.5 s — timer must NOT have fired because state is .background.
+        try? await Task.sleep(nanoseconds: 2_500_000_000)
+        XCTAssertFalse(fired, "startIfActive must be a no-op when appStateProvider returns .background")
     }
 
     // MARK: - onThresholdReached callback


### PR DESCRIPTION
## What

Inject an `AppStateProviding` protocol seam into `ScreenTimeTracker` to replace the direct `UIApplication.shared.applicationState` read in `startIfActive()`.

## Why

`startIfActive()` previously read `UIApplication.shared` directly — a hidden global that made the active-vs-background branch untestable. The existing test-class comment explicitly flagged this: *"UIApplication.shared.applicationState... In the test runner the state is .background, so it does not start the timer."*

## Changes

**Production:**
- `ScreenTimeTracker.swift`: defines `AppStateProviding` protocol + `UIApplication` conformance; adds `appStateProvider: AppStateProviding? = nil` init param (resolved to `UIApplication.shared` inside init to avoid `@MainActor` default-arg restriction); routes `startIfActive()` through `appStateProvider.applicationState`

**Tests:**
- `MockAppStateProvider.swift` (new): fixed-state stub
- `ScreenTimeTrackerTests.swift`: 2 new focused seam tests
  - `test_startIfActive_withActiveState_startsTimer` — injected `.active` → threshold fires
  - `test_startIfActive_withBackgroundState_doesNotStartTimer` — injected `.background` → no callback

## Validation

- `./scripts/build.sh build` ✅ clean
- `./scripts/build.sh test` ✅ 1962/1962 tests pass (up from 1960)

Closes part of #462 Phase A.