### PR TITLE
#462 Phase A: OverlayManager notification center factory seam

### DIFF
--- a/EyePostureReminder/Services/OverlayManager.swift
+++ b/EyePostureReminder/Services/OverlayManager.swift
@@ -96,6 +96,8 @@ final class OverlayManager: OverlayPresenting {
 
     // MARK: - Dependencies
 
+    typealias NotificationCenterFactory = () -> NotificationCenter
+
     private let audioManager: MediaControlling
     private let accessibilityNotificationPoster: AccessibilityNotificationPosting
     private let notificationCenter: NotificationCenter
@@ -130,12 +132,13 @@ final class OverlayManager: OverlayPresenting {
     init(
         audioManager: MediaControlling = AudioInterruptionManager(),
         accessibilityNotificationPoster: AccessibilityNotificationPosting = LiveAccessibilityNotificationPoster(),
-        notificationCenter: NotificationCenter = .default
+        notificationCenter: NotificationCenter? = nil,
+        makeNotificationCenter: @escaping NotificationCenterFactory = { .default }
     ) {
         self.audioManager = audioManager
         self.accessibilityNotificationPoster = accessibilityNotificationPoster
-        self.notificationCenter = notificationCenter
-        sceneActivationObserver = notificationCenter.addObserver(
+        self.notificationCenter = notificationCenter ?? makeNotificationCenter()
+        sceneActivationObserver = self.notificationCenter.addObserver(
             forName: UIScene.didActivateNotification,
             object: nil,
             queue: .main

--- a/Tests/EyePostureReminderTests/Services/OverlayManagerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/OverlayManagerTests.swift
@@ -23,6 +23,36 @@ final class OverlayManagerTests: XCTestCase {
         XCTAssertNotNil(manager)
     }
 
+    // MARK: - Initializer DI seams
+
+    func test_init_withoutNotificationCenter_usesFactoryOnce() {
+        var factoryCallCount = 0
+        let factoryCenter = NotificationCenter()
+        _ = OverlayManager(
+            notificationCenter: nil,
+            makeNotificationCenter: {
+                factoryCallCount += 1
+                return factoryCenter
+            }
+        )
+
+        XCTAssertEqual(factoryCallCount, 1)
+    }
+
+    func test_init_withNotificationCenter_bypassesFactory() {
+        var factoryCalled = false
+        let injectedCenter = NotificationCenter()
+        _ = OverlayManager(
+            notificationCenter: injectedCenter,
+            makeNotificationCenter: {
+                factoryCalled = true
+                return NotificationCenter()
+            }
+        )
+
+        XCTAssertFalse(factoryCalled)
+    }
+
     // MARK: - isOverlayVisible — initial state
 
     /// In a headless test environment there is no window scene, so no overlay


### PR DESCRIPTION
Summary:\n- inject makeNotificationCenter fallback factory into OverlayManager initializer\n- preserve behavior by resolving NotificationCenter.default only when center is not injected\n- add focused tests for fallback-used and injected-bypass init paths\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462