### PR TITLE
#462 Phase A: AppCoordinator IPC store factory seam

### DIFF
--- a/.squad/agents/rusty/history.md
+++ b/.squad/agents/rusty/history.md
@@ -255,6 +255,7 @@ Result: **10/10 passed**
 - Shield as opt-in "Hard Mode" overlay on existing reminder system is the right product framing. Avoids coupling the health intervention core loop to an entitlement-gated API.
 - `ShieldTriggerReason.rawValue` stability matters: values are written to App Group UserDefaults and read by extension processes in a separate sandbox. The tests pin these as a regression gate.
 - FamilyControls does NOT work in Simulator at all. All real shield validation is device-only, post-#201.
+- For AppCoordinator DI seams, convert eager singleton/store defaults into `Dependency? = nil` + `makeDependency` factory closures, then test both fallback and bypass paths to keep behavior unchanged and testability explicit.
 
 ### 2026-04-30: Post-#299 Architecture Audit — Clean
 
@@ -328,4 +329,3 @@ Result: **10/10 passed**
 
 **Final merge verdict at handoff:**
 - **REJECT FOR NOW** — residual risk remains in Settings shard stability despite remediation closure for #497/#498/#499 and overlay/dark-mode improvements.
-

--- a/.squad/skills/appgroup-ipcstore-factory-seam/SKILL.md
+++ b/.squad/skills/appgroup-ipcstore-factory-seam/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: "appgroup-ipcstore-factory-seam"
+description: "Inject optional AppGroupIPCProviding plus fallback factory to avoid eager AppGroupIPCStore defaults"
+domain: "testing"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+Use when a coordinator/service initializer defaults IPC persistence directly to `AppGroupIPCStore()` and you need deterministic fallback-path tests without changing behavior.
+
+## Patterns
+- Replace eager concrete default args with optional protocol injection (`ipcStore: AppGroupIPCProviding? = nil`).
+- Add a fallback factory closure (`makeIPCStore`) that keeps production defaults.
+- Resolve once in `init` (`ipcStore ?? makeIPCStore()`), then use the resolved store everywhere.
+- Add two tests: factory called when explicit store is nil, and factory bypassed when explicit store is injected.
+
+## Examples
+- `EyePostureReminder/Services/AppCoordinator.swift`
+- `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`
+
+## Anti-Patterns
+- `ipcStore: AppGroupIPCProviding = AppGroupIPCStore()` in initializer signatures.
+- Re-instantiating `AppGroupIPCStore()` outside the resolved dependency path.

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -191,7 +191,8 @@ final class AppCoordinator: ObservableObject {
         launchArgumentsProvider: @escaping () -> [String] = { CommandLine.arguments },
         uiTestMode: Bool? = nil,
         deviceActivityMonitor: DeviceActivityMonitorProviding? = nil,
-        ipcStore: AppGroupIPCProviding = AppGroupIPCStore(),
+        ipcStore: AppGroupIPCProviding? = nil,
+        makeIPCStore: @escaping () -> AppGroupIPCProviding = { AppGroupIPCStore() },
         lifecycleNotificationCenter: NotificationCenter = .default,
         watchdogHeartbeatGraceInterval: TimeInterval = 10,
         dateProvider: DateProviding = SystemDateProvider()
@@ -212,7 +213,7 @@ final class AppCoordinator: ObservableObject {
             launchArguments: resolvedLaunchArguments
         )
         self.deviceActivityMonitor = Self.resolveDeviceActivityMonitor(deviceActivityMonitor)
-        self.ipcStore = ipcStore
+        self.ipcStore = ipcStore ?? makeIPCStore()
         self.dateProvider = dateProvider
         self.lifecycleNotificationCenter = lifecycleNotificationCenter
         self.watchdogHeartbeatGraceInterval = watchdogHeartbeatGraceInterval

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -153,6 +153,58 @@ final class AppCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.notificationAuthStatus, .denied)
     }
 
+    func test_init_withoutIPCStore_usesInjectedIPCStoreFactory() async {
+        struct FactoryReadEventsError: Error {}
+        var factoryCallCount = 0
+        let factoryStore = MockAppGroupIPCRecorder()
+        factoryStore.readEventsError = FactoryReadEventsError()
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: ReminderScheduler(notificationCenter: MockNotificationCenter()),
+            notificationCenter: MockNotificationCenter(),
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: nil,
+            makeIPCStore: {
+                factoryCallCount += 1
+                return factoryStore
+            }
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        XCTAssertThrowsError(try coordinator.ipcStore.readEvents()) { error in
+            XCTAssertTrue(error is FactoryReadEventsError)
+        }
+
+        XCTAssertEqual(factoryCallCount, 1)
+    }
+
+    func test_init_withExplicitIPCStore_doesNotCallIPCStoreFactory() async {
+        struct InjectedReadEventsError: Error {}
+        var factoryCallCount = 0
+        let injectedStore = MockAppGroupIPCRecorder()
+        injectedStore.readEventsError = InjectedReadEventsError()
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: ReminderScheduler(notificationCenter: MockNotificationCenter()),
+            notificationCenter: MockNotificationCenter(),
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: injectedStore,
+            makeIPCStore: {
+                factoryCallCount += 1
+                return MockAppGroupIPCRecorder()
+            }
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        XCTAssertThrowsError(try coordinator.ipcStore.readEvents()) { error in
+            XCTAssertTrue(error is InjectedReadEventsError)
+        }
+
+        XCTAssertEqual(factoryCallCount, 0)
+    }
+
     func test_init_withUITestScreenTimeStatus_keepsStatusForRelaunches() {
         UserDefaults.standard.set(
             ScreenTimeAuthorizationStatus.notDetermined.rawValue,


### PR DESCRIPTION
Summary:\n- Replace eager AppCoordinator IPC default (AppGroupIPCStore) with DI seam\n- Add makeIPCStore fallback factory while preserving production behavior\n- Add focused tests for fallback factory usage and explicit-store bypass\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462