### PR TITLE
#462 Phase A: AppCoordinator processEnvironment provider seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -153,3 +153,6 @@
 - Keep seam tests surgical: add one fallback-used assertion and one explicit-injection-bypass assertion, then verify through a public behavior call (`refreshAuthStatus`) instead of private state checks.
 - User preference reinforced: continue #462 with tiny DI/SRP slices only, each validated with `./scripts/build.sh build` and `./scripts/build.sh test`.
 - Key file paths: `EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`, `.squad/decisions/inbox/basher-appcoordinator-notificationcenter-factory-seam.md`.
+
+## Learnings
+- AppCoordinator launch-context seam: prefer `processEnvironment: [String: String]? = nil` plus `processEnvironmentProvider` fallback, resolve once in `init`, and thread the resolved value into `resolveScreenTimeAuthorization` so tests can assert fallback-used and explicit-bypass paths without touching `ProcessInfo.processInfo.environment` globals.

--- a/.squad/skills/launch-context-di-seam/SKILL.md
+++ b/.squad/skills/launch-context-di-seam/SKILL.md
@@ -20,12 +20,13 @@ Use this when service or coordinator logic branches on process launch context
 - For singleton-backed callbacks (e.g., app launch wiring), inject a zero-arg factory (`makeNotificationCenter`) and use it only on the fallback path so tests can validate callback behavior without invoking fragile system singletons directly.
 - For launch-argument consumers in delegates/services, use `launchArguments: [String]? = nil` with an injected `launchArgumentsProvider` fallback closure so tests can verify both fallback and explicit-argument bypass paths deterministically.
 - For coordinators that consume launch arguments in multiple places, resolve once (`let resolvedLaunchArguments = launchArguments ?? launchArgumentsProvider()`) and thread the resolved value through each branch to avoid mixed injected/global behavior.
+- Apply the same optional+provider pattern to process environment reads (`processEnvironment: [String: String]? = nil`, `processEnvironmentProvider`) and resolve once in `init` before passing to resolver helpers.
 - For coordinator lifecycle methods that branch on UI-test mode after init (for example `refreshAuthStatus`), persist the resolved init value in an instance property and guard on that property instead of static globals.
 
 ## Examples
-- `AppCoordinator.init(..., processEnvironment: [String: String] = ProcessInfo.processInfo.environment, launchArguments: [String]? = nil, launchArgumentsProvider: @escaping () -> [String] = { CommandLine.arguments }, ...)`
+- `AppCoordinator.init(..., processEnvironment: [String: String]? = nil, processEnvironmentProvider: @escaping () -> [String: String] = { ProcessInfo.processInfo.environment }, launchArguments: [String]? = nil, launchArgumentsProvider: @escaping () -> [String] = { CommandLine.arguments }, ...)`
 - `resolveScreenTimeAuthorization(..., processEnvironment:, launchArguments:)` in `EyePostureReminder/Services/AppCoordinator.swift`.
-- Focused coverage in `Tests/EyePostureReminderTests/Services/AppCoordinatorUITestLaunchContextTests.swift` (`test_init_withoutLaunchArguments_usesInjectedLaunchArgumentsProvider`, `test_init_withExplicitLaunchArguments_doesNotCallInjectedLaunchArgumentsProvider`).
+- Focused coverage in `Tests/EyePostureReminderTests/Services/AppCoordinatorUITestLaunchContextTests.swift` (`test_init_withoutLaunchArguments_usesInjectedLaunchArgumentsProvider`, `test_init_withExplicitLaunchArguments_doesNotCallInjectedLaunchArgumentsProvider`, `test_init_withoutProcessEnvironment_usesInjectedProcessEnvironmentProvider`, `test_init_withExplicitProcessEnvironment_doesNotCallInjectedProcessEnvironmentProvider`).
 - `AppDelegate.init(..., makeSettingsStore: @escaping @MainActor () -> SettingsStore = { SettingsStore() })` with usage in `applyUITestLaunchArguments()` and seam coverage in `Tests/EyePostureReminderTests/Services/AppDelegateTests.swift`.
 - `AppDelegate.init(..., makeNotificationCenter: @escaping () -> UserNotificationCenterDelegating = { UNUserNotificationCenter.current() })` with fallback-path coverage in `test_didFinishLaunching_withNilNotificationCenter_usesInjectedFactory`.
 - `AppDelegate.init(..., launchArguments: [String]? = nil, launchArgumentsProvider: @escaping () -> [String] = { CommandLine.arguments })` with fallback/bypass coverage in `test_init_withoutLaunchArguments_usesInjectedLaunchArgumentsProvider` and `test_init_withExplicitLaunchArguments_doesNotCallInjectedLaunchArgumentsProvider`.
@@ -37,3 +38,4 @@ Use this when service or coordinator logic branches on process launch context
 - Mixing an injected UI-test mode for one resolver with a static global (`AppCoordinator.isUITestMode`) in another resolver.
 - Resolving singleton callbacks inline (`UNUserNotificationCenter.current()`) when a tiny fallback factory seam would make the same code deterministic in unit tests.
 - Reading `CommandLine.arguments` directly in default parameter values when an optional argument + provider seam can keep behavior while improving test control.
+- Reading `ProcessInfo.processInfo.environment` directly in default parameter values when an optional argument + provider seam can keep behavior while improving test control.

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -186,7 +186,8 @@ final class AppCoordinator: ObservableObject {
         pauseConditionProvider: PauseConditionProviding? = nil,
         screenTimeAuthorization: ScreenTimeAuthorizationProviding? = nil,
         uiTestStatusStore: UserDefaults = .standard,
-        processEnvironment: [String: String] = ProcessInfo.processInfo.environment,
+        processEnvironment: [String: String]? = nil,
+        processEnvironmentProvider: @escaping () -> [String: String] = { ProcessInfo.processInfo.environment },
         launchArguments: [String]? = nil,
         launchArgumentsProvider: @escaping () -> [String] = { CommandLine.arguments },
         uiTestMode: Bool? = nil,
@@ -206,10 +207,11 @@ final class AppCoordinator: ObservableObject {
         self.notificationCenter = notificationCenter ?? makeNotificationCenter()
         self.overlayManager = Self.resolveOverlayManager(overlayManager)
         let resolvedLaunchArguments = launchArguments ?? launchArgumentsProvider()
+        let resolvedProcessEnvironment = processEnvironment ?? processEnvironmentProvider()
         self.screenTimeAuthorization = Self.resolveScreenTimeAuthorization(
             screenTimeAuthorization,
             uiTestStatusStore: uiTestStatusStore,
-            processEnvironment: processEnvironment,
+            processEnvironment: resolvedProcessEnvironment,
             launchArguments: resolvedLaunchArguments
         )
         self.deviceActivityMonitor = Self.resolveDeviceActivityMonitor(deviceActivityMonitor)

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestLaunchContextTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestLaunchContextTests.swift
@@ -92,6 +92,56 @@ final class AppCoordinatorUITestLaunchContextTests: XCTestCase {
         XCTAssertEqual(stub?.authorizationStatus, .notDetermined)
     }
 
+    func test_init_withoutProcessEnvironment_usesInjectedProcessEnvironmentProvider() {
+        let mockNotif = MockNotificationCenter()
+        var providerCallCount = 0
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            uiTestStatusStore: isolatedDefaults(for: #function),
+            processEnvironment: nil,
+            processEnvironmentProvider: {
+                providerCallCount += 1
+                return ["UITEST_SCREEN_TIME_STATUS": "notDetermined"]
+            },
+            launchArguments: ["EyePostureReminderTests"],
+            ipcStore: MockAppGroupIPCRecorder()
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        let stub = coordinator.screenTimeAuthorization as? ScreenTimeAuthorizationStub
+        XCTAssertEqual(providerCallCount, 1)
+        XCTAssertEqual(stub?.authorizationStatus, .notDetermined)
+    }
+
+    func test_init_withExplicitProcessEnvironment_doesNotCallInjectedProcessEnvironmentProvider() {
+        let mockNotif = MockNotificationCenter()
+        var providerCallCount = 0
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: ReminderScheduler(notificationCenter: mockNotif),
+            notificationCenter: mockNotif,
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            uiTestStatusStore: isolatedDefaults(for: #function),
+            processEnvironment: ["UITEST_SCREEN_TIME_STATUS": "notDetermined"],
+            processEnvironmentProvider: {
+                providerCallCount += 1
+                return [:]
+            },
+            launchArguments: ["EyePostureReminderTests"],
+            ipcStore: MockAppGroupIPCRecorder()
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        let stub = coordinator.screenTimeAuthorization as? ScreenTimeAuthorizationStub
+        XCTAssertEqual(providerCallCount, 0)
+        XCTAssertEqual(stub?.authorizationStatus, .notDetermined)
+    }
+
     private func isolatedDefaults(for function: StaticString) -> UserDefaults {
         let suiteName = "AppCoordinatorUITestLaunchContextTests.\(function)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {


### PR DESCRIPTION
Summary:\n- make AppCoordinator process environment input optional and resolve via injected processEnvironmentProvider fallback\n- preserve runtime behavior by defaulting provider to ProcessInfo.processInfo.environment\n- add focused init seam tests for fallback-used and explicit-environment bypass paths\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462