### PR TITLE
#462 Phase A: AppGroupIPCStore notification center seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -156,3 +156,4 @@
 
 ## Learnings
 - AppCoordinator launch-context seam: prefer `processEnvironment: [String: String]? = nil` plus `processEnvironmentProvider` fallback, resolve once in `init`, and thread the resolved value into `resolveScreenTimeAuthorization` so tests can assert fallback-used and explicit-bypass paths without touching `ProcessInfo.processInfo.environment` globals.
+- For notification-emitting shared stores, inject `NotificationCenter` and use it for `post` calls; add a seam test that observes on the injected center plus a negative assertion on `.default` to prove global isolation without behavior changes (`Extensions/Shared/AppGroupIPCStore.swift`, `Tests/EyePostureReminderTests/Services/AppGroupIPCStoreTests.swift`).

--- a/.squad/skills/notification-center-observer-seam/SKILL.md
+++ b/.squad/skills/notification-center-observer-seam/SKILL.md
@@ -11,7 +11,7 @@ Use when a service/coordinator registers observers via `NotificationCenter.defau
 
 ## Patterns
 - Add a `NotificationCenter` dependency with default `.default` in the initializer.
-- Store it on the type and use it for both `addObserver` and `removeObserver`.
+- Store it on the type and use it for all notification interactions (`addObserver`, `removeObserver`, and `post`).
 - For observer callbacks that read runtime state, inject a tiny state-provider closure (or protocol) so tests can drive callback outcomes deterministically.
 - In `@MainActor` types where callback closures are nonisolated/sendable, keep provider seams compile-safe (for example with `nonisolated(unsafe)` immutable closure storage) and dispatch UI-state mutations back to main.
 - In tests, inject a fresh `NotificationCenter()` and post notifications there.
@@ -22,6 +22,7 @@ Use when a service/coordinator registers observers via `NotificationCenter.defau
 - `EyePostureReminder/Services/ScreenTimeTracker.swift` + `Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift`
 - `EyePostureReminder/Services/PauseConditionManager.swift` (`LiveCarPlayDetector`) + `Tests/EyePostureReminderTests/Services/LiveCarPlayDetectorTests.swift`
 - `EyePostureReminder/Services/OverlayManager.swift` + `Tests/EyePostureReminderTests/Services/OverlayManagerExtendedTests.swift`
+- `Extensions/Shared/AppGroupIPCStore.swift` + `Tests/EyePostureReminderTests/Services/AppGroupIPCStoreTests.swift`
 
 ## Anti-Patterns
 - Registering on `NotificationCenter.default` and removing on a different center.

--- a/Extensions/Shared/AppGroupIPCStore.swift
+++ b/Extensions/Shared/AppGroupIPCStore.swift
@@ -89,16 +89,19 @@ public final class AppGroupIPCStore {
 
     private let defaults: UserDefaults?
     private let maxEventCount: Int
+    private let notificationCenter: NotificationCenter
     private let lock = NSLock()
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
 
     public init(
         defaults: UserDefaults? = AppGroupDefaults.resolve(consumer: "AppGroupIPCStore"),
-        maxEventCount: Int = 100
+        maxEventCount: Int = 100,
+        notificationCenter: NotificationCenter = .default
     ) {
         self.defaults = defaults
         self.maxEventCount = max(1, maxEventCount)
+        self.notificationCenter = notificationCenter
     }
 
     public var isAvailable: Bool {
@@ -133,7 +136,7 @@ public final class AppGroupIPCStore {
             return true
         }
         if let changedValue {
-            NotificationCenter.default.post(
+            notificationCenter.post(
                 name: Self.trueInterruptEnabledDidChangeNotification,
                 object: self,
                 userInfo: [Self.trueInterruptEnabledValueUserInfoKey: changedValue]

--- a/Tests/EyePostureReminderTests/Services/AppGroupIPCStoreTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppGroupIPCStoreTests.swift
@@ -63,6 +63,37 @@ final class AppGroupIPCStoreTests: XCTestCase {
         XCTAssertEqual(observedValues, [true])
     }
 
+    func test_trueInterruptEnabled_postsChangeNotificationOnInjectedCenterOnly() throws {
+        let injectedCenter = NotificationCenter()
+        let store = AppGroupIPCStore(defaults: defaults, maxEventCount: 3, notificationCenter: injectedCenter)
+        var injectedCount = 0
+        var defaultCount = 0
+        let injectedObserver = injectedCenter.addObserver(
+            forName: AppGroupIPCStore.trueInterruptEnabledDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            injectedCount += 1
+        }
+        let defaultObserver = NotificationCenter.default.addObserver(
+            forName: AppGroupIPCStore.trueInterruptEnabledDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            defaultCount += 1
+        }
+        defer {
+            injectedCenter.removeObserver(injectedObserver)
+            NotificationCenter.default.removeObserver(defaultObserver)
+        }
+        try store.writeSelection(AppGroupSelectionSnapshot(categoryCount: 0, appCount: 1, lastUpdated: Date()))
+
+        XCTAssertTrue(store.setTrueInterruptEnabled(true))
+
+        XCTAssertEqual(injectedCount, 1)
+        XCTAssertEqual(defaultCount, 0)
+    }
+
     func test_trueInterruptEnabled_doesNotPostChangeNotificationWhenValueUnchanged() {
         var notificationCount = 0
         let observer = NotificationCenter.default.addObserver(


### PR DESCRIPTION
Summary:\n- inject NotificationCenter into AppGroupIPCStore with a .default production fallback\n- route trueInterruptEnabled change notifications through the resolved center\n- add focused seam test proving injected-center delivery and default-center isolation\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462