### PR TITLE
#462 Phase A: OverlayManager settings store factory seam

### DIFF
--- a/EyePostureReminder/Services/OverlayManager.swift
+++ b/EyePostureReminder/Services/OverlayManager.swift
@@ -98,10 +98,12 @@ final class OverlayManager: OverlayPresenting {
 
     typealias AudioManagerFactory = () -> MediaControlling
     typealias NotificationCenterFactory = () -> NotificationCenter
+    typealias SettingsStoreFactory = () -> SettingsPersisting
 
     private let audioManager: MediaControlling
     private let accessibilityNotificationPoster: AccessibilityNotificationPosting
     private let notificationCenter: NotificationCenter
+    private let settingsStore: SettingsPersisting
 
     // MARK: - State
 
@@ -134,12 +136,15 @@ final class OverlayManager: OverlayPresenting {
         audioManager: MediaControlling? = nil,
         accessibilityNotificationPoster: AccessibilityNotificationPosting = LiveAccessibilityNotificationPoster(),
         notificationCenter: NotificationCenter? = nil,
+        settingsStore: SettingsPersisting? = nil,
         makeAudioManager: @escaping AudioManagerFactory = { AudioInterruptionManager() },
-        makeNotificationCenter: @escaping NotificationCenterFactory = { .default }
+        makeNotificationCenter: @escaping NotificationCenterFactory = { .default },
+        makeSettingsStore: @escaping SettingsStoreFactory = { UserDefaults.standard }
     ) {
         self.audioManager = audioManager ?? makeAudioManager()
         self.accessibilityNotificationPoster = accessibilityNotificationPoster
         self.notificationCenter = notificationCenter ?? makeNotificationCenter()
+        self.settingsStore = settingsStore ?? makeSettingsStore()
         sceneActivationObserver = self.notificationCenter.addObserver(
             forName: UIScene.didActivateNotification,
             object: nil,
@@ -213,8 +218,8 @@ final class OverlayManager: OverlayPresenting {
                 duration: duration,
                 hapticsEnabled: hapticsEnabled,
                 onAnalyticsEvent: AnalyticsLogger.log,
-                onSettingsTap: {
-                    UserDefaults.standard.set(true, forKey: AppStorageKey.openSettingsOnLaunch)
+                onSettingsTap: { [settingsStore = self.settingsStore] in
+                    settingsStore.set(true, forKey: AppStorageKey.openSettingsOnLaunch)
                 },
                 onDismiss: { [weak self] in
                     Task { @MainActor in self?.dismissOverlay() }

--- a/Tests/EyePostureReminderTests/Services/OverlayManagerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/OverlayManagerTests.swift
@@ -81,6 +81,34 @@ final class OverlayManagerTests: XCTestCase {
         XCTAssertFalse(factoryCalled)
     }
 
+    func test_init_withoutSettingsStore_usesFactoryOnce() {
+        var factoryCallCount = 0
+        let mockStore = MockSettingsPersisting()
+        _ = OverlayManager(
+            settingsStore: nil,
+            makeSettingsStore: {
+                factoryCallCount += 1
+                return mockStore
+            }
+        )
+
+        XCTAssertEqual(factoryCallCount, 1)
+    }
+
+    func test_init_withSettingsStore_bypassesFactory() {
+        var factoryCalled = false
+        let injectedStore = MockSettingsPersisting()
+        _ = OverlayManager(
+            settingsStore: injectedStore,
+            makeSettingsStore: {
+                factoryCalled = true
+                return MockSettingsPersisting()
+            }
+        )
+
+        XCTAssertFalse(factoryCalled)
+    }
+
     // MARK: - isOverlayVisible — initial state
 
     /// In a headless test environment there is no window scene, so no overlay


### PR DESCRIPTION
## Summary
- inject `settingsStore: SettingsPersisting? = nil` plus `makeSettingsStore` factory fallback into `OverlayManager`
- route `openSettingsOnLaunch` write in `onSettingsTap` closure through injected `settingsStore`
- remove direct `UserDefaults.standard` coupling from `showOverlay` path
- preserve default runtime behavior: factory defaults to `{ UserDefaults.standard }`

## Tests
- `test_init_withoutSettingsStore_usesFactoryOnce`
- `test_init_withSettingsStore_bypassesFactory`

## Validation
- ./scripts/build.sh build ✅
- ./scripts/build.sh test ✅ (1983 tests, 0 failures)

Refs #462