### PR TITLE
#462 Phase A: AppCoordinator ScreenTimeTracker factory seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -168,3 +168,10 @@
 - Key file paths: `EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`, `.squad/decisions/inbox/basher-appcoordinator-dateprovider-factory-seam.md`.
 - For non-singleton collaborator defaults in services, prefer `dependency: Protocol? = nil` plus `makeDependency` fallback factory and resolve once in `init`; add paired fallback-used and explicit-bypass tests to remove eager concrete construction while preserving behavior (`EyePostureReminder/Services/OverlayManager.swift`, `Tests/EyePostureReminderTests/Services/OverlayManagerExtendedTests.swift`).
 - For AppCoordinator scheduling guards, use the instance-resolved `isUITestModeEnabled` flag inside lifecycle methods (`scheduleReminders`) instead of static `AppCoordinator.isUITestMode`; this keeps injected UI-test mode deterministic and avoids mixed global/injected behavior.
+
+## 2026-05-03T17:55:00Z: #462 Phase A — AppCoordinator ScreenTimeTracker Factory Seam (COMPLETED)
+
+- Learned pattern: when coordinators resolve non-singleton service defaults, inject an optional factory closure and resolve once in `init` to eliminate hidden concrete construction while preserving runtime behavior.
+- Architecture decision: `AppCoordinator.resolveScreenTimeTracker` now accepts `makeScreenTimeTracker` and only constructs `ScreenTimeTracker()` on the final production fallback path.
+- Validation: `./scripts/build.sh build` and `./scripts/build.sh test` passed after change.
+- Key file paths: `EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`.

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -183,6 +183,7 @@ final class AppCoordinator: ObservableObject {
         makeNotificationCenter: @escaping () -> NotificationScheduling = { UNUserNotificationCenter.current() },
         overlayManager: OverlayPresenting? = nil,
         screenTimeTracker: ScreenTimeTracking? = nil,
+        makeScreenTimeTracker: (() -> ScreenTimeTracking)? = nil,
         pauseConditionProvider: PauseConditionProviding? = nil,
         makePauseConditionManager: ((SettingsStore) -> PauseConditionProviding)? = nil,
         screenTimeAuthorization: ScreenTimeAuthorizationProviding? = nil,
@@ -232,7 +233,8 @@ final class AppCoordinator: ObservableObject {
         // the accessibility tree between interactions, causing stale element reads.
         self.screenTimeTracker = Self.resolveScreenTimeTracker(
             screenTimeTracker,
-            uiTestMode: resolvedUITestMode
+            uiTestMode: resolvedUITestMode,
+            makeScreenTimeTracker: makeScreenTimeTracker
         )
         self.pauseConditionManager = Self.resolvePauseConditionManager(
             pauseConditionProvider,
@@ -671,10 +673,17 @@ private extension AppCoordinator {
 
     static func resolveScreenTimeTracker(
         _ screenTimeTracker: ScreenTimeTracking?,
-        uiTestMode: Bool
+        uiTestMode: Bool,
+        makeScreenTimeTracker: (() -> ScreenTimeTracking)?
     ) -> ScreenTimeTracking {
         guard let screenTimeTracker else {
-            return uiTestMode ? NoopScreenTimeTracker() : ScreenTimeTracker()
+            guard uiTestMode == false else {
+                return NoopScreenTimeTracker()
+            }
+            if let makeScreenTimeTracker {
+                return makeScreenTimeTracker()
+            }
+            return ScreenTimeTracker()
         }
         return screenTimeTracker
     }

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -153,6 +153,50 @@ final class AppCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.notificationAuthStatus, .denied)
     }
 
+    func test_init_withoutScreenTimeTracker_usesInjectedScreenTimeTrackerFactory() {
+        var factoryCallCount = 0
+        let factoryTracker = MockScreenTimeTracker()
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: ReminderScheduler(notificationCenter: MockNotificationCenter()),
+            notificationCenter: MockNotificationCenter(),
+            screenTimeTracker: nil,
+            makeScreenTimeTracker: {
+                factoryCallCount += 1
+                return factoryTracker
+            },
+            pauseConditionProvider: MockPauseConditionProvider(),
+            uiTestMode: false,
+            ipcStore: MockAppGroupIPCRecorder()
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        XCTAssertEqual(factoryCallCount, 1)
+        XCTAssertTrue(coordinator.screenTimeTracker === factoryTracker)
+    }
+
+    func test_init_withExplicitScreenTimeTracker_doesNotCallScreenTimeTrackerFactory() {
+        var factoryCallCount = 0
+        let injectedTracker = MockScreenTimeTracker()
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: ReminderScheduler(notificationCenter: MockNotificationCenter()),
+            notificationCenter: MockNotificationCenter(),
+            screenTimeTracker: injectedTracker,
+            makeScreenTimeTracker: {
+                factoryCallCount += 1
+                return MockScreenTimeTracker()
+            },
+            pauseConditionProvider: MockPauseConditionProvider(),
+            uiTestMode: false,
+            ipcStore: MockAppGroupIPCRecorder()
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        XCTAssertEqual(factoryCallCount, 0)
+        XCTAssertTrue(coordinator.screenTimeTracker === injectedTracker)
+    }
+
     func test_init_withoutLifecycleNotificationCenter_usesInjectedLifecycleNotificationCenterFactory() {
         var factoryCallCount = 0
         let coordinator = AppCoordinator(


### PR DESCRIPTION
Summary:\n- add optional makeScreenTimeTracker factory seam in AppCoordinator init\n- route resolveScreenTimeTracker through factory when no tracker is injected and UI test mode is off\n- add focused unit tests for factory fallback-used and explicit-injection-bypass behavior\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462