### PR TITLE
Phase A: cache AppDelegate service dependency resolution

### DIFF
--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -19,6 +19,10 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     private let makeNotificationCenter: () -> UserNotificationCenterDelegating
     private let makeMetricKitSubscriber: () -> MetricKitSubscribing
     private let makeSettingsStore: @MainActor () -> SettingsStore
+    private lazy var resolvedNotificationCenter: UserNotificationCenterDelegating =
+        notificationCenter ?? makeNotificationCenter()
+    private lazy var resolvedMetricKitSubscriber: MetricKitSubscribing =
+        metricKitSubscriber ?? makeMetricKitSubscriber()
 
     init(
         notificationCenter: UserNotificationCenterDelegating? = nil,
@@ -79,10 +83,9 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
-        let notificationCenter = notificationCenter ?? makeNotificationCenter()
-        notificationCenter.delegate = self
+        resolvedNotificationCenter.delegate = self
         installUncaughtExceptionHandler()
-        (metricKitSubscriber ?? makeMetricKitSubscriber()).register()
+        resolvedMetricKitSubscriber.register()
 #if DEBUG
         applyUITestLaunchArguments()
 #endif

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -208,6 +208,46 @@ final class AppDelegateTests: XCTestCase {
         XCTAssertEqual(factoryMetricKitSubscriber.registerCallCount, 1)
     }
 
+    func test_didFinishLaunching_calledTwice_reusesFactoryNotificationCenterInstance() {
+        let factoryCenter = MockUserNotificationCenter()
+        let mockMetricKitSubscriber = MockMetricKitSubscriber()
+        var makeNotificationCenterCallCount = 0
+        let sut = AppDelegate(
+            notificationCenter: nil,
+            metricKitSubscriber: mockMetricKitSubscriber,
+            makeNotificationCenter: {
+                makeNotificationCenterCallCount += 1
+                return factoryCenter
+            }
+        )
+
+        _ = sut.application(UIApplication.shared, didFinishLaunchingWithOptions: nil)
+        _ = sut.application(UIApplication.shared, didFinishLaunchingWithOptions: nil)
+
+        XCTAssertEqual(makeNotificationCenterCallCount, 1)
+        XCTAssertTrue(factoryCenter.delegate === sut)
+    }
+
+    func test_didFinishLaunching_calledTwice_reusesFactoryMetricKitSubscriberInstance() {
+        let mockCenter = MockUserNotificationCenter()
+        let factoryMetricKitSubscriber = MockMetricKitSubscriber()
+        var makeMetricKitSubscriberCallCount = 0
+        let sut = AppDelegate(
+            notificationCenter: mockCenter,
+            metricKitSubscriber: nil,
+            makeMetricKitSubscriber: {
+                makeMetricKitSubscriberCallCount += 1
+                return factoryMetricKitSubscriber
+            }
+        )
+
+        _ = sut.application(UIApplication.shared, didFinishLaunchingWithOptions: nil)
+        _ = sut.application(UIApplication.shared, didFinishLaunchingWithOptions: nil)
+
+        XCTAssertEqual(makeMetricKitSubscriberCallCount, 1)
+        XCTAssertEqual(factoryMetricKitSubscriber.registerCallCount, 2)
+    }
+
 #if DEBUG
     func test_init_withoutUITestDefaults_usesInjectedDefaultsFactory() throws {
         let defaults = try makeIsolatedDefaults(suffix: #function)


### PR DESCRIPTION
## Summary
- resolve AppDelegate notification center once and reuse it across lifecycle callbacks
- resolve MetricKit subscriber once and reuse it across lifecycle callbacks
- add unit tests proving factory seams are invoked once even if didFinishLaunching is called multiple times

## Testing
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462