### PR TITLE
#462 Phase A: SettingsViewModel date provider factory seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -175,3 +175,7 @@
 - Architecture decision: `AppCoordinator.resolveScreenTimeTracker` now accepts `makeScreenTimeTracker` and only constructs `ScreenTimeTracker()` on the final production fallback path.
 - Validation: `./scripts/build.sh build` and `./scripts/build.sh test` passed after change.
 - Key file paths: `EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`.
+
+## Learnings
+
+- For view-model constructor clocks, prefer `dateProvider: DateProviding? = nil` plus `makeDateProvider` fallback and resolve once in `init`; add fallback-used and explicit-bypass tests through `snooze(for:)` to remove eager `SystemDateProvider()` coupling while preserving behavior (`EyePostureReminder/ViewModels/SettingsViewModel.swift`, `Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift`).

--- a/.squad/skills/date-provider-default-seam/SKILL.md
+++ b/.squad/skills/date-provider-default-seam/SKILL.md
@@ -37,6 +37,8 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - `Tests/EyePostureReminderTests/Services/AppCoordinatorExtendedTests.swift`
 - `EyePostureReminder/ViewModels/SettingsViewModel.swift`
 - `Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift`
+- `EyePostureReminder/ViewModels/SettingsViewModel.swift` (`makeDateProvider` constructor seam)
+- `Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift` (`snooze(for:)` fallback-used/explicit-bypass assertions)
 - `EyePostureReminder/Services/AppCoordinator.swift`
 - `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`
 - `Tests/EyePostureReminderTests/Services/AppCoordinatorExtendedTests.swift`

--- a/EyePostureReminder/ViewModels/SettingsViewModel.swift
+++ b/EyePostureReminder/ViewModels/SettingsViewModel.swift
@@ -13,6 +13,7 @@ import os
 /// preview and production wire-up minimal while keeping unit tests clean.
 @MainActor
 final class SettingsViewModel: ObservableObject {
+    typealias DateProviderFactory = () -> DateProviding
 
     // MARK: - Snooze Options (M2.3)
 
@@ -302,12 +303,14 @@ final class SettingsViewModel: ObservableObject {
         settings: SettingsStore,
         scheduler: ReminderScheduling,
         maxSnoozeCount: Int = AppConfig.load().features.maxSnoozeCount,
-        dateProvider: DateProviding = SystemDateProvider()
+        dateProvider: DateProviding? = nil,
+        makeDateProvider: @escaping DateProviderFactory = { SystemDateProvider() }
     ) {
+        let resolvedDateProvider = dateProvider ?? makeDateProvider()
         self.settings  = settings
         self.scheduler = scheduler
         self.maxConsecutiveSnoozes = maxSnoozeCount
-        self.dateProvider = dateProvider
+        self.dateProvider = resolvedDateProvider
         settings.objectWillChange
             .sink { [weak self] in self?.objectWillChange.send() }
             .store(in: &cancellables)

--- a/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift
@@ -39,6 +39,20 @@ final class SettingsViewModelExtendedTests: XCTestCase {
         )
     }
 
+    private func makeSUT(
+        maxSnoozeCount: Int = 2,
+        dateProvider: DateProviding? = nil,
+        makeDateProvider: @escaping SettingsViewModel.DateProviderFactory
+    ) -> SettingsViewModel {
+        SettingsViewModel(
+            settings: settings,
+            scheduler: mockScheduler,
+            maxSnoozeCount: maxSnoozeCount,
+            dateProvider: dateProvider,
+            makeDateProvider: makeDateProvider
+        )
+    }
+
     // MARK: - SnoozeOption.allCases
 
     func test_snoozeOptions_countIsThree() {
@@ -379,6 +393,54 @@ final class SettingsViewModelExtendedTests: XCTestCase {
     }
 
     // MARK: - DateProviding seam (deterministic snooze tests)
+
+    @available(*, deprecated, message: "Tests legacy snooze(for:) date-provider seam")
+    func test_init_withoutDateProvider_usesFactoryDateProviderForSnoozeComputation() throws {
+        let fixedNow = Date(timeIntervalSince1970: 2_000_000)
+        let fallbackProvider = MockDateProvider(now: fixedNow)
+        var factoryCallCount = 0
+        let sut = makeSUT(
+            dateProvider: nil,
+            makeDateProvider: {
+                factoryCallCount += 1
+                return fallbackProvider
+            }
+        )
+
+        sut.snooze(for: 5)
+
+        XCTAssertEqual(factoryCallCount, 1, "Factory must be used when explicit dateProvider is absent")
+        let snoozedUntil = try XCTUnwrap(settings.snoozedUntil)
+        XCTAssertEqual(
+            snoozedUntil.timeIntervalSince1970,
+            fixedNow.addingTimeInterval(5 * 60).timeIntervalSince1970,
+            accuracy: 0.001
+        )
+    }
+
+    @available(*, deprecated, message: "Tests legacy snooze(for:) date-provider seam")
+    func test_init_withExplicitDateProvider_bypassesFactory() throws {
+        let explicitNow = Date(timeIntervalSince1970: 3_000_000)
+        let explicitProvider = MockDateProvider(now: explicitNow)
+        var factoryCallCount = 0
+        let sut = makeSUT(
+            dateProvider: explicitProvider,
+            makeDateProvider: {
+                factoryCallCount += 1
+                return MockDateProvider(now: .distantPast)
+            }
+        )
+
+        sut.snooze(for: 5)
+
+        XCTAssertEqual(factoryCallCount, 0, "Factory must not run when explicit dateProvider is provided")
+        let snoozedUntil = try XCTUnwrap(settings.snoozedUntil)
+        XCTAssertEqual(
+            snoozedUntil.timeIntervalSince1970,
+            explicitNow.addingTimeInterval(5 * 60).timeIntervalSince1970,
+            accuracy: 0.001
+        )
+    }
 
     func test_isSnoozeActive_withMockedNow_exactlyAtExpiry_returnsFalse() {
         let fixedNow = Date(timeIntervalSince1970: 1_000_000)


### PR DESCRIPTION
## Summary\n- switch SettingsViewModel date dependency to optional injection + fallback factory seam\n- resolve date provider once in init to remove eager SystemDateProvider default construction\n- add focused fallback-used and explicit-bypass unit tests for the seam\n\n## Validation\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462