### PR TITLE
#462 Phase A: LiveCarPlayDetector NotificationCenter factory seam

### DIFF
--- a/EyePostureReminder/Services/PauseConditionManager.swift
+++ b/EyePostureReminder/Services/PauseConditionManager.swift
@@ -106,6 +106,8 @@ final class LiveFocusStatusDetector: NSObject, FocusStatusDetecting {
 @MainActor
 final class LiveCarPlayDetector: CarPlayDetecting {
 
+    typealias NotificationCenterFactory = () -> NotificationCenter
+
     private(set) var isCarPlayActive: Bool = false
     var onCarPlayChanged: ((Bool) -> Void)?
 
@@ -114,10 +116,11 @@ final class LiveCarPlayDetector: CarPlayDetecting {
     private var observer: NSObjectProtocol?
 
     init(
-        notificationCenter: NotificationCenter = .default,
-        isCarPlayActiveProvider: @escaping () -> Bool = LiveCarPlayDetector.defaultIsCarPlayActive
+        notificationCenter: NotificationCenter? = nil,
+        isCarPlayActiveProvider: @escaping () -> Bool = LiveCarPlayDetector.defaultIsCarPlayActive,
+        makeNotificationCenter: @escaping NotificationCenterFactory = { .default }
     ) {
-        self.notificationCenter = notificationCenter
+        self.notificationCenter = notificationCenter ?? makeNotificationCenter()
         self.isCarPlayActiveProvider = isCarPlayActiveProvider
     }
 

--- a/Tests/EyePostureReminderTests/Services/LiveCarPlayDetectorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/LiveCarPlayDetectorTests.swift
@@ -5,6 +5,34 @@ import XCTest
 @MainActor
 final class LiveCarPlayDetectorTests: XCTestCase {
 
+    func test_init_withoutNotificationCenter_usesFactoryFallback() {
+        var factoryCallCount = 0
+        _ = LiveCarPlayDetector(
+            isCarPlayActiveProvider: { false },
+            makeNotificationCenter: {
+                factoryCallCount += 1
+                return NotificationCenter()
+            }
+        )
+
+        XCTAssertEqual(factoryCallCount, 1)
+    }
+
+    func test_init_withNotificationCenter_bypassesFactoryFallback() {
+        var factoryCallCount = 0
+        let injectedCenter = NotificationCenter()
+        _ = LiveCarPlayDetector(
+            notificationCenter: injectedCenter,
+            isCarPlayActiveProvider: { false },
+            makeNotificationCenter: {
+                factoryCallCount += 1
+                return NotificationCenter()
+            }
+        )
+
+        XCTAssertEqual(factoryCallCount, 0)
+    }
+
     func test_startMonitoring_seedsInitialStateFromInjectedProvider() {
         let notificationCenter = NotificationCenter()
         let detector = LiveCarPlayDetector(


### PR DESCRIPTION
## Summary\n- add optional NotificationCenter injection + factory fallback in LiveCarPlayDetector\n- preserve runtime behavior by defaulting fallback to NotificationCenter.default\n- add focused fallback-used and explicit-bypass unit tests\n\n## Testing\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462