### PR TITLE
#462 Phase A: SelectedAppsState IPC store factory seam

### DIFF
--- a/EyePostureReminder/Services/SelectedAppsState.swift
+++ b/EyePostureReminder/Services/SelectedAppsState.swift
@@ -43,6 +43,7 @@ extension AppGroupIPCStore: SelectedAppsIPCStoring {}
 /// Observable store for the True Interrupt Mode app/category selection.
 @MainActor
 final class SelectedAppsState: ObservableObject {
+    typealias IPCStoreFactory = (UserDefaults?) -> any SelectedAppsIPCStoring
 
     // MARK: App Group + Persistence Keys
 
@@ -71,9 +72,11 @@ final class SelectedAppsState: ObservableObject {
     ///   leaves extension-critical persistence unavailable instead of falling
     ///   back to standard defaults.
     convenience init(
-        defaults: UserDefaults? = AppGroupDefaults.resolve(consumer: "SelectedAppsState")
+        defaults: UserDefaults? = AppGroupDefaults.resolve(consumer: "SelectedAppsState"),
+        ipcStore: (any SelectedAppsIPCStoring)? = nil,
+        makeIPCStore: @escaping IPCStoreFactory = { AppGroupIPCStore(defaults: $0) }
     ) {
-        self.init(ipcStore: AppGroupIPCStore(defaults: defaults))
+        self.init(ipcStore: ipcStore ?? makeIPCStore(defaults))
     }
 
     /// Create a state object backed by an explicit IPC store (for testing).

--- a/Tests/EyePostureReminderTests/Services/SelectedAppsStateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/SelectedAppsStateTests.swift
@@ -104,6 +104,51 @@ final class SelectedAppsStateTests: XCTestCase {
         XCTAssertFalse(sut.isTrueInterruptEnabled)
     }
 
+    func test_init_defaultsFactory_usesFactoryWhenIPCStoreNotProvided() {
+        let expectedMetadata = SelectedAppsMetadata(
+            categoryCount: 1,
+            appCount: 2,
+            lastUpdated: Date(timeIntervalSince1970: 6_000_000)
+        )
+        let fallbackStore = MockSelectedAppsIPCStore()
+        fallbackStore.storedSnapshot = expectedMetadata
+
+        var capturedDefaults: UserDefaults?
+        let sut = SelectedAppsState(
+            defaults: testDefaults,
+            makeIPCStore: { defaults in
+                capturedDefaults = defaults
+                return fallbackStore
+            }
+        )
+
+        XCTAssertTrue(capturedDefaults === testDefaults)
+        XCTAssertEqual(sut.selectionMetadata, expectedMetadata)
+    }
+
+    func test_init_defaultsFactory_bypassesFactoryWhenIPCStoreProvided() {
+        let expectedMetadata = SelectedAppsMetadata(
+            categoryCount: 2,
+            appCount: 1,
+            lastUpdated: Date(timeIntervalSince1970: 7_000_000)
+        )
+        let injectedStore = MockSelectedAppsIPCStore()
+        injectedStore.storedSnapshot = expectedMetadata
+        var factoryCalled = false
+
+        let sut = SelectedAppsState(
+            defaults: testDefaults,
+            ipcStore: injectedStore,
+            makeIPCStore: { _ in
+                factoryCalled = true
+                return MockSelectedAppsIPCStore()
+            }
+        )
+
+        XCTAssertFalse(factoryCalled)
+        XCTAssertEqual(sut.selectionMetadata, expectedMetadata)
+    }
+
     // MARK: - setEnabled
 
     func test_setEnabled_trueWithSelection_persistsToDefaults() {


### PR DESCRIPTION
Summary:
- replace eager AppGroupIPCStore(defaults:) construction in SelectedAppsState convenience init with optional ipcStore injection plus makeIPCStore fallback factory
- preserve runtime behavior by defaulting the factory to AppGroupIPCStore(defaults:)
- add focused tests for fallback-used and explicit-store-bypass paths

Validation:
- ./scripts/build.sh build
- ./scripts/build.sh test

Closes #462