### PR TITLE
#462 Phase A: add SelectedAppsState IPC factory seam

### DIFF
--- a/EyePostureReminder/Services/SelectedAppsState.swift
+++ b/EyePostureReminder/Services/SelectedAppsState.swift
@@ -71,9 +71,13 @@ final class SelectedAppsState: ObservableObject {
     ///   leaves extension-critical persistence unavailable instead of falling
     ///   back to standard defaults.
     convenience init(
-        defaults: UserDefaults? = AppGroupDefaults.resolve(consumer: "SelectedAppsState")
+        defaults: UserDefaults? = AppGroupDefaults.resolve(consumer: "SelectedAppsState"),
+        ipcStore: (any SelectedAppsIPCStoring)? = nil,
+        makeIPCStore: (UserDefaults?) -> any SelectedAppsIPCStoring = { defaults in
+            AppGroupIPCStore(defaults: defaults)
+        }
     ) {
-        self.init(ipcStore: AppGroupIPCStore(defaults: defaults))
+        self.init(ipcStore: ipcStore ?? makeIPCStore(defaults))
     }
 
     /// Create a state object backed by an explicit IPC store (for testing).

--- a/Tests/EyePostureReminderTests/Services/SelectedAppsStateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/SelectedAppsStateTests.swift
@@ -104,6 +104,58 @@ final class SelectedAppsStateTests: XCTestCase {
         XCTAssertFalse(sut.isTrueInterruptEnabled)
     }
 
+    func test_init_withExplicitIPCStore_bypassesFactory() {
+        let expectedMetadata = SelectedAppsMetadata(
+            categoryCount: 1,
+            appCount: 2,
+            lastUpdated: Date(timeIntervalSince1970: 6_000_000)
+        )
+        let explicitStore = MockSelectedAppsIPCStore()
+        explicitStore.storedSnapshot = expectedMetadata
+        explicitStore.storedEnabled = true
+        var factoryCallCount = 0
+
+        let sut = SelectedAppsState(
+            defaults: testDefaults,
+            ipcStore: explicitStore,
+            makeIPCStore: { _ in
+                factoryCallCount += 1
+                return MockSelectedAppsIPCStore()
+            }
+        )
+
+        XCTAssertEqual(factoryCallCount, 0)
+        XCTAssertEqual(sut.selectionMetadata, expectedMetadata)
+        XCTAssertTrue(sut.isTrueInterruptEnabled)
+    }
+
+    func test_init_withoutExplicitIPCStore_usesFactoryWithPassedDefaults() {
+        let expectedMetadata = SelectedAppsMetadata(
+            categoryCount: 2,
+            appCount: 1,
+            lastUpdated: Date(timeIntervalSince1970: 7_000_000)
+        )
+        let factoryStore = MockSelectedAppsIPCStore()
+        factoryStore.storedSnapshot = expectedMetadata
+        factoryStore.storedEnabled = true
+        var capturedDefaults: UserDefaults?
+        var factoryCallCount = 0
+
+        let sut = SelectedAppsState(
+            defaults: testDefaults,
+            makeIPCStore: { defaults in
+                factoryCallCount += 1
+                capturedDefaults = defaults
+                return factoryStore
+            }
+        )
+
+        XCTAssertEqual(factoryCallCount, 1)
+        XCTAssertTrue(capturedDefaults === testDefaults)
+        XCTAssertEqual(sut.selectionMetadata, expectedMetadata)
+        XCTAssertTrue(sut.isTrueInterruptEnabled)
+    }
+
     // MARK: - setEnabled
 
     func test_setEnabled_trueWithSelection_persistsToDefaults() {


### PR DESCRIPTION
## Summary
- add a tiny DI seam in SelectedAppsState convenience init via optional ipcStore override and makeIPCStore fallback factory
- preserve production behavior by defaulting the factory to AppGroupIPCStore(defaults:)
- add focused unit tests proving explicit-store bypass and fallback-factory path with passed defaults

## Testing
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462
