### PR TITLE
#462 Phase A: OnboardingPermissionView notification-center factory seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -179,3 +179,7 @@
 ## Learnings
 
 - For view-model constructor clocks, prefer `dateProvider: DateProviding? = nil` plus `makeDateProvider` fallback and resolve once in `init`; add fallback-used and explicit-bypass tests through `snooze(for:)` to remove eager `SystemDateProvider()` coupling while preserving behavior (`EyePostureReminder/ViewModels/SettingsViewModel.swift`, `Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift`).
+- For singleton-backed dependencies inside onboarding permission flow, prefer `notificationCenter: NotificationScheduling? = nil` plus `makeNotificationCenter` fallback and resolve once in `init`; this removes eager `UNUserNotificationCenter.current()` default-argument coupling while preserving runtime behavior.
+- Keep seam tests surgical in view-layer DI slices: one fallback-used assertion and one explicit-injection-bypass assertion are sufficient when body rendering already has coverage.
+- User preference reinforced: continue #462 with tiny DI/SRP micro-slices and always validate with `./scripts/build.sh build` and `./scripts/build.sh test`.
+- Key file paths: `EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift`, `Tests/EyePostureReminderTests/Views/OnboardingViewTests.swift`, `.squad/skills/notification-center-factory-seam/SKILL.md`.

--- a/.squad/skills/notification-center-factory-seam/SKILL.md
+++ b/.squad/skills/notification-center-factory-seam/SKILL.md
@@ -18,6 +18,8 @@ Use when a coordinator/service initializer defaults a notification dependency di
 ## Examples
 - `EyePostureReminder/Services/AppCoordinator.swift`
 - `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`
+- `EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift`
+- `Tests/EyePostureReminderTests/Views/OnboardingViewTests.swift`
 
 ## Anti-Patterns
 - `notificationCenter: NotificationScheduling = UNUserNotificationCenter.current()` in initializer signatures.

--- a/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
@@ -16,10 +16,11 @@ struct OnboardingPermissionView: View {
     @Environment(\.accessibilityEnabled) private var accessibilityEnabled
 
     init(onNext: @escaping () -> Void,
-         notificationCenter: NotificationScheduling = UNUserNotificationCenter.current(),
+         notificationCenter: NotificationScheduling? = nil,
+         makeNotificationCenter: @escaping () -> NotificationScheduling = { UNUserNotificationCenter.current() },
          accessibilityEnabledOverride: Bool? = nil) {
         self.onNext = onNext
-        self.notificationCenter = notificationCenter
+        self.notificationCenter = notificationCenter ?? makeNotificationCenter()
         self.accessibilityEnabledOverride = accessibilityEnabledOverride
     }
 

--- a/Tests/EyePostureReminderTests/Views/OnboardingViewTests.swift
+++ b/Tests/EyePostureReminderTests/Views/OnboardingViewTests.swift
@@ -135,6 +135,38 @@ final class OnboardingViewTests: XCTestCase {
         // If it compiles and runs, the DI seam works.
     }
 
+    /// When no notification center is injected, the fallback factory is used once.
+    func test_permissionView_notificationCenterFactory_usedWhenDependencyMissing() {
+        var factoryCallCount = 0
+        let view = OnboardingPermissionView(
+            onNext: {},
+            notificationCenter: nil,
+            makeNotificationCenter: {
+                factoryCallCount += 1
+                return MockNotificationCenter()
+            },
+            accessibilityEnabledOverride: false
+        )
+        _ = view.body
+        XCTAssertEqual(factoryCallCount, 1)
+    }
+
+    /// When a notification center is injected, the fallback factory is bypassed.
+    func test_permissionView_notificationCenterFactory_bypassedWhenDependencyProvided() {
+        var factoryCallCount = 0
+        let view = OnboardingPermissionView(
+            onNext: {},
+            notificationCenter: MockNotificationCenter(),
+            makeNotificationCenter: {
+                factoryCallCount += 1
+                return MockNotificationCenter()
+            },
+            accessibilityEnabledOverride: false
+        )
+        _ = view.body
+        XCTAssertEqual(factoryCallCount, 0)
+    }
+
     /// The skip button has a known accessibility identifier.
     func test_permissionView_skipButton_accessibilityIdentifier() {
         let mock = MockNotificationCenter()


### PR DESCRIPTION
Summary:
- make OnboardingPermissionView notification center dependency optional with makeNotificationCenter fallback factory
- resolve dependency once in init to remove eager singleton default-argument coupling
- add focused seam tests for fallback-used and injected-bypass behavior

Validation:
- ./scripts/build.sh build passed
- ./scripts/build.sh test passed

Refs: #462