### PR TITLE
#462 Phase A: MetricKitSubscriber logger factory seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -183,3 +183,14 @@
 - Keep seam tests surgical in view-layer DI slices: one fallback-used assertion and one explicit-injection-bypass assertion are sufficient when body rendering already has coverage.
 - User preference reinforced: continue #462 with tiny DI/SRP micro-slices and always validate with `./scripts/build.sh build` and `./scripts/build.sh test`.
 - Key file paths: `EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift`, `Tests/EyePostureReminderTests/Views/OnboardingViewTests.swift`, `.squad/skills/notification-center-factory-seam/SKILL.md`.
+
+## 2026-05-03: #462 Phase A — MetricKitSubscriber Logger Factory Seam (COMPLETED)
+
+- Branch: `basher/462-phasea-metrickit-logger-factory-seam`
+- Slice: Replaced eager `LifecycleMetricKitLogger()` initializer default with optional logger + `makeLogger` fallback factory in `MetricKitSubscriber`.
+- Validation: `./scripts/build.sh build` ✅, `./scripts/build.sh test` ✅.
+- Scope: `EyePostureReminder/Services/MetricKitSubscriber.swift`, `Tests/EyePostureReminderTests/Services/MetricKitSubscriberTests.swift`.
+
+## Learnings
+
+- For singleton-backed logging collaborators, prefer `logger: Protocol? = nil` plus `makeLogger` fallback factory and resolve once in `init`; add fallback-used and explicit-bypass tests around a public behavior (`register`) to remove eager concrete logger coupling while preserving runtime output.

--- a/EyePostureReminder/Services/MetricKitSubscriber.swift
+++ b/EyePostureReminder/Services/MetricKitSubscriber.swift
@@ -55,10 +55,11 @@ final class MetricKitSubscriber: NSObject, MXMetricManagerSubscriber {
     init(
         metricManager: MetricKitManaging? = nil,
         makeMetricManager: @escaping () -> MetricKitManaging = { MXMetricManager.shared },
-        logger: MetricKitLogging = LifecycleMetricKitLogger()
+        logger: MetricKitLogging? = nil,
+        makeLogger: @escaping () -> MetricKitLogging = { LifecycleMetricKitLogger() }
     ) {
         self.metricManager = metricManager ?? makeMetricManager()
-        self.logger = logger
+        self.logger = logger ?? makeLogger()
         super.init()
     }
 

--- a/Tests/EyePostureReminderTests/Services/MetricKitSubscriberTests.swift
+++ b/Tests/EyePostureReminderTests/Services/MetricKitSubscriberTests.swift
@@ -132,6 +132,49 @@ final class MetricKitSubscriberTests: XCTestCase {
         XCTAssertEqual(fallbackManager.addCallCount, 0)
     }
 
+    func test_register_withNilLogger_usesFactoryLogger() {
+        let manager = MockMetricKitManager()
+        let fallbackLogger = MockMetricKitLogger()
+        var factoryCallCount = 0
+        let subscriber = MetricKitSubscriber(
+            metricManager: manager,
+            logger: nil,
+            makeLogger: {
+                factoryCallCount += 1
+                return fallbackLogger
+            }
+        )
+
+        subscriber.register()
+
+        XCTAssertEqual(factoryCallCount, 1)
+        XCTAssertEqual(
+            fallbackLogger.infoMessages,
+            ["MetricKit subscriber registered"]
+        )
+    }
+
+    func test_register_withInjectedLogger_bypassesFactory() {
+        let manager = MockMetricKitManager()
+        let logger = MockMetricKitLogger()
+        let fallbackLogger = MockMetricKitLogger()
+        var factoryCallCount = 0
+        let subscriber = MetricKitSubscriber(
+            metricManager: manager,
+            logger: logger,
+            makeLogger: {
+                factoryCallCount += 1
+                return fallbackLogger
+            }
+        )
+
+        subscriber.register()
+
+        XCTAssertEqual(factoryCallCount, 0)
+        XCTAssertEqual(logger.infoMessages, ["MetricKit subscriber registered"])
+        XCTAssertTrue(fallbackLogger.infoMessages.isEmpty)
+    }
+
     // MARK: - didReceive([MXMetricPayload])
 
     /// Empty payload array must be handled gracefully — the `for` loop


### PR DESCRIPTION
Summary:\n- replace eager logger default argument with optional logger plus makeLogger fallback factory in MetricKitSubscriber\n- resolve logger once in init to preserve behavior while removing eager coupling\n- add focused seam tests for fallback-used and injected-bypass logger paths\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462