### PR TITLE
#462 Phase A: ScreenTimeTracker app-state factory seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -194,3 +194,7 @@
 ## Learnings
 
 - For singleton-backed logging collaborators, prefer `logger: Protocol? = nil` plus `makeLogger` fallback factory and resolve once in `init`; add fallback-used and explicit-bypass tests around a public behavior (`register`) to remove eager concrete logger coupling while preserving runtime output.
+- For app-state lifecycle seams, prefer `appStateProvider: AppStateProviding? = nil` plus `makeAppStateProvider` fallback and resolve once in `init`; this removes direct `UIApplication.shared` coupling while preserving `startIfActive()` behavior.
+- Architecture decision: keep this #462 slice scoped to one constructor seam in `ScreenTimeTracker` and validate through existing timer-threshold behavior tests to avoid lifecycle callback regressions.
+- User preference reinforced: keep every #462 Phase A PR surgical (single DI/SRP improvement + focused unit assertions + full `./scripts/build.sh build` and `./scripts/build.sh test`).
+- Key file paths: `EyePostureReminder/Services/ScreenTimeTracker.swift`, `Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift`.

--- a/.squad/skills/app-state-provider-factory-seam/SKILL.md
+++ b/.squad/skills/app-state-provider-factory-seam/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: "app-state-provider-factory-seam"
+description: "Inject UIApplication state provider with optional factory fallback for deterministic lifecycle tests"
+domain: "testing"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+Use when a lifecycle-aware service reads `UIApplication.shared` directly for foreground/background checks and you need deterministic tests.
+
+## Patterns
+- Keep the protocol seam (`AppStateProviding`) for explicit injection.
+- Add optional fallback factory injection (`makeAppStateProvider`) and resolve once in `init`.
+- Preserve production behavior with `UIApplication.shared` only on fallback.
+- Add two focused tests:
+  - fallback factory used when provider is nil
+  - explicit provider bypasses factory
+
+## Examples
+- `EyePostureReminder/Services/ScreenTimeTracker.swift`
+- `Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift`
+
+## Anti-Patterns
+- Direct `UIApplication.shared` reads in constructor paths with no seam coverage.
+- Testing private dependency state instead of public behavior (`startIfActive()` callback path).

--- a/EyePostureReminder/Services/ScreenTimeTracker.swift
+++ b/EyePostureReminder/Services/ScreenTimeTracker.swift
@@ -105,10 +105,14 @@ final class ScreenTimeTracker: ScreenTimeTracking {
     ///   - appStateProvider: Provides `UIApplication.applicationState` for `startIfActive()`.
     ///     Defaults to `UIApplication.shared`. Inject a mock to drive active/background behavior
     ///     in unit tests without depending on the real UIApplication singleton.
+    ///   - makeAppStateProvider: Optional fallback factory used when `appStateProvider` is nil.
+    ///     Keeps production behavior (`UIApplication.shared`) while enabling deterministic
+    ///     fallback-path tests.
     init(
         resetGracePeriod: TimeInterval = 5.0,
         lifecycleNotificationCenter: NotificationCenter = .default,
-        appStateProvider: AppStateProviding? = nil
+        appStateProvider: AppStateProviding? = nil,
+        makeAppStateProvider: (() -> AppStateProviding)? = nil
     ) {
         if resetGracePeriod < 0 {
             Logger.scheduling.warning(
@@ -119,7 +123,8 @@ final class ScreenTimeTracker: ScreenTimeTracking {
             self.resetGracePeriod = resetGracePeriod
         }
         self.lifecycleNotificationCenter = lifecycleNotificationCenter
-        self.appStateProvider = appStateProvider ?? UIApplication.shared
+        let resolvedAppStateProvider = makeAppStateProvider ?? { UIApplication.shared }
+        self.appStateProvider = appStateProvider ?? resolvedAppStateProvider()
         for type in ReminderType.allCases {
             elapsed[type] = 0
         }

--- a/Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift
@@ -228,6 +228,58 @@ final class ScreenTimeTrackerTests: XCTestCase {
         XCTAssertFalse(fired, "startIfActive must be a no-op when appStateProvider returns .background")
     }
 
+    func test_startIfActive_withNilAppStateProvider_usesFactoryProvider() async {
+        let center = NotificationCenter()
+        var factoryCallCount = 0
+        let tracker = ScreenTimeTracker(
+            resetGracePeriod: 5.0,
+            lifecycleNotificationCenter: center,
+            appStateProvider: nil,
+            makeAppStateProvider: {
+                factoryCallCount += 1
+                return MockAppStateProvider(state: .active)
+            }
+        )
+        defer { tracker.stop() }
+
+        tracker.setThreshold(1.0, for: .eyes)
+        let exp = expectation(description: "threshold fires via factory app state provider")
+        tracker.onThresholdReached = { type in
+            if type == .eyes { exp.fulfill() }
+        }
+
+        tracker.startIfActive()
+
+        await fulfillment(of: [exp], timeout: 4.0)
+        XCTAssertEqual(factoryCallCount, 1)
+    }
+
+    func test_startIfActive_withInjectedAppStateProvider_bypassesFactory() async {
+        let center = NotificationCenter()
+        var factoryCallCount = 0
+        let tracker = ScreenTimeTracker(
+            resetGracePeriod: 5.0,
+            lifecycleNotificationCenter: center,
+            appStateProvider: MockAppStateProvider(state: .active),
+            makeAppStateProvider: {
+                factoryCallCount += 1
+                return MockAppStateProvider(state: .background)
+            }
+        )
+        defer { tracker.stop() }
+
+        tracker.setThreshold(1.0, for: .eyes)
+        let exp = expectation(description: "threshold fires via injected app state provider")
+        tracker.onThresholdReached = { type in
+            if type == .eyes { exp.fulfill() }
+        }
+
+        tracker.startIfActive()
+
+        await fulfillment(of: [exp], timeout: 4.0)
+        XCTAssertEqual(factoryCallCount, 0)
+    }
+
     // MARK: - onThresholdReached callback
 
     func test_onThresholdReached_canBeAssigned() {


### PR DESCRIPTION
Summary:\n- replace direct fallback to UIApplication.shared in ScreenTimeTracker init with optional appStateProvider plus makeAppStateProvider factory seam\n- resolve appStateProvider once in init to preserve production behavior while removing direct singleton coupling\n- add focused seam tests for fallback-used and injected-bypass paths through startIfActive threshold behavior\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462