### PR TITLE
refactor: route SettingsStore reset config through DI seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -201,3 +201,9 @@
 - For AppCoordinator scene-activation checks in notification handling, inject `hasActiveSceneProvider: (() -> Bool)?` plus optional `makeHasActiveSceneProvider` and resolve once in `init`; default to `UIApplication.shared.connectedScenes` inside `init` (not default args) to stay Swift 6 actor-safe while removing hidden global UIKit reads (`EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`).
 - For view-model scalar config defaults, prefer `value: Int? = nil` plus `makeValue` fallback factory resolved once in `init`; add fallback-used and explicit-bypass tests to remove eager `AppConfig.load()` default-argument coupling while preserving behavior (`EyePostureReminder/ViewModels/SettingsViewModel.swift`, `Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift`).
 - For config-heavy stores, prefer `config: AppConfig? = nil` plus `makeConfig` fallback resolved once in `init`; add fallback-used and explicit-bypass tests to remove eager `AppConfig.load()` default-argument coupling while preserving defaults behavior (`EyePostureReminder/Models/SettingsStore.swift`, `Tests/EyePostureReminderTests/Models/SettingsStoreTests.swift`).
+
+## Learnings
+
+### 2026-05-03T20:10:00Z: #462 Phase A resetToDefaults config seam
+- `SettingsStore.resetToDefaults()` now resolves config via the init-injected `makeConfig` seam when no explicit config is passed, removing eager `AppConfig.load()` from the method signature while keeping production defaults behavior.
+- Added focused unit tests covering factory-path reset and explicit-config reset bypass.

--- a/EyePostureReminder/Models/SettingsStore.swift
+++ b/EyePostureReminder/Models/SettingsStore.swift
@@ -163,6 +163,7 @@ final class SettingsStore: ObservableObject {
     // MARK: - Init
 
     private let store: SettingsPersisting
+    private let makeConfig: AppConfigFactory
 
     typealias SettingsStoreFactory = () -> SettingsPersisting
     typealias AppConfigFactory = () -> AppConfig
@@ -174,8 +175,15 @@ final class SettingsStore: ObservableObject {
         makeConfig: @escaping AppConfigFactory = { AppConfig.load() }
     ) {
         let resolvedStore = store ?? makeStore()
-        let resolvedConfig = config ?? makeConfig()
+        let resolvedConfigFactory: AppConfigFactory = {
+            if let config {
+                return config
+            }
+            return makeConfig()
+        }
+        let resolvedConfig = resolvedConfigFactory()
         self.store = resolvedStore
+        self.makeConfig = resolvedConfigFactory
         let defaultEyesBreakDuration = Self.sanitizedBreakDuration(
             resolvedConfig.defaults.eyeBreakDuration,
             defaultValue: AppConfig.fallback.defaults.eyeBreakDuration,
@@ -230,19 +238,20 @@ final class SettingsStore: ObservableObject {
     // MARK: - Reset to Defaults
 
     /// Restores all user-configurable settings to the values specified in `defaults.json`.
-    func resetToDefaults(config: AppConfig = AppConfig.load()) {
-        globalEnabled = config.features.globalEnabledDefault
+    func resetToDefaults(config: AppConfig? = nil) {
+        let resolvedConfig = config ?? makeConfig()
+        globalEnabled = resolvedConfig.features.globalEnabledDefault
         eyesEnabled = true
         postureEnabled = true
-        eyesInterval = config.defaults.eyeInterval
+        eyesInterval = resolvedConfig.defaults.eyeInterval
         eyesBreakDuration = Self.sanitizedBreakDuration(
-            config.defaults.eyeBreakDuration,
+            resolvedConfig.defaults.eyeBreakDuration,
             defaultValue: AppConfig.fallback.defaults.eyeBreakDuration,
             key: Keys.eyesBreakDuration
         )
-        postureInterval = config.defaults.postureInterval
+        postureInterval = resolvedConfig.defaults.postureInterval
         postureBreakDuration = Self.sanitizedBreakDuration(
-            config.defaults.postureBreakDuration,
+            resolvedConfig.defaults.postureBreakDuration,
             defaultValue: AppConfig.fallback.defaults.postureBreakDuration,
             key: Keys.postureBreakDuration
         )

--- a/Tests/EyePostureReminderTests/Models/SettingsStoreConfigTests.swift
+++ b/Tests/EyePostureReminderTests/Models/SettingsStoreConfigTests.swift
@@ -7,8 +7,8 @@ import XCTest
 ///
 /// ## Expected SettingsStore API (per decisions.md):
 /// ```swift
-/// init(store: SettingsPersisting = UserDefaults.standard, config: AppConfig = .load())
-/// func resetToDefaults(config: AppConfig = .load())
+/// init(store: SettingsPersisting? = nil, makeStore: () -> SettingsPersisting, config: AppConfig? = nil, makeConfig: () -> AppConfig)
+/// func resetToDefaults(config: AppConfig? = nil)
 /// ```
 @MainActor
 final class SettingsStoreConfigTests: XCTestCase {

--- a/Tests/EyePostureReminderTests/Models/SettingsStoreTests.swift
+++ b/Tests/EyePostureReminderTests/Models/SettingsStoreTests.swift
@@ -149,6 +149,71 @@ final class SettingsStoreTests: XCTestCase {
         XCTAssertTrue(reloaded.globalEnabled)
     }
 
+    func test_resetToDefaults_withoutConfig_usesInjectedConfigFactory() {
+        let injectedConfig = AppConfig(
+            defaults: AppConfig.Defaults(
+                eyeInterval: 777,
+                eyeBreakDuration: 20,
+                postureInterval: 888,
+                postureBreakDuration: 10
+            ),
+            features: AppConfig.Features(globalEnabledDefault: false, maxSnoozeCount: 3)
+        )
+        var factoryCallCount = 0
+        let reloaded = SettingsStore(
+            store: MockSettingsPersisting(),
+            config: nil,
+            makeConfig: {
+                factoryCallCount += 1
+                return injectedConfig
+            }
+        )
+        reloaded.eyesInterval = 1200
+
+        reloaded.resetToDefaults()
+
+        XCTAssertEqual(factoryCallCount, 2)
+        XCTAssertEqual(reloaded.eyesInterval, 777)
+        XCTAssertFalse(reloaded.globalEnabled)
+    }
+
+    func test_resetToDefaults_withExplicitConfig_doesNotCallInjectedConfigFactory() {
+        let seededConfig = AppConfig(
+            defaults: AppConfig.Defaults(
+                eyeInterval: 1200,
+                eyeBreakDuration: 20,
+                postureInterval: 1800,
+                postureBreakDuration: 10
+            ),
+            features: AppConfig.Features(globalEnabledDefault: true, maxSnoozeCount: 3)
+        )
+        let resetConfig = AppConfig(
+            defaults: AppConfig.Defaults(
+                eyeInterval: 600,
+                eyeBreakDuration: 20,
+                postureInterval: 900,
+                postureBreakDuration: 10
+            ),
+            features: AppConfig.Features(globalEnabledDefault: false, maxSnoozeCount: 3)
+        )
+        var didCallFactory = false
+        let reloaded = SettingsStore(
+            store: MockSettingsPersisting(),
+            config: seededConfig,
+            makeConfig: {
+                didCallFactory = true
+                return .fallback
+            }
+        )
+
+        reloaded.resetToDefaults(config: resetConfig)
+
+        XCTAssertFalse(didCallFactory)
+        XCTAssertEqual(reloaded.eyesInterval, 600)
+        XCTAssertEqual(reloaded.postureInterval, 900)
+        XCTAssertFalse(reloaded.globalEnabled)
+    }
+
     // MARK: - Persistence: Booleans
 
     func test_setGlobalEnabled_false_persistsAndLoads() {


### PR DESCRIPTION
## Summary
- remove eager AppConfig.load() default argument from SettingsStore.resetToDefaults
- resolve reset config via the init-injected makeConfig seam when no explicit config is provided
- add focused unit tests for reset factory usage and explicit-config bypass

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462