### PR TITLE
refactor: inject ShieldSession triggeredAt DI seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -207,3 +207,4 @@
 ### 2026-05-03T20:10:00Z: #462 Phase A resetToDefaults config seam
 - `SettingsStore.resetToDefaults()` now resolves config via the init-injected `makeConfig` seam when no explicit config is passed, removing eager `AppConfig.load()` from the method signature while keeping production defaults behavior.
 - Added focused unit tests covering factory-path reset and explicit-config reset bypass.
+- For value-type convenience initializers with `Date()` defaults, prefer `timestamp: Date? = nil` plus `makeTimestamp` fallback factory and resolve once in the initializer body; add paired tests for fallback-used and explicit-date-bypass (`EyePostureReminder/Services/ScreenTimeShieldTypes.swift`, `Tests/EyePostureReminderTests/Services/DeviceActivityMonitorTests.swift`).

--- a/.squad/skills/date-provider-default-seam/SKILL.md
+++ b/.squad/skills/date-provider-default-seam/SKILL.md
@@ -24,6 +24,7 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - For lifecycle session metrics initialized during scheduling, seed `sessionStartTime` from `dateProvider.now` (not `Date()`) so `appSessionEnd` duration assertions stay deterministic under injected clocks.
 - For launch-readiness latency metrics, capture foreground-entry timestamps and latency deltas from the same injected `dateProvider.now` seam; in tests, advance `MockDateProvider.now` during an awaited dependency callback to prove wall-clock time is not used.
 - For constructor-level clock defaults, prefer `dateProvider: DateProviding? = nil` plus `makeDateProvider` fallback and resolve once in `init`; add paired fallback-used and explicit-bypass tests that assert behavior through a public method.
+- For value-type convenience initializers that expose `Date()` defaults, switch to `timestamp: Date? = nil` plus `makeTimestamp` fallback factory and resolve in-body (`timestamp ?? makeTimestamp()`); add fallback-used and explicit-date-bypass tests.
 
 ## Benefits
 - Production path no longer depends on implicit `Date()` globals.
@@ -44,3 +45,5 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - `Tests/EyePostureReminderTests/Services/AppCoordinatorExtendedTests.swift`
 - `EyePostureReminder/Services/AppCoordinator.swift` (`makeDateProvider` seam)
 - `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift` (`cancelAllReminders` fallback/bypass assertions)
+- `EyePostureReminder/Services/ScreenTimeShieldTypes.swift` (`makeTriggeredAt` convenience-init seam)
+- `Tests/EyePostureReminderTests/Services/DeviceActivityMonitorTests.swift` (`ShieldSession` fallback/bypass assertions)

--- a/EyePostureReminder/Services/ScreenTimeShieldTypes.swift
+++ b/EyePostureReminder/Services/ScreenTimeShieldTypes.swift
@@ -63,6 +63,8 @@ struct ShieldSession: Sendable, Equatable {
 // MARK: - ShieldSession + ReminderType
 
 extension ShieldSession {
+    typealias TriggeredAtFactory = () -> Date
+
     /// Convenience initialiser that derives the `ShieldTriggerReason` from a `ReminderType`.
     ///
     /// Used by `AppCoordinator` when bridging the `ScreenTimeTracker.onThresholdReached`
@@ -71,9 +73,16 @@ extension ShieldSession {
     /// - Parameters:
     ///   - type: The reminder type that reached its threshold.
     ///   - durationSeconds: Break duration in seconds (read from `SettingsStore`).
-    ///   - triggeredAt: Wall-clock trigger time. Defaults to `Date()`.
-    init(type: ReminderType, durationSeconds: TimeInterval, triggeredAt: Date = Date()) {
-        self.init(reason: type.shieldReason, durationSeconds: durationSeconds, triggeredAt: triggeredAt)
+    ///   - triggeredAt: Wall-clock trigger time. Uses `makeTriggeredAt()` when `nil`.
+    ///   - makeTriggeredAt: Factory for the default trigger time.
+    init(
+        type: ReminderType,
+        durationSeconds: TimeInterval,
+        triggeredAt: Date? = nil,
+        makeTriggeredAt: TriggeredAtFactory = Date.init
+    ) {
+        let resolvedTriggeredAt = triggeredAt ?? makeTriggeredAt()
+        self.init(reason: type.shieldReason, durationSeconds: durationSeconds, triggeredAt: resolvedTriggeredAt)
     }
 }
 

--- a/Tests/EyePostureReminderTests/Services/DeviceActivityMonitorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/DeviceActivityMonitorTests.swift
@@ -82,6 +82,37 @@ final class DeviceActivityMonitorTests: XCTestCase {
         XCTAssertEqual(session.triggeredAt, fixedDate)
     }
 
+    func test_shieldSession_fromType_whenTriggeredAtMissing_usesFactory() {
+        var factoryCallCount = 0
+        let expectedDate = Date(timeIntervalSince1970: 1_234_567)
+        let session = ShieldSession(
+            type: .eyes,
+            durationSeconds: 20,
+            makeTriggeredAt: {
+                factoryCallCount += 1
+                return expectedDate
+            }
+        )
+        XCTAssertEqual(session.triggeredAt, expectedDate)
+        XCTAssertEqual(factoryCallCount, 1)
+    }
+
+    func test_shieldSession_fromType_whenTriggeredAtProvided_bypassesFactory() {
+        var factoryCallCount = 0
+        let providedDate = Date(timeIntervalSince1970: 2_468_000)
+        let session = ShieldSession(
+            type: .posture,
+            durationSeconds: 20,
+            triggeredAt: providedDate,
+            makeTriggeredAt: {
+                factoryCallCount += 1
+                return Date(timeIntervalSince1970: 0)
+            }
+        )
+        XCTAssertEqual(session.triggeredAt, providedDate)
+        XCTAssertEqual(factoryCallCount, 0)
+    }
+
     func test_shieldSession_fromType_defaultsTriggeredAtToNow() {
         let before = Date()
         let session = ShieldSession(type: .eyes, durationSeconds: 20)


### PR DESCRIPTION
## Summary
- replace eager Date() default in ShieldSession convenience init with optional triggeredAt plus makeTriggeredAt fallback factory
- keep behavior unchanged by defaulting the factory to Date.init
- add focused unit tests proving fallback factory use and explicit-date factory bypass

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462