### PR TITLE
#462 Phase A micro-slice: CarPlay audio session DI seam

### DIFF
--- a/.squad/agents/rusty/history.md
+++ b/.squad/agents/rusty/history.md
@@ -329,3 +329,9 @@ Result: **10/10 passed**
 
 **Final merge verdict at handoff:**
 - **REJECT FOR NOW** — residual risk remains in Settings shard stability despite remediation closure for #497/#498/#499 and overlay/dark-mode improvements.
+
+### 2026-05-03: #462 Phase A Micro-slice — LiveCarPlayDetector AudioSession seam
+
+- Added an `AudioSessionRouting` protocol seam in `PauseConditionManager.swift` and extended `AVAudioSession` to conform, removing direct `AVAudioSession.sharedInstance()` access from `LiveCarPlayDetector` static route logic.
+- `LiveCarPlayDetector` now resolves dependencies with optional injection + factory fallback (`audioSession ?? makeAudioSession()`), preserving existing behavior while improving DI clarity.
+- Added focused seam coverage in `LiveCarPlayDetectorTests` for factory fallback and injected bypass paths, alongside existing behavior tests.

--- a/.squad/skills/audio-session-factory-seam/SKILL.md
+++ b/.squad/skills/audio-session-factory-seam/SKILL.md
@@ -14,6 +14,7 @@ Use when a service reads `AVAudioSession.sharedInstance()` directly in runtime m
 - Make `AVAudioSession` conform directly.
 - Inject `audioSession: AudioSessionControlling? = nil` plus `makeAudioSession` fallback.
 - Resolve once in `init` (`audioSession ?? makeAudioSession()`), then reuse.
+- For detector-style services, allow an optional state-provider closure override; default it to a helper that reads the resolved injected/factory audio session.
 - Add focused tests for real behavior calls and seam tests for fallback-used/injected-bypass.
 
 ## Anti-Patterns

--- a/EyePostureReminder/Services/PauseConditionManager.swift
+++ b/EyePostureReminder/Services/PauseConditionManager.swift
@@ -33,6 +33,12 @@ protocol CarPlayDetecting: AnyObject {
     func stopMonitoring()
 }
 
+protocol AudioSessionRouting {
+    var currentRoute: AVAudioSessionRouteDescription { get }
+}
+
+extension AVAudioSession: AudioSessionRouting {}
+
 @MainActor
 protocol DrivingActivityDetecting: AnyObject {
     var isDriving: Bool { get }
@@ -106,6 +112,7 @@ final class LiveFocusStatusDetector: NSObject, FocusStatusDetecting {
 @MainActor
 final class LiveCarPlayDetector: CarPlayDetecting {
 
+    typealias AudioSessionFactory = () -> AudioSessionRouting
     typealias NotificationCenterFactory = () -> NotificationCenter
 
     private(set) var isCarPlayActive: Bool = false
@@ -116,12 +123,17 @@ final class LiveCarPlayDetector: CarPlayDetecting {
     private var observer: NSObjectProtocol?
 
     init(
+        audioSession: AudioSessionRouting? = nil,
         notificationCenter: NotificationCenter? = nil,
-        isCarPlayActiveProvider: @escaping () -> Bool = LiveCarPlayDetector.defaultIsCarPlayActive,
+        isCarPlayActiveProvider: (() -> Bool)? = nil,
+        makeAudioSession: @escaping AudioSessionFactory = { AVAudioSession.sharedInstance() },
         makeNotificationCenter: @escaping NotificationCenterFactory = { .default }
     ) {
+        let resolvedAudioSession = audioSession ?? makeAudioSession()
         self.notificationCenter = notificationCenter ?? makeNotificationCenter()
-        self.isCarPlayActiveProvider = isCarPlayActiveProvider
+        self.isCarPlayActiveProvider = isCarPlayActiveProvider ?? {
+            LiveCarPlayDetector.isCarPlayActive(from: resolvedAudioSession)
+        }
     }
 
     func startMonitoring() {
@@ -154,10 +166,10 @@ final class LiveCarPlayDetector: CarPlayDetecting {
 
     // nonisolated: required because NotificationCenter.addObserver(forName:queue:) closure
     // is not actor-isolated; the callback dispatches back to main for state mutation.
-    nonisolated private static func defaultIsCarPlayActive() -> Bool {
+    nonisolated private static func isCarPlayActive(from audioSession: AudioSessionRouting) -> Bool {
         // .carPlay port may not be exposed in all SDK configurations; match via raw value.
         let carPlayPort = AVAudioSession.Port(rawValue: "CarPlay")
-        let outputs = AVAudioSession.sharedInstance().currentRoute.outputs
+        let outputs = audioSession.currentRoute.outputs
         for output in outputs where output.portType == carPlayPort { return true }
         return false
     }

--- a/Tests/EyePostureReminderTests/Services/LiveCarPlayDetectorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/LiveCarPlayDetectorTests.swift
@@ -5,6 +5,42 @@ import XCTest
 @MainActor
 final class LiveCarPlayDetectorTests: XCTestCase {
 
+    private final class StubAudioSession: AudioSessionRouting {
+        var currentRoute: AVAudioSessionRouteDescription
+
+        init(currentRoute: AVAudioSessionRouteDescription = AVAudioSession.sharedInstance().currentRoute) {
+            self.currentRoute = currentRoute
+        }
+    }
+
+    func test_init_withoutAudioSession_usesFactoryFallback() {
+        var factoryCallCount = 0
+        _ = LiveCarPlayDetector(
+            isCarPlayActiveProvider: { false },
+            makeAudioSession: {
+                factoryCallCount += 1
+                return StubAudioSession()
+            }
+        )
+
+        XCTAssertEqual(factoryCallCount, 1)
+    }
+
+    func test_init_withAudioSession_bypassesFactoryFallback() {
+        var factoryCallCount = 0
+        let injectedAudioSession = StubAudioSession()
+        _ = LiveCarPlayDetector(
+            audioSession: injectedAudioSession,
+            isCarPlayActiveProvider: { false },
+            makeAudioSession: {
+                factoryCallCount += 1
+                return StubAudioSession()
+            }
+        )
+
+        XCTAssertEqual(factoryCallCount, 0)
+    }
+
     func test_init_withoutNotificationCenter_usesFactoryFallback() {
         var factoryCallCount = 0
         _ = LiveCarPlayDetector(


### PR DESCRIPTION
Summary:\n- micro-slice for #462 Phase A\n- inject AudioSessionRouting seam into LiveCarPlayDetector via optional dependency + factory fallback\n- preserve existing behavior and keep notification-center/provider paths unchanged\n- add focused unit tests for audio session fallback/bypass paths\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462