### PR TITLE
#462 Phase A micro-slice: OverlayManager window scene provider seam

### DIFF
--- a/EyePostureReminder/Services/OverlayManager.swift
+++ b/EyePostureReminder/Services/OverlayManager.swift
@@ -100,11 +100,13 @@ final class OverlayManager: OverlayPresenting {
     typealias AccessibilityNotificationPosterFactory = () -> AccessibilityNotificationPosting
     typealias NotificationCenterFactory = () -> NotificationCenter
     typealias SettingsStoreFactory = () -> SettingsPersisting
+    typealias WindowSceneProvider = () -> UIWindowScene?
 
     private let audioManager: MediaControlling
     private let accessibilityNotificationPoster: AccessibilityNotificationPosting
     private let notificationCenter: NotificationCenter
     private let settingsStore: SettingsPersisting
+    private let windowSceneProvider: WindowSceneProvider
 
     // MARK: - State
 
@@ -138,17 +140,30 @@ final class OverlayManager: OverlayPresenting {
         accessibilityNotificationPoster: AccessibilityNotificationPosting? = nil,
         notificationCenter: NotificationCenter? = nil,
         settingsStore: SettingsPersisting? = nil,
+        windowSceneProvider: WindowSceneProvider? = nil,
         makeAudioManager: @escaping AudioManagerFactory = { AudioInterruptionManager() },
         makeAccessibilityNotificationPoster: @escaping AccessibilityNotificationPosterFactory = {
             LiveAccessibilityNotificationPoster()
         },
         makeNotificationCenter: @escaping NotificationCenterFactory = { .default },
-        makeSettingsStore: @escaping SettingsStoreFactory = { UserDefaults.standard }
+        makeSettingsStore: @escaping SettingsStoreFactory = { UserDefaults.standard },
+        makeWindowSceneProvider: (() -> WindowSceneProvider)? = nil
     ) {
         self.audioManager = audioManager ?? makeAudioManager()
         self.accessibilityNotificationPoster = accessibilityNotificationPoster ?? makeAccessibilityNotificationPoster()
         self.notificationCenter = notificationCenter ?? makeNotificationCenter()
         self.settingsStore = settingsStore ?? makeSettingsStore()
+        if let windowSceneProvider {
+            self.windowSceneProvider = windowSceneProvider
+        } else if let makeWindowSceneProvider {
+            self.windowSceneProvider = makeWindowSceneProvider()
+        } else {
+            self.windowSceneProvider = {
+                UIApplication.shared.connectedScenes
+                    .compactMap({ $0 as? UIWindowScene })
+                    .first(where: { $0.activationState == .foregroundActive })
+            }
+        }
         sceneActivationObserver = self.notificationCenter.addObserver(
             forName: UIScene.didActivateNotification,
             object: nil,
@@ -187,10 +202,7 @@ final class OverlayManager: OverlayPresenting {
             return
         }
 
-        guard let windowScene = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .first(where: { $0.activationState == .foregroundActive })
-        else {
+        guard let windowScene = windowSceneProvider() else {
             // Queue the request so it is shown once a scene becomes foreground-active.
             overlayQueue.append(QueuedOverlay(
                 type: type,
@@ -302,10 +314,7 @@ final class OverlayManager: OverlayPresenting {
         // the tail because isOverlayVisible is true), corrupting FIFO order. (#289)
         guard !isOverlayVisible else { return }
         guard !overlayQueue.isEmpty else { return }
-        guard UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .contains(where: { $0.activationState == .foregroundActive })
-        else {
+        guard windowSceneProvider() != nil else {
             Logger.overlay.warning(
                 "presentNextQueuedOverlay: no active scene — item retained in queue for next attempt"
             )

--- a/Tests/EyePostureReminderTests/Services/OverlayManagerExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/Services/OverlayManagerExtendedTests.swift
@@ -7,6 +7,37 @@ import XCTest
 @MainActor
 final class OverlayManagerExtendedTests: XCTestCase {
 
+    // MARK: - windowSceneProvider factory seam
+
+    func test_init_withoutWindowSceneProvider_usesInjectedFactory() {
+        var makeWindowSceneProviderCallCount = 0
+
+        _ = OverlayManager(
+            windowSceneProvider: nil,
+            makeWindowSceneProvider: {
+                makeWindowSceneProviderCallCount += 1
+                return { nil }
+            }
+        )
+
+        XCTAssertEqual(makeWindowSceneProviderCallCount, 1)
+    }
+
+    func test_init_withExplicitWindowSceneProvider_doesNotCallFactory() {
+        var makeWindowSceneProviderCallCount = 0
+
+        _ = OverlayManager(
+            windowSceneProvider: { nil },
+            makeWindowSceneProvider: {
+                makeWindowSceneProviderCallCount += 1
+                return { nil }
+            }
+        )
+
+        XCTAssertEqual(makeWindowSceneProviderCallCount, 0)
+    }
+
+
     // MARK: - clearQueue(for:) — per-type filtering
 
     func test_clearQueueForType_withNoQueuedItems_doesNotCrash() {


### PR DESCRIPTION
## Summary

Injects a `WindowSceneProvider` closure seam into `OverlayManager`, removing two hardcoded `UIApplication.shared.connectedScenes` reads from the service body.

## Changes

### Production
- `EyePostureReminder/Services/OverlayManager.swift`
  - Add `typealias WindowSceneProvider = () -> UIWindowScene?`
  - Add `private let windowSceneProvider: WindowSceneProvider` stored property
  - Add `windowSceneProvider: WindowSceneProvider? = nil` + optional `makeWindowSceneProvider: (() -> WindowSceneProvider)?` to `init`
  - Resolve via 3-way guard in `@MainActor init` body (avoids Swift 6 actor-isolation in default arg position)
  - Replace `UIApplication.shared.connectedScenes` in `showOverlay` → `windowSceneProvider()`
  - Replace `UIApplication.shared.connectedScenes` in `presentNextQueuedOverlay` → `windowSceneProvider() != nil`

### Tests
- `Tests/EyePostureReminderTests/Services/OverlayManagerExtendedTests.swift`
  - `test_init_withoutWindowSceneProvider_usesInjectedFactory` — fallback factory invoked exactly once
  - `test_init_withExplicitWindowSceneProvider_doesNotCallFactory` — explicit provider bypasses factory

## Behavior
Runtime behavior unchanged — production path falls through to the same `UIApplication.shared.connectedScenes` query, now inside `init` on the main actor.

## Validation
- `./scripts/build.sh build` ✅
- `./scripts/build.sh test` ✅ (2019 tests, 0 failures; 1 rerun for intermittent simulator termination)

Closes part of #462