### PR TITLE
#462 Phase A: AppCoordinator scheduler factory seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -210,3 +210,6 @@
 - For value-type convenience initializers with `Date()` defaults, prefer `timestamp: Date? = nil` plus `makeTimestamp` fallback factory and resolve once in the initializer body; add paired tests for fallback-used and explicit-date-bypass (`EyePostureReminder/Services/ScreenTimeShieldTypes.swift`, `Tests/EyePostureReminderTests/Services/DeviceActivityMonitorTests.swift`).
 - For coordinator-owned collaborators with concrete defaults, prefer `dependency: Protocol? = nil` plus `makeDependency` fallback and resolve once in `init`; this removes hidden construction from service initializers while preserving production behavior (`EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`).
 - For #462 Phase A micro-slices, keep DI/SRP PRs to one constructor seam and two narrow fallback/bypass tests; avoid touching runtime lifecycle logic unless required.
+
+## Learnings
+- For AppCoordinator service defaults, prefer `scheduler: ReminderScheduling? = nil` plus `makeScheduler` fallback resolved once in `init`; test both fallback-used and explicit-bypass paths to remove hidden `ReminderScheduler()` construction while preserving behavior (`EyePostureReminder/Services/AppCoordinator.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`).

--- a/.squad/skills/reminder-scheduler-factory-seam/SKILL.md
+++ b/.squad/skills/reminder-scheduler-factory-seam/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: "reminder-scheduler-factory-seam"
+description: "Inject ReminderScheduling fallback factory in AppCoordinator init"
+domain: "testing"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+Use when `AppCoordinator` (or similar coordinator) accepts an optional `ReminderScheduling` dependency and currently constructs `ReminderScheduler()` directly when nil.
+
+## Pattern
+- Keep `scheduler` optional in initializer.
+- Add optional fallback factory: `makeScheduler: (() -> ReminderScheduling)? = nil`.
+- Resolve once in init with precedence: explicit dependency -> factory -> concrete fallback.
+- Preserve runtime behavior by keeping `ReminderScheduler()` as the final production fallback.
+- Add two focused tests: factory-used and explicit-scheduler-bypasses-factory.
+
+## Examples
+- `EyePostureReminder/Services/AppCoordinator.swift`
+- `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift`
+
+## Anti-Patterns
+- Direct `ReminderScheduler()` construction without a factory seam in coordinator init.
+- Re-resolving scheduler in multiple methods instead of a single init-time resolution.

--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -181,6 +181,7 @@ final class AppCoordinator: ObservableObject {
     init(
         settings: SettingsStore? = nil,
         scheduler: ReminderScheduling? = nil,
+        makeScheduler: (() -> ReminderScheduling)? = nil,
         notificationCenter: NotificationScheduling? = nil,
         makeNotificationCenter: @escaping () -> NotificationScheduling = { UNUserNotificationCenter.current() },
         overlayManager: OverlayPresenting? = nil,
@@ -213,7 +214,7 @@ final class AppCoordinator: ObservableObject {
             "Watchdog heartbeat grace interval must be finite and non-negative"
         )
         self.settings = Self.resolveSettings(settings)
-        self.scheduler = Self.resolveScheduler(scheduler)
+        self.scheduler = Self.resolveScheduler(scheduler, makeScheduler: makeScheduler)
         self.notificationCenter = notificationCenter ?? makeNotificationCenter()
         self.overlayManager = Self.resolveOverlayManager(
             overlayManager,
@@ -650,8 +651,17 @@ private extension AppCoordinator {
         settings ?? SettingsStore()
     }
 
-    static func resolveScheduler(_ scheduler: ReminderScheduling?) -> ReminderScheduling {
-        scheduler ?? ReminderScheduler()
+    static func resolveScheduler(
+        _ scheduler: ReminderScheduling?,
+        makeScheduler: (() -> ReminderScheduling)?
+    ) -> ReminderScheduling {
+        if let scheduler {
+            return scheduler
+        }
+        if let makeScheduler {
+            return makeScheduler()
+        }
+        return ReminderScheduler()
     }
 
     static func resolveOverlayManager(

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -87,6 +87,48 @@ final class AppCoordinatorTests: XCTestCase {
         XCTAssertEqual(sut.notificationAuthStatus, .notDetermined)
     }
 
+    func test_init_withoutScheduler_usesInjectedSchedulerFactory() {
+        var factoryCallCount = 0
+        let factoryScheduler = MockReminderScheduler()
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: nil,
+            makeScheduler: {
+                factoryCallCount += 1
+                return factoryScheduler
+            },
+            notificationCenter: MockNotificationCenter(),
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: MockAppGroupIPCRecorder()
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        XCTAssertEqual(factoryCallCount, 1)
+        XCTAssertTrue((coordinator.scheduler as AnyObject) === factoryScheduler)
+    }
+
+    func test_init_withExplicitScheduler_doesNotCallSchedulerFactory() {
+        var factoryCallCount = 0
+        let injectedScheduler = MockReminderScheduler()
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: injectedScheduler,
+            makeScheduler: {
+                factoryCallCount += 1
+                return MockReminderScheduler()
+            },
+            notificationCenter: MockNotificationCenter(),
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: MockAppGroupIPCRecorder()
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        XCTAssertEqual(factoryCallCount, 0)
+        XCTAssertTrue((coordinator.scheduler as AnyObject) === injectedScheduler)
+    }
+
     func test_init_withInjectedSettings_exposesTheSameInstance() {
         XCTAssertTrue(sut.settings === settings)
     }


### PR DESCRIPTION
Summary:\n- add makeScheduler DI seam to AppCoordinator init\n- resolve scheduler once with explicit -> factory -> ReminderScheduler fallback\n- add focused fallback-used and explicit-bypass unit tests\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462