### PR TITLE
#462 Phase A: SettingsViewModel calendar DI seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -223,3 +223,11 @@
 - Checkpoint 2 (PR alignment): Confirmed PR `#579` is open from `basher/462-phasea-notificationdelegate-factory-seam` to `main` with title `#462 Phase A: AppDelegate settings store resolution seam`.
 - Checkpoint 3 (validation): Ran `./scripts/build.sh build` and `./scripts/build.sh test` successfully (exit code 0) after confirming the seam + focused tests.
 - Checkpoint 4 (branch state): Confirmed branch is in sync with `origin/basher/462-phasea-notificationdelegate-factory-seam` (no ahead/behind commits) and ready for review/merge.
+
+## 2026-05-03T22:40:00Z: #462 Phase A — SettingsViewModel Calendar Factory Seam (COMPLETED)
+
+- Branch: `basher/462-phasea-appdelegate-exceptionhandler-seam`
+- Slice: Added `calendar: Calendar?` + `makeCalendar` init seam in `SettingsViewModel`, resolved once in init, and routed `snooze(option:)` rest-of-day computation through injected calendar.
+- Validation: `./scripts/build.sh build` ✅, `./scripts/build.sh test` ✅.
+- Scope: `EyePostureReminder/ViewModels/SettingsViewModel.swift`, `Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift`.
+- Learned pattern: for time-zone-sensitive day-boundary logic, inject `Calendar` as optional + factory and add fallback-used/explicit-bypass tests to avoid hidden `Calendar.current` coupling while preserving production defaults.

--- a/EyePostureReminder/ViewModels/SettingsViewModel.swift
+++ b/EyePostureReminder/ViewModels/SettingsViewModel.swift
@@ -15,6 +15,7 @@ import os
 final class SettingsViewModel: ObservableObject {
     typealias DateProviderFactory = () -> DateProviding
     typealias MaxSnoozeCountFactory = () -> Int
+    typealias CalendarFactory = () -> Calendar
 
     // MARK: - Snooze Options (M2.3)
 
@@ -51,6 +52,11 @@ final class SettingsViewModel: ObservableObject {
 
         /// Computes the absolute snooze expiry date from an injected reference date.
         func endDate(referenceDate: Date) -> Date {
+            endDate(referenceDate: referenceDate, calendar: .current)
+        }
+
+        /// Computes the absolute snooze expiry date from injected date + calendar.
+        func endDate(referenceDate: Date, calendar: Calendar) -> Date {
             switch self {
             case .fiveMinutes:
                 return referenceDate.addingTimeInterval(5 * 60)
@@ -61,7 +67,6 @@ final class SettingsViewModel: ObservableObject {
                 // `calendar.date(byAdding:)` never returns nil for valid inputs,
                 // so no fallback is needed — a fallback of `+24h` would be wrong
                 // on DST transition days (23 or 25 hours, not midnight).
-                let calendar = Calendar.current
                 return calendar.date(
                     byAdding: .day,
                     value: 1,
@@ -123,6 +128,7 @@ final class SettingsViewModel: ObservableObject {
     let settings: SettingsStore
     private let scheduler: ReminderScheduling
     private let dateProvider: DateProviding
+    private let calendar: Calendar
     private var cancellables: Set<AnyCancellable> = []
 
     // MARK: - Computed State (M2.3)
@@ -306,14 +312,18 @@ final class SettingsViewModel: ObservableObject {
         maxSnoozeCount: Int? = nil,
         makeMaxSnoozeCount: @escaping MaxSnoozeCountFactory = { AppConfig.load().features.maxSnoozeCount },
         dateProvider: DateProviding? = nil,
-        makeDateProvider: @escaping DateProviderFactory = { SystemDateProvider() }
+        makeDateProvider: @escaping DateProviderFactory = { SystemDateProvider() },
+        calendar: Calendar? = nil,
+        makeCalendar: @escaping CalendarFactory = { .current }
     ) {
         let resolvedMaxSnoozeCount = maxSnoozeCount ?? makeMaxSnoozeCount()
         let resolvedDateProvider = dateProvider ?? makeDateProvider()
+        let resolvedCalendar = calendar ?? makeCalendar()
         self.settings  = settings
         self.scheduler = scheduler
         self.maxConsecutiveSnoozes = resolvedMaxSnoozeCount
         self.dateProvider = resolvedDateProvider
+        self.calendar = resolvedCalendar
         settings.objectWillChange
             .sink { [weak self] in self?.objectWillChange.send() }
             .store(in: &cancellables)
@@ -356,7 +366,7 @@ final class SettingsViewModel: ObservableObject {
             Logger.settings.info("Snooze limit reached — ignoring snooze request")
             return
         }
-        let endDate = option.endDate(referenceDate: dateProvider.now)
+        let endDate = option.endDate(referenceDate: dateProvider.now, calendar: calendar)
         guard endDate > dateProvider.now else {
             // Guard against clock skew or NTP drift producing a past end date;
             // applying a past snoozedUntil would be cleared immediately by

--- a/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift
@@ -42,14 +42,18 @@ final class SettingsViewModelExtendedTests: XCTestCase {
     private func makeSUT(
         maxSnoozeCount: Int = 2,
         dateProvider: DateProviding? = nil,
-        makeDateProvider: @escaping SettingsViewModel.DateProviderFactory
+        makeDateProvider: @escaping SettingsViewModel.DateProviderFactory,
+        calendar: Calendar? = nil,
+        makeCalendar: @escaping SettingsViewModel.CalendarFactory = { .current }
     ) -> SettingsViewModel {
         SettingsViewModel(
             settings: settings,
             scheduler: mockScheduler,
             maxSnoozeCount: maxSnoozeCount,
             dateProvider: dateProvider,
-            makeDateProvider: makeDateProvider
+            makeDateProvider: makeDateProvider,
+            calendar: calendar,
+            makeCalendar: makeCalendar
         )
     }
 
@@ -233,6 +237,56 @@ final class SettingsViewModelExtendedTests: XCTestCase {
 
         XCTAssertEqual(factoryCallCount, 0, "Factory must not run when explicit maxSnoozeCount is provided")
         XCTAssertEqual(sut.maxConsecutiveSnoozes, 5)
+    }
+
+    func test_init_withoutCalendar_usesFactoryCalendarForRestOfDaySnoozeComputation() throws {
+        let fixedNow = Date(timeIntervalSince1970: 1_700_000_000)
+        let dateProvider = MockDateProvider(now: fixedNow)
+        var fallbackCalendar = Calendar(identifier: .gregorian)
+        fallbackCalendar.timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 14 * 3600))
+        var factoryCallCount = 0
+        let sut = makeSUT(
+            dateProvider: dateProvider,
+            makeDateProvider: { dateProvider },
+            calendar: nil,
+            makeCalendar: {
+                factoryCallCount += 1
+                return fallbackCalendar
+            }
+        )
+
+        sut.snooze(option: .restOfDay)
+
+        XCTAssertEqual(factoryCallCount, 1, "Factory must run when explicit calendar is absent")
+        let expected = try XCTUnwrap(
+            fallbackCalendar.date(byAdding: .day, value: 1, to: fallbackCalendar.startOfDay(for: fixedNow))
+        )
+        XCTAssertEqual(settings.snoozedUntil, expected)
+    }
+
+    func test_init_withExplicitCalendar_bypassesFactoryForRestOfDaySnoozeComputation() throws {
+        let fixedNow = Date(timeIntervalSince1970: 1_700_000_000)
+        let dateProvider = MockDateProvider(now: fixedNow)
+        var explicitCalendar = Calendar(identifier: .gregorian)
+        explicitCalendar.timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: -12 * 3600))
+        var factoryCallCount = 0
+        let sut = makeSUT(
+            dateProvider: dateProvider,
+            makeDateProvider: { dateProvider },
+            calendar: explicitCalendar,
+            makeCalendar: {
+                factoryCallCount += 1
+                return .current
+            }
+        )
+
+        sut.snooze(option: .restOfDay)
+
+        XCTAssertEqual(factoryCallCount, 0, "Factory must not run when explicit calendar is provided")
+        let expected = try XCTUnwrap(
+            explicitCalendar.date(byAdding: .day, value: 1, to: explicitCalendar.startOfDay(for: fixedNow))
+        )
+        XCTAssertEqual(settings.snoozedUntil, expected)
     }
 
     // MARK: - isSnoozeActive


### PR DESCRIPTION
Summary:\n- add optional calendar + makeCalendar factory seam to SettingsViewModel\n- resolve calendar once in init and use it for snooze(option:) end-date computation\n- add focused tests for fallback-used and explicit-bypass calendar paths\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462