### PR TITLE
#462 Phase A: ScreenTimeTracker lifecycle NotificationCenter factory seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -231,3 +231,7 @@
 - Validation: `./scripts/build.sh build` ✅, `./scripts/build.sh test` ✅.
 - Scope: `EyePostureReminder/ViewModels/SettingsViewModel.swift`, `Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift`.
 - Learned pattern: for time-zone-sensitive day-boundary logic, inject `Calendar` as optional + factory and add fallback-used/explicit-bypass tests to avoid hidden `Calendar.current` coupling while preserving production defaults.
+
+## Learnings
+
+- For lifecycle observer dependencies in services, prefer `notificationCenter: NotificationCenter? = nil` plus `makeNotificationCenter` fallback resolved once in `init`; add fallback-used and explicit-bypass tests by posting lifecycle notifications through the resolved center to remove hidden `.default` coupling while preserving runtime behavior (`EyePostureReminder/Services/ScreenTimeTracker.swift`, `Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift`).

--- a/EyePostureReminder/Services/ScreenTimeTracker.swift
+++ b/EyePostureReminder/Services/ScreenTimeTracker.swift
@@ -102,6 +102,9 @@ final class ScreenTimeTracker: ScreenTimeTracking {
     ///     smaller value in tests to exercise grace-period behaviour without long sleeps.
     ///   - lifecycleNotificationCenter: Notification center used for app lifecycle observer
     ///     registration/removal. Defaults to `.default` for production behavior.
+    ///   - makeLifecycleNotificationCenter: Optional fallback factory used when
+    ///     `lifecycleNotificationCenter` is nil. Keeps production behavior (`.default`)
+    ///     while allowing deterministic fallback-path tests.
     ///   - appStateProvider: Provides `UIApplication.applicationState` for `startIfActive()`.
     ///     Defaults to `UIApplication.shared`. Inject a mock to drive active/background behavior
     ///     in unit tests without depending on the real UIApplication singleton.
@@ -110,7 +113,8 @@ final class ScreenTimeTracker: ScreenTimeTracking {
     ///     fallback-path tests.
     init(
         resetGracePeriod: TimeInterval = 5.0,
-        lifecycleNotificationCenter: NotificationCenter = .default,
+        lifecycleNotificationCenter: NotificationCenter? = nil,
+        makeLifecycleNotificationCenter: (() -> NotificationCenter)? = nil,
         appStateProvider: AppStateProviding? = nil,
         makeAppStateProvider: (() -> AppStateProviding)? = nil
     ) {
@@ -122,7 +126,8 @@ final class ScreenTimeTracker: ScreenTimeTracking {
         } else {
             self.resetGracePeriod = resetGracePeriod
         }
-        self.lifecycleNotificationCenter = lifecycleNotificationCenter
+        let resolvedLifecycleNotificationCenter = makeLifecycleNotificationCenter ?? { .default }
+        self.lifecycleNotificationCenter = lifecycleNotificationCenter ?? resolvedLifecycleNotificationCenter()
         let resolvedAppStateProvider = makeAppStateProvider ?? { UIApplication.shared }
         self.appStateProvider = appStateProvider ?? resolvedAppStateProvider()
         for type in ReminderType.allCases {

--- a/Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift
@@ -280,6 +280,60 @@ final class ScreenTimeTrackerTests: XCTestCase {
         XCTAssertEqual(factoryCallCount, 0)
     }
 
+    // MARK: - lifecycleNotificationCenter factory seam
+
+    func test_init_withNilLifecycleNotificationCenter_usesFactoryCenter() async {
+        let center = NotificationCenter()
+        var factoryCallCount = 0
+        let tracker = ScreenTimeTracker(
+            resetGracePeriod: 5.0,
+            lifecycleNotificationCenter: nil,
+            makeLifecycleNotificationCenter: {
+                factoryCallCount += 1
+                return center
+            },
+            appStateProvider: MockAppStateProvider(state: .background)
+        )
+        defer { tracker.stop() }
+
+        tracker.setThreshold(1.0, for: .eyes)
+        let exp = expectation(description: "threshold fires via factory lifecycle notification center")
+        tracker.onThresholdReached = { type in
+            if type == .eyes { exp.fulfill() }
+        }
+
+        center.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        await fulfillment(of: [exp], timeout: 4.0)
+        XCTAssertEqual(factoryCallCount, 1)
+    }
+
+    func test_init_withInjectedLifecycleNotificationCenter_bypassesFactory() async {
+        let center = NotificationCenter()
+        var factoryCallCount = 0
+        let tracker = ScreenTimeTracker(
+            resetGracePeriod: 5.0,
+            lifecycleNotificationCenter: center,
+            makeLifecycleNotificationCenter: {
+                factoryCallCount += 1
+                return NotificationCenter()
+            },
+            appStateProvider: MockAppStateProvider(state: .background)
+        )
+        defer { tracker.stop() }
+
+        tracker.setThreshold(1.0, for: .eyes)
+        let exp = expectation(description: "threshold fires via injected lifecycle notification center")
+        tracker.onThresholdReached = { type in
+            if type == .eyes { exp.fulfill() }
+        }
+
+        center.post(name: UIApplication.didBecomeActiveNotification, object: nil)
+
+        await fulfillment(of: [exp], timeout: 4.0)
+        XCTAssertEqual(factoryCallCount, 0)
+    }
+
     // MARK: - onThresholdReached callback
 
     func test_onThresholdReached_canBeAssigned() {


### PR DESCRIPTION
## Summary\n- replace ScreenTimeTracker's eager lifecycle NotificationCenter default argument with optional injection + fallback factory resolved in init\n- preserve runtime behavior by keeping .default as fallback path\n- add focused tests proving fallback factory is used when center is nil and bypassed when center is injected\n\n## Validation\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462