### PR TITLE
#462 Phase A: LiveFocusStatusDetector FocusStatusCenter DI seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -235,3 +235,24 @@
 ## Learnings
 
 - For lifecycle observer dependencies in services, prefer `notificationCenter: NotificationCenter? = nil` plus `makeNotificationCenter` fallback resolved once in `init`; add fallback-used and explicit-bypass tests by posting lifecycle notifications through the resolved center to remove hidden `.default` coupling while preserving runtime behavior (`EyePostureReminder/Services/ScreenTimeTracker.swift`, `Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift`).
+
+## 2026-05-03T14:40:00Z: #462 Phase A DI/SRP — LiveFocusStatusDetector FocusStatusCenter DI Seam (COMPLETED)
+
+**Task:** Execute next smallest #462 Phase A DI/SRP micro-slice from origin/main (after PR #581 merged)
+
+**Slice:** Inject FocusStatusCenterProviding seam into LiveFocusStatusDetector, removing all INFocusStatusCenter.default hard references
+
+**Branch:** basher/462-phasea-livefocusdetector-center-seam  
+**Commit:** 3ef099f  
+**PR:** https://github.com/yashasg/fantastic-octo-fortnight/pull/582
+
+**Changes:**
+- PauseConditionManager: Added FocusStatusCenterProviding protocol with requestFocusAuthorization(_:), currentIsFocused, and observeFocusChanges(_:); INFocusStatusCenter extension satisfies protocol; LiveFocusStatusDetector now accepts focusCenter/makeFocusCenter injection
+- LiveFocusStatusDetectorTests: 5 new tests covering factory seam, auth requested, auth denied (fail-open), and auth-granted focus state seeding
+
+**Validation:** ✅ Build clean, 2036 tests, 0 failures
+
+**Learnings:**
+- For protocols mirroring SDK singleton methods, avoid reusing the exact SDK method name/signature (e.g., INFocusStatusCenter.requestAuthorization has a different label and type than what a generic protocol would expect); use a distinct wrapper method name (requestFocusAuthorization) that converts to a simpler Bool to sidestep ambiguity.
+- KVO observation tokens can be typed as AnyObject in protocol return positions; NSKeyValueObservation deinit calls invalidate() automatically so setting token = nil safely cancels observation.
+- AnyObject token pattern (observeFocusChanges returning AnyObject) lets mocks return NSObject() as a no-op token without needing to subclass NSKeyValueObservation.

--- a/.squad/skills/date-provider-default-seam/SKILL.md
+++ b/.squad/skills/date-provider-default-seam/SKILL.md
@@ -47,3 +47,17 @@ Use when a service method currently takes `now: Date = Date()` and production co
 - `Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift` (`cancelAllReminders` fallback/bypass assertions)
 - `EyePostureReminder/Services/ScreenTimeShieldTypes.swift` (`makeTriggeredAt` convenience-init seam)
 - `Tests/EyePostureReminderTests/Services/DeviceActivityMonitorTests.swift` (`ShieldSession` fallback/bypass assertions)
+
+---
+
+## Pattern: SDK Singleton Abstraction via Distinct Wrapper Method
+
+**Context:** When injecting a protocol over an SDK singleton whose method names/signatures differ across versions or conflict with generic protocol naming.
+
+**Problem:** Mirroring an SDK method name (e.g., `requestAuthorization`) in a protocol can cause type-inference ambiguity when the SDK method uses a different argument label or parameter type.
+
+**Solution:** Use a distinct wrapper method name (e.g., `requestFocusAuthorization(_ handler: @escaping (Bool) -> Void)`) that converts the SDK's native type to a simpler protocol-level type (`Bool`). Implement it in an extension on the SDK class.
+
+**Token pattern for KVO:** Return `AnyObject` from observation methods; `NSKeyValueObservation`'s deinit calls `invalidate()` automatically, so `token = nil` cleanly cancels. Mock can return `NSObject()` as a no-op token.
+
+**Files:** `EyePostureReminder/Services/PauseConditionManager.swift`, `Tests/EyePostureReminderTests/Services/LiveFocusStatusDetectorTests.swift`

--- a/EyePostureReminder/Services/PauseConditionManager.swift
+++ b/EyePostureReminder/Services/PauseConditionManager.swift
@@ -53,6 +53,38 @@ protocol PauseConditionProviding: ServiceLifecycle {
     var onPauseStateChanged: (@MainActor (Bool) -> Void)? { get set }
 }
 
+// MARK: - FocusStatusCenterProviding
+
+/// Abstracts `INFocusStatusCenter` for testability.
+///
+/// Concrete conformance is provided by `INFocusStatusCenter` via extension.
+/// Tests inject a `MockFocusStatusCenter` to exercise authorization and
+/// observation paths without real Focus mode permissions.
+protocol FocusStatusCenterProviding: AnyObject {
+    /// Request Focus mode authorization and deliver the result as a `Bool`
+    /// (`true` = authorized, `false` = denied/restricted).
+    func requestFocusAuthorization(_ handler: @escaping (Bool) -> Void)
+    /// Current Focus active state (wraps `focusStatus.isFocused ?? false`).
+    var currentIsFocused: Bool { get }
+    /// Register for future focus state changes. The returned token must be retained
+    /// for as long as observation is desired; releasing it cancels delivery.
+    func observeFocusChanges(_ handler: @escaping (Bool) -> Void) -> AnyObject
+}
+
+extension INFocusStatusCenter: FocusStatusCenterProviding {
+    var currentIsFocused: Bool { focusStatus.isFocused ?? false }
+
+    func requestFocusAuthorization(_ handler: @escaping (Bool) -> Void) {
+        requestAuthorization { status in handler(status == .authorized) }
+    }
+
+    func observeFocusChanges(_ handler: @escaping (Bool) -> Void) -> AnyObject {
+        return observe(\.focusStatus, options: [.new]) { center, _ in
+            handler(center.focusStatus.isFocused ?? false)
+        }
+    }
+}
+
 // MARK: - LiveFocusStatusDetector
 
 /// Observes `INFocusStatusCenter` for Focus mode changes.
@@ -61,31 +93,36 @@ protocol PauseConditionProviding: ServiceLifecycle {
 @MainActor
 final class LiveFocusStatusDetector: NSObject, FocusStatusDetecting {
 
+    typealias FocusCenterFactory = () -> FocusStatusCenterProviding
+
+    private let focusCenter: FocusStatusCenterProviding
     private(set) var isFocused: Bool = false
     var onFocusChanged: ((Bool) -> Void)?
 
-    private var focusObservation: NSKeyValueObservation?
+    /// Retained to keep observation alive; releasing it cancels KVO delivery.
+    private var focusObservation: AnyObject?
+
+    init(
+        focusCenter: FocusStatusCenterProviding? = nil,
+        makeFocusCenter: @escaping FocusCenterFactory = { INFocusStatusCenter.default }
+    ) {
+        self.focusCenter = focusCenter ?? makeFocusCenter()
+    }
 
     func startMonitoring() {
         // Request authorization first. KVO is deferred until after auth completes
         // to avoid accessing focusStatus before the usage description is acknowledged —
         // an early access crashes the app even when Info.plist has the key.
-        INFocusStatusCenter.default.requestAuthorization { [weak self] status in
-            guard let self else { return }
-            guard status == .authorized else { return }
+        focusCenter.requestFocusAuthorization { [weak self] authorized in
+            guard let self, authorized else { return }
 
-            let focused = INFocusStatusCenter.default.focusStatus.isFocused ?? false
+            let focused = self.focusCenter.currentIsFocused
             DispatchQueue.main.async {
                 self.isFocused = focused
                 self.onFocusChanged?(focused)
 
-                // KVO on `focusStatus` — fires whenever Focus mode activates or deactivates.
-                self.focusObservation = INFocusStatusCenter.default.observe(
-                    \.focusStatus,
-                    options: [.new]
-                ) { [weak self] _, _ in
-                    guard let self else { return }
-                    let focused = INFocusStatusCenter.default.focusStatus.isFocused ?? false
+                // Observation token: releasing cancels KVO delivery automatically.
+                self.focusObservation = self.focusCenter.observeFocusChanges { [weak self] focused in
                     // Use [weak self] on the inner dispatch to prevent a stale-write race:
                     // if stopMonitoring() + startMonitoring() run while this block is queued,
                     // the freshly-initialised isFocused must not be overwritten. Fixes #492.
@@ -100,7 +137,6 @@ final class LiveFocusStatusDetector: NSObject, FocusStatusDetecting {
     }
 
     func stopMonitoring() {
-        focusObservation?.invalidate()
         focusObservation = nil
     }
 }

--- a/Tests/EyePostureReminderTests/Services/LiveFocusStatusDetectorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/LiveFocusStatusDetectorTests.swift
@@ -1,0 +1,109 @@
+@testable import EyePostureReminder
+import XCTest
+
+// MARK: - LiveFocusStatusDetectorTests
+
+/// Unit tests for `LiveFocusStatusDetector`.
+///
+/// `INFocusStatusCenter.default` is replaced by `MockFocusStatusCenter` so no
+/// real Focus mode permissions are required. Authorization and observation paths
+/// are exercised via synchronous mock helpers.
+@MainActor
+final class LiveFocusStatusDetectorTests: XCTestCase {
+
+    // MARK: - Mock
+
+    private final class MockFocusStatusCenter: FocusStatusCenterProviding {
+        private(set) var authorizationRequested = false
+        private var pendingAuthHandler: ((Bool) -> Void)?
+        private var focusChangesHandler: ((Bool) -> Void)?
+        var stubbedIsFocused: Bool = false
+
+        var currentIsFocused: Bool { stubbedIsFocused }
+
+        func requestFocusAuthorization(_ handler: @escaping (Bool) -> Void) {
+            authorizationRequested = true
+            pendingAuthHandler = handler
+        }
+
+        func observeFocusChanges(_ handler: @escaping (Bool) -> Void) -> AnyObject {
+            focusChangesHandler = handler
+            return NSObject()
+        }
+
+        func simulateAuthResponse(_ authorized: Bool) {
+            pendingAuthHandler?(authorized)
+        }
+
+        func simulateFocusChange(_ focused: Bool) {
+            stubbedIsFocused = focused
+            focusChangesHandler?(focused)
+        }
+    }
+
+    // MARK: - Factory Seam
+
+    func test_init_withoutFocusCenter_usesFactoryFallback() {
+        var factoryCallCount = 0
+        _ = LiveFocusStatusDetector(
+            makeFocusCenter: {
+                factoryCallCount += 1
+                return MockFocusStatusCenter()
+            }
+        )
+        XCTAssertEqual(factoryCallCount, 1, "Factory must be called exactly once when no explicit center is injected")
+    }
+
+    func test_init_withFocusCenter_bypassesFactoryFallback() {
+        var factoryCallCount = 0
+        let center = MockFocusStatusCenter()
+        _ = LiveFocusStatusDetector(
+            focusCenter: center,
+            makeFocusCenter: {
+                factoryCallCount += 1
+                return MockFocusStatusCenter()
+            }
+        )
+        XCTAssertEqual(factoryCallCount, 0, "Factory must not be called when an explicit center is injected")
+    }
+
+    // MARK: - Authorization
+
+    func test_startMonitoring_requestsAuthorization() {
+        let center = MockFocusStatusCenter()
+        let detector = LiveFocusStatusDetector(focusCenter: center)
+
+        detector.startMonitoring()
+
+        XCTAssertTrue(center.authorizationRequested, "startMonitoring must request Focus mode authorization")
+        detector.stopMonitoring()
+    }
+
+    func test_startMonitoring_whenAuthDenied_isFocusedUnchanged() {
+        let center = MockFocusStatusCenter()
+        center.stubbedIsFocused = true
+        let detector = LiveFocusStatusDetector(focusCenter: center)
+
+        detector.startMonitoring()
+        center.simulateAuthResponse(false)
+        // Denied path exits early — no main dispatch is enqueued.
+
+        XCTAssertFalse(detector.isFocused, "Denied authorization must leave isFocused unchanged (fail-open)")
+        detector.stopMonitoring()
+    }
+
+    func test_startMonitoring_whenAuthGranted_seedsCurrentFocusState() {
+        let center = MockFocusStatusCenter()
+        center.stubbedIsFocused = true
+        let detector = LiveFocusStatusDetector(focusCenter: center)
+        let exp = expectation(description: "onFocusChanged fired after auth granted")
+        detector.onFocusChanged = { _ in exp.fulfill() }
+
+        detector.startMonitoring()
+        center.simulateAuthResponse(true)
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertTrue(detector.isFocused, "Authorized path must seed isFocused from injected center.currentIsFocused")
+        detector.stopMonitoring()
+    }
+}


### PR DESCRIPTION
## Summary

Injects `FocusStatusCenterProviding` into `LiveFocusStatusDetector`, removing all three hard `INFocusStatusCenter.default` references. Production behavior is unchanged; the `INFocusStatusCenter` extension satisfies the protocol transparently.

## Changes

**`EyePostureReminder/Services/PauseConditionManager.swift`**
- Added `FocusStatusCenterProviding` protocol (`requestFocusAuthorization`, `currentIsFocused`, `observeFocusChanges`)
- Added `extension INFocusStatusCenter: FocusStatusCenterProviding`
- `LiveFocusStatusDetector`: added `focusCenter`/`makeFocusCenter` injection; removed all `INFocusStatusCenter.default` direct calls

**`Tests/EyePostureReminderTests/Services/LiveFocusStatusDetectorTests.swift`** _(new)_
- 5 focused tests: factory bypass/fallback, auth requested, auth denied (fail-open), auth granted seeds focus state

## Validation

- `./scripts/build.sh build` ✅
- `./scripts/build.sh test` ✅ — 2036 tests, 0 failures

Refs #462