### PR TITLE
#462 Phase A: AppCoordinator UI-test mode launch-args resolver seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -256,3 +256,7 @@
 - For protocols mirroring SDK singleton methods, avoid reusing the exact SDK method name/signature (e.g., INFocusStatusCenter.requestAuthorization has a different label and type than what a generic protocol would expect); use a distinct wrapper method name (requestFocusAuthorization) that converts to a simpler Bool to sidestep ambiguity.
 - KVO observation tokens can be typed as AnyObject in protocol return positions; NSKeyValueObservation deinit calls invalidate() automatically so setting token = nil safely cancels observation.
 - AnyObject token pattern (observeFocusChanges returning AnyObject) lets mocks return NSObject() as a no-op token without needing to subclass NSKeyValueObservation.
+
+## Learnings
+
+- For static launch-context helpers, add a tiny resolver seam (`launchArguments: [String]?` + `launchArgumentsProvider`) and have the public static computed property call it; this removes hard `CommandLine.arguments` coupling while preserving behavior and enables focused fallback/bypass tests (`EyePostureReminder/Services/AppCoordinator+UITestMode.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorUITestModeResolverTests.swift`).

--- a/.squad/skills/launch-context-di-seam/SKILL.md
+++ b/.squad/skills/launch-context-di-seam/SKILL.md
@@ -22,6 +22,7 @@ Use this when service or coordinator logic branches on process launch context
 - For coordinators that consume launch arguments in multiple places, resolve once (`let resolvedLaunchArguments = launchArguments ?? launchArgumentsProvider()`) and thread the resolved value through each branch to avoid mixed injected/global behavior.
 - Apply the same optional+provider pattern to process environment reads (`processEnvironment: [String: String]? = nil`, `processEnvironmentProvider`) and resolve once in `init` before passing to resolver helpers.
 - For coordinator lifecycle methods that branch on UI-test mode after init (for example `refreshAuthStatus`), persist the resolved init value in an instance property and guard on that property instead of static globals.
+- For static launch-mode booleans used by views, expose a computed property backed by a seamable resolver (`launchArguments` optional + provider closure) so tests can cover fallback and explicit-bypass behavior without mutating `CommandLine.arguments`.
 
 ## Examples
 - `AppCoordinator.init(..., processEnvironment: [String: String]? = nil, processEnvironmentProvider: @escaping () -> [String: String] = { ProcessInfo.processInfo.environment }, launchArguments: [String]? = nil, launchArgumentsProvider: @escaping () -> [String] = { CommandLine.arguments }, ...)`
@@ -31,6 +32,7 @@ Use this when service or coordinator logic branches on process launch context
 - `AppDelegate.init(..., makeNotificationCenter: @escaping () -> UserNotificationCenterDelegating = { UNUserNotificationCenter.current() })` with fallback-path coverage in `test_didFinishLaunching_withNilNotificationCenter_usesInjectedFactory`.
 - `AppDelegate.init(..., launchArguments: [String]? = nil, launchArgumentsProvider: @escaping () -> [String] = { CommandLine.arguments })` with fallback/bypass coverage in `test_init_withoutLaunchArguments_usesInjectedLaunchArgumentsProvider` and `test_init_withExplicitLaunchArguments_doesNotCallInjectedLaunchArgumentsProvider`.
 - `AppCoordinator.scheduleReminders()` UI-test gates (`requestNotificationPermission`, tracker configuration guard) should branch on instance `isUITestModeEnabled`; coverage: `test_scheduleReminders_withInjectedUITestModeTrue_skipsPermissionPromptAndTrackerConfiguration` in `Tests/EyePostureReminderTests/Services/AppCoordinatorUITestModeResolverTests.swift`.
+- `AppCoordinator+UITestMode.resolveIsUITestMode(launchArguments:launchArgumentsProvider:)` feeding computed `AppCoordinator.isUITestMode`; seam coverage: `test_resolveIsUITestMode_withoutLaunchArguments_usesInjectedProvider` and `test_resolveIsUITestMode_withExplicitLaunchArguments_bypassesProvider`.
 
 ## Anti-Patterns
 - Reading launch context globals directly inside static resolvers.

--- a/EyePostureReminder/Services/AppCoordinator+UITestMode.swift
+++ b/EyePostureReminder/Services/AppCoordinator+UITestMode.swift
@@ -16,7 +16,17 @@ extension AppCoordinator {
     /// `#if DEBUG` ensures this `CommandLine` inspection is compiled out of Release/TestFlight
     /// builds, preventing accidental onboarding state resets in production (re: #350/#405).
 #if DEBUG
-    static let isUITestMode: Bool = isUITestMode(launchArguments: CommandLine.arguments)
+    static var isUITestMode: Bool {
+        resolveIsUITestMode()
+    }
+
+    static func resolveIsUITestMode(
+        launchArguments: [String]? = nil,
+        launchArgumentsProvider: () -> [String] = { CommandLine.arguments }
+    ) -> Bool {
+        let resolvedLaunchArguments = launchArguments ?? launchArgumentsProvider()
+        return isUITestMode(launchArguments: resolvedLaunchArguments)
+    }
 
     static func isUITestMode(launchArguments: [String]) -> Bool {
         launchArguments.contains("--skip-onboarding") ||
@@ -26,7 +36,14 @@ extension AppCoordinator {
             launchArguments.contains("--simulate-screen-time-not-determined")
     }
 #else
-    static let isUITestMode: Bool = false
+    static var isUITestMode: Bool { false }
+
+    static func resolveIsUITestMode(
+        launchArguments: [String]? = nil,
+        launchArgumentsProvider: () -> [String] = { CommandLine.arguments }
+    ) -> Bool {
+        false
+    }
 
     static func isUITestMode(launchArguments: [String]) -> Bool {
         false

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestModeResolverTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestModeResolverTests.swift
@@ -8,6 +8,33 @@ final class AppCoordinatorUITestModeResolverTests: XCTestCase {
         XCTAssertTrue(AppCoordinator.isUITestMode(launchArguments: ["--show-overlay-eyes"]))
     }
 
+    func test_resolveIsUITestMode_withoutLaunchArguments_usesInjectedProvider() {
+        var providerCallCount = 0
+
+        let mode = AppCoordinator.resolveIsUITestMode(launchArgumentsProvider: {
+            providerCallCount += 1
+            return ["--show-overlay-posture"]
+        })
+
+        XCTAssertEqual(providerCallCount, 1)
+        XCTAssertTrue(mode)
+    }
+
+    func test_resolveIsUITestMode_withExplicitLaunchArguments_bypassesProvider() {
+        var providerCallCount = 0
+
+        let mode = AppCoordinator.resolveIsUITestMode(
+            launchArguments: ["--skip-onboarding"],
+            launchArgumentsProvider: {
+                providerCallCount += 1
+                return []
+            }
+        )
+
+        XCTAssertEqual(providerCallCount, 0)
+        XCTAssertTrue(mode)
+    }
+
     func test_init_withUITestLaunchArgument_andNoTracker_resolvesNoopScreenTimeTracker() {
         let mockNotif = MockNotificationCenter()
         let coordinator = AppCoordinator(


### PR DESCRIPTION
Summary:\n- add resolveIsUITestMode(launchArguments:launchArgumentsProvider:) in AppCoordinator+UITestMode\n- make AppCoordinator.isUITestMode use the resolver seam instead of hard CommandLine.arguments\n- add focused fallback/bypass resolver tests\n\nValidation:\n- ./scripts/build.sh build passed\n- ./scripts/build.sh test passed\n\nRefs #462