### PR TITLE
#462 Phase A: HomeView launch-context provider seam

### DIFF
--- a/.squad/agents/rusty/history.md
+++ b/.squad/agents/rusty/history.md
@@ -256,6 +256,7 @@ Result: **10/10 passed**
 - `ShieldTriggerReason.rawValue` stability matters: values are written to App Group UserDefaults and read by extension processes in a separate sandbox. The tests pin these as a regression gate.
 - FamilyControls does NOT work in Simulator at all. All real shield validation is device-only, post-#201.
 - For AppCoordinator DI seams, convert eager singleton/store defaults into `Dependency? = nil` + `makeDependency` factory closures, then test both fallback and bypass paths to keep behavior unchanged and testability explicit.
+- For SwiftUI views that still need DEBUG launch-context checks, avoid direct `CommandLine`/`ProcessInfo` reads in computed properties; inject optional launch-context values plus provider closures and unit-test fallback/bypass behavior via a static resolver.
 
 ### 2026-04-30: Post-#299 Architecture Audit — Clean
 

--- a/.squad/skills/launch-context-di-seam/SKILL.md
+++ b/.squad/skills/launch-context-di-seam/SKILL.md
@@ -23,6 +23,7 @@ Use this when service or coordinator logic branches on process launch context
 - Apply the same optional+provider pattern to process environment reads (`processEnvironment: [String: String]? = nil`, `processEnvironmentProvider`) and resolve once in `init` before passing to resolver helpers.
 - For coordinator lifecycle methods that branch on UI-test mode after init (for example `refreshAuthStatus`), persist the resolved init value in an instance property and guard on that property instead of static globals.
 - For static launch-mode booleans used by views, expose a computed property backed by a seamable resolver (`launchArguments` optional + provider closure) so tests can cover fallback and explicit-bypass behavior without mutating `CommandLine.arguments`.
+- For SwiftUI view debug gates that check launch arguments/environment, pass optional `launchArguments` and `processEnvironment` into the view initializer plus provider closures, then keep branching logic in a static resolver function for deterministic unit tests.
 
 ## Examples
 - `AppCoordinator.init(..., processEnvironment: [String: String]? = nil, processEnvironmentProvider: @escaping () -> [String: String] = { ProcessInfo.processInfo.environment }, launchArguments: [String]? = nil, launchArgumentsProvider: @escaping () -> [String] = { CommandLine.arguments }, ...)`
@@ -33,6 +34,7 @@ Use this when service or coordinator logic branches on process launch context
 - `AppDelegate.init(..., launchArguments: [String]? = nil, launchArgumentsProvider: @escaping () -> [String] = { CommandLine.arguments })` with fallback/bypass coverage in `test_init_withoutLaunchArguments_usesInjectedLaunchArgumentsProvider` and `test_init_withExplicitLaunchArguments_doesNotCallInjectedLaunchArgumentsProvider`.
 - `AppCoordinator.scheduleReminders()` UI-test gates (`requestNotificationPermission`, tracker configuration guard) should branch on instance `isUITestModeEnabled`; coverage: `test_scheduleReminders_withInjectedUITestModeTrue_skipsPermissionPromptAndTrackerConfiguration` in `Tests/EyePostureReminderTests/Services/AppCoordinatorUITestModeResolverTests.swift`.
 - `AppCoordinator+UITestMode.resolveIsUITestMode(launchArguments:launchArgumentsProvider:)` feeding computed `AppCoordinator.isUITestMode`; seam coverage: `test_resolveIsUITestMode_withoutLaunchArguments_usesInjectedProvider` and `test_resolveIsUITestMode_withExplicitLaunchArguments_bypassesProvider`.
+- `HomeView.resolveShouldShowUITestScreenTimePrompt(launchArguments:launchArgumentsProvider:processEnvironment:processEnvironmentProvider:)` with seam coverage in `HomeViewLaunchContextResolverTests` for fallback and explicit bypass paths.
 
 ## Anti-Patterns
 - Reading launch context globals directly inside static resolvers.

--- a/EyePostureReminder/Views/HomeView.swift
+++ b/EyePostureReminder/Views/HomeView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct HomeView: View {
+    typealias LaunchArgumentsProvider = () -> [String]
+    typealias ProcessEnvironmentProvider = () -> [String: String]
 
     @EnvironmentObject var settings: SettingsStore
     @EnvironmentObject var coordinator: AppCoordinator
@@ -11,9 +13,23 @@ struct HomeView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let accessibilityNotificationPoster: AccessibilityNotificationPosting
+    private let launchArguments: [String]?
+    private let launchArgumentsProvider: LaunchArgumentsProvider
+    private let processEnvironment: [String: String]?
+    private let processEnvironmentProvider: ProcessEnvironmentProvider
 
-    init(accessibilityNotificationPoster: AccessibilityNotificationPosting = LiveAccessibilityNotificationPoster()) {
+    init(
+        accessibilityNotificationPoster: AccessibilityNotificationPosting = LiveAccessibilityNotificationPoster(),
+        launchArguments: [String]? = nil,
+        launchArgumentsProvider: @escaping LaunchArgumentsProvider = { CommandLine.arguments },
+        processEnvironment: [String: String]? = nil,
+        processEnvironmentProvider: @escaping ProcessEnvironmentProvider = { ProcessInfo.processInfo.environment }
+    ) {
         self.accessibilityNotificationPoster = accessibilityNotificationPoster
+        self.launchArguments = launchArguments
+        self.launchArgumentsProvider = launchArgumentsProvider
+        self.processEnvironment = processEnvironment
+        self.processEnvironmentProvider = processEnvironmentProvider
     }
 
     private var statusLabel: String {
@@ -29,15 +45,33 @@ struct HomeView: View {
             return true
         }
 #if DEBUG
-        if CommandLine.arguments.contains("--simulate-screen-time-not-determined") {
-            return true
-        }
-        if ProcessInfo.processInfo.environment["UITEST_SCREEN_TIME_STATUS"] == "notDetermined" {
+        if Self.resolveShouldShowUITestScreenTimePrompt(
+            launchArguments: launchArguments,
+            launchArgumentsProvider: launchArgumentsProvider,
+            processEnvironment: processEnvironment,
+            processEnvironmentProvider: processEnvironmentProvider
+        ) {
             return true
         }
 #endif
         return false
     }
+
+#if DEBUG
+    static func resolveShouldShowUITestScreenTimePrompt(
+        launchArguments: [String]? = nil,
+        launchArgumentsProvider: LaunchArgumentsProvider = { CommandLine.arguments },
+        processEnvironment: [String: String]? = nil,
+        processEnvironmentProvider: ProcessEnvironmentProvider = { ProcessInfo.processInfo.environment }
+    ) -> Bool {
+        let resolvedLaunchArguments = launchArguments ?? launchArgumentsProvider()
+        if resolvedLaunchArguments.contains("--simulate-screen-time-not-determined") {
+            return true
+        }
+        let resolvedProcessEnvironment = processEnvironment ?? processEnvironmentProvider()
+        return resolvedProcessEnvironment["UITEST_SCREEN_TIME_STATUS"] == "notDetermined"
+    }
+#endif
 
     var body: some View {
         VStack(spacing: AppSpacing.lg) {

--- a/Tests/EyePostureReminderTests/Views/HomeViewLaunchContextResolverTests.swift
+++ b/Tests/EyePostureReminderTests/Views/HomeViewLaunchContextResolverTests.swift
@@ -1,0 +1,76 @@
+@testable import EyePostureReminder
+import XCTest
+
+#if DEBUG
+@MainActor
+final class HomeViewLaunchContextResolverTests: XCTestCase {
+    func test_resolver_withoutExplicitLaunchContext_usesInjectedProviders() {
+        var launchArgumentsProviderCallCount = 0
+        var processEnvironmentProviderCallCount = 0
+
+        let result = HomeView.resolveShouldShowUITestScreenTimePrompt(
+            launchArguments: nil,
+            launchArgumentsProvider: {
+                launchArgumentsProviderCallCount += 1
+                return ["EyePostureReminderTests", "--simulate-screen-time-not-determined"]
+            },
+            processEnvironment: nil,
+            processEnvironmentProvider: {
+                processEnvironmentProviderCallCount += 1
+                return [:]
+            }
+        )
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(launchArgumentsProviderCallCount, 1)
+        XCTAssertEqual(processEnvironmentProviderCallCount, 0)
+    }
+
+    func test_resolver_withExplicitLaunchArguments_bypassesInjectedProvider() {
+        var launchArgumentsProviderCallCount = 0
+        var processEnvironmentProviderCallCount = 0
+
+        let result = HomeView.resolveShouldShowUITestScreenTimePrompt(
+            launchArguments: ["EyePostureReminderTests", "--simulate-screen-time-not-determined"],
+            launchArgumentsProvider: {
+                launchArgumentsProviderCallCount += 1
+                return []
+            },
+            processEnvironment: [:],
+            processEnvironmentProvider: {
+                processEnvironmentProviderCallCount += 1
+                return [:]
+            }
+        )
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(launchArgumentsProviderCallCount, 0)
+        XCTAssertEqual(processEnvironmentProviderCallCount, 0)
+    }
+
+    func test_resolver_withoutExplicitProcessEnvironment_usesInjectedProvider() {
+        var processEnvironmentProviderCallCount = 0
+
+        let result = HomeView.resolveShouldShowUITestScreenTimePrompt(
+            launchArguments: ["EyePostureReminderTests"],
+            processEnvironment: nil,
+            processEnvironmentProvider: {
+                processEnvironmentProviderCallCount += 1
+                return ["UITEST_SCREEN_TIME_STATUS": "notDetermined"]
+            }
+        )
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(processEnvironmentProviderCallCount, 1)
+    }
+
+    func test_resolver_withNoDebugLaunchContext_returnsFalse() {
+        let result = HomeView.resolveShouldShowUITestScreenTimePrompt(
+            launchArguments: ["EyePostureReminderTests"],
+            processEnvironment: [:]
+        )
+
+        XCTAssertFalse(result)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- add a tiny launch-context DI seam in HomeView for DEBUG prompt overrides
- route launch-argument/environment checks through a static resolver with fallback providers
- add focused unit tests for fallback and explicit-bypass paths

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462
