### PR TITLE
#462 Phase A: AppDelegate exception-handler installer seam

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -260,3 +260,17 @@
 ## Learnings
 
 - For static launch-context helpers, add a tiny resolver seam (`launchArguments: [String]?` + `launchArgumentsProvider`) and have the public static computed property call it; this removes hard `CommandLine.arguments` coupling while preserving behavior and enables focused fallback/bypass tests (`EyePostureReminder/Services/AppCoordinator+UITestMode.swift`, `Tests/EyePostureReminderTests/Services/AppCoordinatorUITestModeResolverTests.swift`).
+
+## 2026-05-03T22:14:06Z: #462 Phase A — AppDelegate Exception Handler Installer Seam (COMPLETED)
+
+- Branch: `basher/462-phasea-appdelegate-exceptionhandler-registrar-seam`
+- Slice: Added `installUncaughtExceptionHandler: (() -> Void)?` seam to `AppDelegate` and resolved it once in `init`; production still installs the same uncaught exception handler via `NSSetUncaughtExceptionHandler`.
+- Validation: `./scripts/build.sh build` ✅, `./scripts/build.sh test` ✅.
+- Scope: `EyePostureReminder/App/AppDelegate.swift`, `Tests/EyePostureReminderTests/Services/AppDelegateTests.swift`.
+
+## Learnings
+
+- For Objective-C exception-hook wiring in app lifecycle delegates, inject an installer closure (`(() -> Void)?`) and resolve once in `init` instead of hard-coding `NSSetUncaughtExceptionHandler` inside lifecycle paths; this keeps crash logging behavior unchanged while making delegate launch wiring deterministic in tests.
+- Focus seam tests on callback invocation counts (`installUncaughtExceptionHandler()` direct call and `didFinishLaunching`) to prove lifecycle wiring without mutating global uncaught-exception handler state.
+- User preference reaffirmed: keep #462 Phase A changes to one tiny DI/SRP seam plus focused tests and run `./scripts/build.sh build` + `./scripts/build.sh test` every slice.
+- Key paths: `EyePostureReminder/App/AppDelegate.swift`, `Tests/EyePostureReminderTests/Services/AppDelegateTests.swift`, `.squad/skills/exception-handler-installer-seam/SKILL.md`.

--- a/.squad/skills/exception-handler-installer-seam/SKILL.md
+++ b/.squad/skills/exception-handler-installer-seam/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: "exception-handler-installer-seam"
+description: "Inject an AppDelegate uncaught-exception installer closure for deterministic lifecycle tests"
+domain: "testing"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+Use when app lifecycle delegates install uncaught Objective-C exception handlers directly in `didFinishLaunching`, which creates hard-to-test global side effects.
+
+## Patterns
+- Add an optional installer dependency (`installUncaughtExceptionHandler: (() -> Void)? = nil`) to the delegate initializer.
+- Resolve once in `init` with precedence: explicit installer -> production default installer.
+- Keep `installUncaughtExceptionHandler()` as the public method and route it through the resolved installer.
+- Preserve production behavior by keeping the same `NSSetUncaughtExceptionHandler` logging closure in the default installer.
+- Add focused tests that assert installer invocation both for direct method calls and launch-path wiring.
+
+## Examples
+- `EyePostureReminder/App/AppDelegate.swift`
+- `Tests/EyePostureReminderTests/Services/AppDelegateTests.swift`
+
+## Anti-Patterns
+- Hard-coding `NSSetUncaughtExceptionHandler` inside delegate lifecycle methods with no seam.
+- Unit tests that mutate global uncaught-exception handler state as setup/teardown.

--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -10,9 +10,12 @@ extension UNUserNotificationCenter: UserNotificationCenterDelegating {}
 
 final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 
+    typealias ExceptionHandlerInstaller = () -> Void
+
     private let notificationCenter: UserNotificationCenterDelegating?
     private let metricKitSubscriber: MetricKitSubscribing?
     private let settingsStore: SettingsStore?
+    private let installUncaughtExceptionHandlerImpl: ExceptionHandlerInstaller
     private let launchArguments: [String]
     private let uiTestDefaults: UserDefaults
     private let launchArgumentsProvider: () -> [String]
@@ -31,6 +34,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         notificationCenter: UserNotificationCenterDelegating? = nil,
         metricKitSubscriber: MetricKitSubscribing? = nil,
         settingsStore: SettingsStore? = nil,
+        installUncaughtExceptionHandler: ExceptionHandlerInstaller? = nil,
         launchArguments: [String]? = nil,
         uiTestDefaults: UserDefaults? = nil,
         launchArgumentsProvider: @escaping () -> [String] = { CommandLine.arguments },
@@ -42,6 +46,8 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         self.notificationCenter = notificationCenter
         self.metricKitSubscriber = metricKitSubscriber
         self.settingsStore = settingsStore
+        self.installUncaughtExceptionHandlerImpl =
+            installUncaughtExceptionHandler ?? Self.installDefaultUncaughtExceptionHandler
         self.launchArgumentsProvider = launchArgumentsProvider
         self.launchArguments = launchArguments ?? launchArgumentsProvider()
         self.makeUITestDefaults = makeUITestDefaults
@@ -103,6 +109,10 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     /// are logged at fault level before the process terminates.
     /// Fault-level messages persist to disk immediately, surviving the crash.
     func installUncaughtExceptionHandler() {
+        installUncaughtExceptionHandlerImpl()
+    }
+
+    private static func installDefaultUncaughtExceptionHandler() {
         NSSetUncaughtExceptionHandler { exception in
             let name = exception.name.rawValue
             let reason = exception.reason ?? "nil"

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -130,19 +130,34 @@ final class AppDelegateTests: XCTestCase {
 
     // MARK: - Uncaught exception handler
 
-    /// Verifies `installUncaughtExceptionHandler` sets a non-nil global handler.
-    /// Called directly because `application(_:didFinishLaunchingWithOptions:)` touches
-    /// MetricKit and UNNotificationCenter which crash in the unit-test host.
-    func test_appDelegate_installsUncaughtExceptionHandler() {
-        NSSetUncaughtExceptionHandler(nil)
-        XCTAssertNil(NSGetUncaughtExceptionHandler(), "precondition: handler should be nil")
-
-        delegate.installUncaughtExceptionHandler()
-
-        XCTAssertNotNil(
-            NSGetUncaughtExceptionHandler(),
-            "installUncaughtExceptionHandler must set a global exception handler"
+    func test_installUncaughtExceptionHandler_usesInjectedInstaller() {
+        var registerCallCount = 0
+        let sut = AppDelegate(
+            installUncaughtExceptionHandler: {
+                registerCallCount += 1
+            }
         )
+
+        sut.installUncaughtExceptionHandler()
+
+        XCTAssertEqual(registerCallCount, 1)
+    }
+
+    func test_didFinishLaunching_registersUncaughtExceptionHandlerViaInjectedInstaller() {
+        let mockCenter = MockUserNotificationCenter()
+        let mockMetricKitSubscriber = MockMetricKitSubscriber()
+        var registerCallCount = 0
+        let sut = AppDelegate(
+            notificationCenter: mockCenter,
+            metricKitSubscriber: mockMetricKitSubscriber,
+            installUncaughtExceptionHandler: {
+                registerCallCount += 1
+            }
+        )
+
+        _ = sut.application(UIApplication.shared, didFinishLaunchingWithOptions: nil)
+
+        XCTAssertEqual(registerCallCount, 1)
     }
 
     func test_didFinishLaunching_registersDelegateAndMetricKitViaInjectedSeams() {


### PR DESCRIPTION
## Summary
- inject an optional installUncaughtExceptionHandler seam into AppDelegate and resolve once in init
- keep production behavior unchanged by defaulting to the existing NSSetUncaughtExceptionHandler installation logic
- add focused AppDelegate tests covering direct installer invocation and didFinishLaunching wiring

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462
