### PR TITLE
Phase A: centralize AppDelegate notification routing

### DIFF
--- a/.squad/agents/basher/history.md
+++ b/.squad/agents/basher/history.md
@@ -324,3 +324,16 @@
 ## Learnings
 
 - Keep CI gate names and commands aligned: if a required check is "Build & Test", wire it to build/test commands only; run lint in a dedicated lint gate to avoid unrelated debt blocking functional PRs.
+
+## 2026-05-04T00:00:00Z: #462 Phase A — AppDelegate Notification Route SRP seam (COMPLETED)
+
+- Slice: centralized category-ID routing into `AppDelegate.notificationRoute(for:)` + shared `dispatchNotificationRoute(_:)` so both notification delegate callbacks use one source of truth.
+- Validation: `./scripts/build.sh build` ✅ and `./scripts/build.sh test` ✅ (2044 tests, 0 failures).
+- Scope: `EyePostureReminder/App/AppDelegate.swift`, `Tests/EyePostureReminderTests/Services/AppDelegateTests.swift`.
+
+## Learnings
+
+- For duplicate UNUserNotificationCenter delegate branches (`willPresent`/`didReceive`), extract a shared route enum + resolver method and dispatch helper in AppDelegate to keep routing behavior consistent and testable.
+- Focus route tests on category-ID → route mapping (`.reminder`, `.snoozeWake`, `.ignore`) so callback coverage does not depend on constructing system-only `UNNotification` objects.
+- User preference reinforced: keep #462 Phase A slices surgical (one DI/SRP production seam + focused tests + required `./scripts/build.sh build` and `./scripts/build.sh test`).
+- Key file paths: `EyePostureReminder/App/AppDelegate.swift`, `Tests/EyePostureReminderTests/Services/AppDelegateTests.swift`.

--- a/.squad/skills/appdelegate-notification-route-seam/SKILL.md
+++ b/.squad/skills/appdelegate-notification-route-seam/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: "appdelegate-notification-route-seam"
+description: "Unify AppDelegate notification category routing with a shared route resolver and dispatcher"
+domain: "testing"
+confidence: "high"
+source: "earned"
+---
+
+## Context
+Use when `AppDelegate` has duplicated category-ID routing logic across both `UNUserNotificationCenterDelegate` callbacks.
+
+## Pattern
+- Add a small route enum (e.g. `.reminder(ReminderType)`, `.snoozeWake`, `.ignore`).
+- Add `notificationRoute(for:)` as a single category resolver.
+- Add `dispatchNotificationRoute(_:)` for coordinator side effects.
+- Call resolver + dispatcher from both `willPresent` and `didReceive`.
+- Add focused route-mapping tests on the resolver method.
+
+## Anti-Patterns
+- Copy/pasting reminder/snooze routing branches in multiple delegate callbacks.
+- Testing routing only through system-only notification objects instead of testing the resolver directly.

--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -10,6 +10,12 @@ extension UNUserNotificationCenter: UserNotificationCenterDelegating {}
 
 final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
 
+    enum NotificationRoute: Equatable {
+        case reminder(ReminderType)
+        case snoozeWake
+        case ignore
+    }
+
     typealias ExceptionHandlerInstaller = () -> Void
 
     private let notificationCenter: UserNotificationCenterDelegating?
@@ -204,6 +210,32 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
 
     // MARK: - UNUserNotificationCenterDelegate
 
+    func notificationRoute(for categoryID: String) -> NotificationRoute {
+        if let type = ReminderType(categoryIdentifier: categoryID) {
+            return .reminder(type)
+        }
+        if categoryID == AppCoordinator.snoozeWakeCategory {
+            return .snoozeWake
+        }
+        return .ignore
+    }
+
+    private func dispatchNotificationRoute(_ route: NotificationRoute) {
+        switch route {
+        case .reminder(let type):
+            Task { @MainActor [weak self] in
+                self?.coordinator?.handleNotification(for: type)
+            }
+        case .snoozeWake:
+            Task { @MainActor [weak self] in
+                self?.coordinator?.cancelSnoozeWakeTaskIfNeeded()
+                await self?.coordinator?.scheduleReminders()
+            }
+        case .ignore:
+            break
+        }
+    }
+
     /// Foreground delivery — show overlay immediately via coordinator.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
@@ -211,18 +243,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
     ) {
         let categoryID = notification.request.content.categoryIdentifier
-        if let type = ReminderType(categoryIdentifier: categoryID) {
-            Task { @MainActor [weak self] in
-                self?.coordinator?.handleNotification(for: type)
-            }
-        } else if categoryID == AppCoordinator.snoozeWakeCategory {
-            // Snooze has expired — cancel the in-process wake Task first so it
-            // doesn't also call handleSnoozeWake() and double-fire analytics.
-            Task { @MainActor [weak self] in
-                self?.coordinator?.cancelSnoozeWakeTaskIfNeeded()
-                await self?.coordinator?.scheduleReminders()
-            }
-        }
+        dispatchNotificationRoute(notificationRoute(for: categoryID))
         // Suppress the system banner — our overlay (or no-op) is the UI.
         completionHandler([])
     }
@@ -234,18 +255,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
         let categoryID = response.notification.request.content.categoryIdentifier
-        if let type = ReminderType(categoryIdentifier: categoryID) {
-            Task { @MainActor [weak self] in
-                self?.coordinator?.handleNotification(for: type)
-            }
-        } else if categoryID == AppCoordinator.snoozeWakeCategory {
-            // Snooze notification tapped (or delivered silently) — cancel the in-process
-            // wake Task before resuming so the two paths don't double-reschedule.
-            Task { @MainActor [weak self] in
-                self?.coordinator?.cancelSnoozeWakeTaskIfNeeded()
-                await self?.coordinator?.scheduleReminders()
-            }
-        }
+        dispatchNotificationRoute(notificationRoute(for: categoryID))
         completionHandler()
     }
 }

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -18,17 +18,17 @@ private final class MockMetricKitSubscriber: MetricKitSubscribing {
 ///
 /// ## What is tested here
 /// - `applicationDidBecomeActive` → clears an expired `snoozedUntil` (via coordinator)
-/// - `ReminderType(categoryIdentifier:)` parsing — the core category-routing logic
-///   used by both `willPresent` and `didReceive`
-/// - `AppCoordinator.snoozeWakeCategory` is distinct from all `ReminderType` identifiers
-///   so snooze-wake routes to `scheduleReminders()` instead of `handleNotification`
+/// - `AppDelegate.notificationRoute(for:)` category routing used by both
+///   `willPresent` and `didReceive`
+/// - `AppCoordinator.snoozeWakeCategory` routes to `scheduleReminders()`
+///   instead of `handleNotification(for:)`
 ///
 /// ## Why `willPresent` and `didReceive` are not called directly
 /// `UNNotification` and `UNNotificationResponse` have no public initialisers — they
 /// are vended exclusively by the system. Because the routing logic inside those two
 /// delegate methods is entirely determined by `categoryIdentifier` string → action
-/// dispatch, testing `ReminderType(categoryIdentifier:)` and the coordinator's
-/// downstream methods provides equivalent coverage without system-object construction.
+/// dispatch, testing `notificationRoute(for:)` and the coordinator's downstream
+/// methods provides equivalent coverage without system-object construction.
 @MainActor
 final class AppDelegateTests: XCTestCase {
 
@@ -482,34 +482,31 @@ final class AppDelegateTests: XCTestCase {
     }
 #endif
 
-    // MARK: - Category-identifier routing logic (ReminderType parsing)
+    // MARK: - Category-identifier routing logic
 
-    /// The two valid reminder category identifiers must parse to the correct types.
-    func test_categoryIdentifier_eyeReminder_parsesToEyes() {
-        let type = ReminderType(categoryIdentifier: "EYE_REMINDER")
-        XCTAssertEqual(type, .eyes, "'EYE_REMINDER' must parse to .eyes")
+    func test_notificationRoute_eyeReminder_routesToEyes() {
+        let route = delegate.notificationRoute(for: "EYE_REMINDER")
+
+        XCTAssertEqual(route, .reminder(.eyes))
     }
 
-    func test_categoryIdentifier_postureReminder_parsesToPosture() {
-        let type = ReminderType(categoryIdentifier: "POSTURE_REMINDER")
-        XCTAssertEqual(type, .posture, "'POSTURE_REMINDER' must parse to .posture")
+    func test_notificationRoute_postureReminder_routesToPosture() {
+        let route = delegate.notificationRoute(for: "POSTURE_REMINDER")
+
+        XCTAssertEqual(route, .reminder(.posture))
     }
 
-    /// An unrecognised category identifier must return `nil` — the delegate no-ops.
-    func test_categoryIdentifier_unknown_returnsNil() {
-        XCTAssertNil(ReminderType(categoryIdentifier: "UNKNOWN_CATEGORY"))
-        XCTAssertNil(ReminderType(categoryIdentifier: ""))
-        XCTAssertNil(ReminderType(categoryIdentifier: "eye_reminder")) // case-sensitive
+    func test_notificationRoute_snoozeWake_routesToSnoozeWake() {
+        let route = delegate.notificationRoute(for: AppCoordinator.snoozeWakeCategory)
+
+        XCTAssertEqual(route, .snoozeWake)
     }
 
-    /// The snooze-wake category must NOT map to any `ReminderType` — this is what
-    /// causes the delegate to route to `scheduleReminders()` instead of
-    /// `handleNotification(for:)`.
-    func test_snoozeWakeCategory_doesNotParseToAnyReminderType() {
-        let type = ReminderType(categoryIdentifier: AppCoordinator.snoozeWakeCategory)
-        XCTAssertNil(
-            type,
-            "snoozeWakeCategory must not map to a ReminderType — it has its own routing branch")
+    /// An unrecognised category identifier must route to `.ignore`.
+    func test_notificationRoute_unknown_routesToIgnore() {
+        XCTAssertEqual(delegate.notificationRoute(for: "UNKNOWN_CATEGORY"), .ignore)
+        XCTAssertEqual(delegate.notificationRoute(for: ""), .ignore)
+        XCTAssertEqual(delegate.notificationRoute(for: "eye_reminder"), .ignore) // case-sensitive
     }
 
     /// Every `ReminderType` case must produce a `categoryIdentifier` that round-trips


### PR DESCRIPTION
## Summary
- extract AppDelegate notificationRoute(for:) to centralize category ID routing
- route both UNUserNotificationCenter delegate callbacks through shared dispatchNotificationRoute
- add focused route-mapping unit tests for reminder, snooze-wake, and ignore paths

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462