### PR TITLE
#462 Phase A: optional AppCoordinator notification center factory

### DIFF
--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -184,7 +184,7 @@ final class AppCoordinator: ObservableObject {
         scheduler: ReminderScheduling? = nil,
         makeScheduler: (() -> ReminderScheduling)? = nil,
         notificationCenter: NotificationScheduling? = nil,
-        makeNotificationCenter: @escaping () -> NotificationScheduling = { UNUserNotificationCenter.current() },
+        makeNotificationCenter: (() -> NotificationScheduling)? = nil,
         overlayManager: OverlayPresenting? = nil,
         makeOverlayManager: (() -> OverlayPresenting)? = nil,
         screenTimeTracker: ScreenTimeTracking? = nil,
@@ -216,7 +216,8 @@ final class AppCoordinator: ObservableObject {
         )
         self.settings = Self.resolveSettings(settings, makeSettings: makeSettings)
         self.scheduler = Self.resolveScheduler(scheduler, makeScheduler: makeScheduler)
-        self.notificationCenter = notificationCenter ?? makeNotificationCenter()
+        let resolvedMakeNotificationCenter = makeNotificationCenter ?? { UNUserNotificationCenter.current() }
+        self.notificationCenter = notificationCenter ?? resolvedMakeNotificationCenter()
         self.overlayManager = Self.resolveOverlayManager(
             overlayManager,
             makeOverlayManager: makeOverlayManager

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -237,6 +237,25 @@ final class AppCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.notificationAuthStatus, .denied)
     }
 
+    func test_init_withExplicitNotificationCenter_andNilNotificationCenterFactory_keepsInjectedCenter() async {
+        let injectedCenter = MockNotificationCenter()
+        injectedCenter.authorizationGranted = false
+        let coordinator = AppCoordinator(
+            settings: SettingsStore(store: MockSettingsPersisting()),
+            scheduler: ReminderScheduler(notificationCenter: injectedCenter),
+            notificationCenter: injectedCenter,
+            makeNotificationCenter: nil,
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: MockAppGroupIPCRecorder()
+        )
+        defer { coordinator.stopFallbackTimers() }
+
+        await coordinator.refreshAuthStatus()
+
+        XCTAssertEqual(coordinator.notificationAuthStatus, .denied)
+    }
+
     func test_init_withoutScreenTimeTracker_usesInjectedScreenTimeTrackerFactory() {
         var factoryCallCount = 0
         let factoryTracker = MockScreenTimeTracker()


### PR DESCRIPTION
Summary:\n- make AppCoordinator notification-center factory optional\n- resolve UNUserNotificationCenter.current fallback inside init only when needed\n- add focused unit test for explicit notification center + nil factory\n\nValidation:\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nRefs #462