### PR TITLE
#462 Phase A: LiveDrivingActivityDetector motion manager factory seam

### DIFF
--- a/EyePostureReminder/Services/PauseConditionManager.swift
+++ b/EyePostureReminder/Services/PauseConditionManager.swift
@@ -211,6 +211,18 @@ final class LiveCarPlayDetector: CarPlayDetecting {
     }
 }
 
+// MARK: - MotionActivityManaging
+
+/// Abstracts `CMMotionActivityManager` instance methods used by
+/// `LiveDrivingActivityDetector` so the detector can be unit-tested without
+/// invoking real CoreMotion hardware.
+protocol MotionActivityManaging {
+    func startActivityUpdates(to queue: OperationQueue, withHandler handler: @escaping CMMotionActivityHandler)
+    func stopActivityUpdates()
+}
+
+extension CMMotionActivityManager: MotionActivityManaging {}
+
 // MARK: - LiveDrivingActivityDetector
 
 /// Uses `CMMotionActivityManager` to detect automotive activity with high confidence.
@@ -219,10 +231,19 @@ final class LiveCarPlayDetector: CarPlayDetecting {
 @MainActor
 final class LiveDrivingActivityDetector: DrivingActivityDetecting {
 
+    typealias MotionManagerFactory = () -> MotionActivityManaging
+
     private(set) var isDriving: Bool = false
     var onDrivingChanged: ((Bool) -> Void)?
 
-    private let manager = CMMotionActivityManager()
+    private let manager: MotionActivityManaging
+
+    init(
+        motionManager: MotionActivityManaging? = nil,
+        makeMotionManager: @escaping MotionManagerFactory = { CMMotionActivityManager() }
+    ) {
+        self.manager = motionManager ?? makeMotionManager()
+    }
 
     func startMonitoring() {
         guard CMMotionActivityManager.isActivityAvailable() else {

--- a/Tests/EyePostureReminderTests/Services/LiveDrivingActivityDetectorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/LiveDrivingActivityDetectorTests.swift
@@ -1,0 +1,99 @@
+@testable import EyePostureReminder
+import CoreMotion
+import XCTest
+
+// MARK: - LiveDrivingActivityDetectorTests
+//
+// Verifies the `MotionManagerFactory` DI seam on `LiveDrivingActivityDetector`.
+// Tests confirm that:
+//   1. The factory is called exactly once when no manager is injected.
+//   2. The factory is bypassed when a concrete manager is injected directly.
+//   3. `stopMonitoring()` delegates to `manager.stopActivityUpdates()`.
+//
+// `startMonitoring()` early-exits on simulators (`CMMotionActivityManager.isActivityAvailable()
+// == false`), so `startActivityUpdates(to:withHandler:)` is not testable in this target.
+// That guard path is covered by the existing `PauseConditionManagerTests`.
+
+@MainActor
+final class LiveDrivingActivityDetectorTests: XCTestCase {
+
+    // MARK: - Stub
+
+    private final class StubMotionManager: MotionActivityManaging {
+        private(set) var startActivityUpdatesCallCount = 0
+        private(set) var stopActivityUpdatesCallCount  = 0
+
+        func startActivityUpdates(
+            to queue: OperationQueue,
+            withHandler handler: @escaping CMMotionActivityHandler
+        ) {
+            startActivityUpdatesCallCount += 1
+        }
+
+        func stopActivityUpdates() {
+            stopActivityUpdatesCallCount += 1
+        }
+    }
+
+    // MARK: - Factory seam
+
+    func test_init_withoutMotionManager_usesFactoryFallback() {
+        var factoryCallCount = 0
+        _ = LiveDrivingActivityDetector(
+            makeMotionManager: {
+                factoryCallCount += 1
+                return StubMotionManager()
+            }
+        )
+
+        XCTAssertEqual(factoryCallCount, 1, "Factory must be called exactly once when no manager is injected")
+    }
+
+    func test_init_withMotionManager_bypassesFactory() {
+        var factoryCallCount = 0
+        let injected = StubMotionManager()
+        _ = LiveDrivingActivityDetector(
+            motionManager: injected,
+            makeMotionManager: {
+                factoryCallCount += 1
+                return StubMotionManager()
+            }
+        )
+
+        XCTAssertEqual(factoryCallCount, 0, "Factory must NOT be called when a manager is injected directly")
+    }
+
+    // MARK: - stopMonitoring delegates to manager
+
+    func test_stopMonitoring_callsStopActivityUpdates() {
+        let stub = StubMotionManager()
+        let detector = LiveDrivingActivityDetector(motionManager: stub)
+
+        detector.stopMonitoring()
+
+        XCTAssertEqual(
+            stub.stopActivityUpdatesCallCount,
+            1,
+            "stopMonitoring() must call manager.stopActivityUpdates() exactly once")
+    }
+
+    func test_stopMonitoring_calledTwice_delegatesBothCalls() {
+        let stub = StubMotionManager()
+        let detector = LiveDrivingActivityDetector(motionManager: stub)
+
+        detector.stopMonitoring()
+        detector.stopMonitoring()
+
+        XCTAssertEqual(
+            stub.stopActivityUpdatesCallCount,
+            2,
+            "Each stopMonitoring() call must forward to manager.stopActivityUpdates()")
+    }
+
+    // MARK: - Default isDriving state
+
+    func test_init_isDrivingDefaultsFalse() {
+        let detector = LiveDrivingActivityDetector(motionManager: StubMotionManager())
+        XCTAssertFalse(detector.isDriving, "isDriving must default to false")
+    }
+}


### PR DESCRIPTION
## Summary
- Extract `MotionActivityManaging` protocol abstracting `CMMotionActivityManager` instance methods (`startActivityUpdates` + `stopActivityUpdates`)
- Extend `CMMotionActivityManager: MotionActivityManaging`
- Add `MotionManagerFactory` typealias + `motionManager`/`makeMotionManager` init params to `LiveDrivingActivityDetector`, replacing the hard-coded `private let manager = CMMotionActivityManager()`
- Add `LiveDrivingActivityDetectorTests`: 5 focused tests covering factory seam, stop delegation, and default state

## Validation
- `./scripts/build.sh build` ✓
- `./scripts/build.sh test` ✓ — 2050 tests, 0 failures

Refs #462