### PR TITLE
#462 Phase A: OnboardingView accessibility poster factory seam

### DIFF
--- a/.squad/agents/rusty/history.md
+++ b/.squad/agents/rusty/history.md
@@ -336,3 +336,13 @@ Result: **10/10 passed**
 - Added an `AudioSessionRouting` protocol seam in `PauseConditionManager.swift` and extended `AVAudioSession` to conform, removing direct `AVAudioSession.sharedInstance()` access from `LiveCarPlayDetector` static route logic.
 - `LiveCarPlayDetector` now resolves dependencies with optional injection + factory fallback (`audioSession ?? makeAudioSession()`), preserving existing behavior while improving DI clarity.
 - Added focused seam coverage in `LiveCarPlayDetectorTests` for factory fallback and injected bypass paths, alongside existing behavior tests.
+
+
+## Learnings
+
+### 2026-05-04: #462 Phase A Micro-slice — OnboardingView Accessibility Poster Factory Seam
+
+- **Architecture decision:** Removed eager concrete construction from `OnboardingView` by resolving `AccessibilityNotificationPosting` via optional injection plus fallback factory.
+- **Pattern:** For DI/SRP micro-slices, keep API behavior stable with `Dependency? = nil` + `makeDependency` factory and verify fallback/bypass in focused unit tests.
+- **User preference captured:** Continue Ralph loop in tiny, surgical slices with behavior preservation and explicit build/test validation.
+- **Key file paths:** `EyePostureReminder/Views/Onboarding/OnboardingView.swift`, `Tests/EyePostureReminderTests/Views/OnboardingViewTests.swift`, `.squad/decisions/inbox/rusty-onboarding-poster-factory-seam.md`.

--- a/.squad/skills/accessibility-poster-factory-seam/SKILL.md
+++ b/.squad/skills/accessibility-poster-factory-seam/SKILL.md
@@ -18,3 +18,10 @@ Use when a service initializer eagerly constructs `LiveAccessibilityNotification
 ## Anti-Patterns
 - Eager concrete construction in initializer defaults.
 - Mixed usage of injected dependency and newly constructed concrete instances.
+
+## Examples
+- `EyePostureReminder/Services/OverlayManager.swift`
+- `Tests/EyePostureReminderTests/Services/OverlayManagerExtendedTests.swift`
+- `EyePostureReminder/Views/Onboarding/OnboardingView.swift`
+- `Tests/EyePostureReminderTests/Views/OnboardingViewTests.swift`
+

--- a/EyePostureReminder/Views/Onboarding/OnboardingView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingView.swift
@@ -7,6 +7,8 @@ import SwiftUI
 import UIKit
 
 struct OnboardingView: View {
+    typealias AccessibilityNotificationPosterFactory = () -> AccessibilityNotificationPosting
+
     @EnvironmentObject private var coordinator: AppCoordinator
     @EnvironmentObject private var settings: SettingsStore
     @StateObject private var selectedAppsState = SelectedAppsState()
@@ -15,8 +17,13 @@ struct OnboardingView: View {
 
     private let accessibilityNotificationPoster: AccessibilityNotificationPosting
 
-    init(accessibilityNotificationPoster: AccessibilityNotificationPosting = LiveAccessibilityNotificationPoster()) {
-        self.accessibilityNotificationPoster = accessibilityNotificationPoster
+    init(
+        accessibilityNotificationPoster: AccessibilityNotificationPosting? = nil,
+        makeAccessibilityNotificationPoster: @escaping AccessibilityNotificationPosterFactory = {
+            LiveAccessibilityNotificationPoster()
+        }
+    ) {
+        self.accessibilityNotificationPoster = accessibilityNotificationPoster ?? makeAccessibilityNotificationPoster()
     }
 
     private static let configurePageControl: Void = {

--- a/Tests/EyePostureReminderTests/Views/OnboardingViewTests.swift
+++ b/Tests/EyePostureReminderTests/Views/OnboardingViewTests.swift
@@ -370,6 +370,34 @@ final class OnboardingViewTests: XCTestCase {
         _ = view
     }
 
+    /// When no poster is injected, the fallback factory is used once.
+    func test_onboardingView_accessibilityPosterFactory_usedWhenDependencyMissing() {
+        var factoryCallCount = 0
+        let view = OnboardingView(
+            accessibilityNotificationPoster: nil,
+            makeAccessibilityNotificationPoster: {
+                factoryCallCount += 1
+                return MockAccessibilityNotificationPoster()
+            }
+        )
+        _ = view
+        XCTAssertEqual(factoryCallCount, 1)
+    }
+
+    /// When a poster is injected, the fallback factory is bypassed.
+    func test_onboardingView_accessibilityPosterFactory_bypassedWhenDependencyProvided() {
+        var factoryCallCount = 0
+        let view = OnboardingView(
+            accessibilityNotificationPoster: MockAccessibilityNotificationPoster(),
+            makeAccessibilityNotificationPoster: {
+                factoryCallCount += 1
+                return MockAccessibilityNotificationPoster()
+            }
+        )
+        _ = view
+        XCTAssertEqual(factoryCallCount, 0)
+    }
+
     // MARK: - Onboarding completion screen-changed notification (#402)
 
     /// `finishOnboarding()` must post a `.screenChanged` notification so VoiceOver


### PR DESCRIPTION
## Summary
- replace eager LiveAccessibilityNotificationPoster initializer default in OnboardingView with optional dependency plus fallback factory seam
- preserve runtime behavior by resolving to the live poster when no dependency is injected
- add focused tests for factory fallback-used and explicit dependency bypass paths

## Validation
- ./scripts/build.sh build
- ./scripts/build.sh test

Refs #462