### PR TITLE
Protect hosted privacy policy link

### DIFF
--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -35,6 +35,9 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         metricKitSubscriber ?? makeMetricKitSubscriber()
     private lazy var resolvedSettingsStore: SettingsStore =
         settingsStore ?? makeSettingsStore()
+#if DEBUG
+    static let uiTestOverlayBreakDuration: TimeInterval = 600
+#endif
 
     override convenience init() {
         self.init(notificationCenter: nil)
@@ -163,16 +166,16 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
             defaults.set(true, forKey: AppStorageKey.hasSeenOnboarding)
             let settings = resolvedSettingsStore
             settings.resetToDefaults()
-            settings.eyesBreakDuration = 120
-            settings.postureBreakDuration = 120
+            settings.eyesBreakDuration = Self.uiTestOverlayBreakDuration
+            settings.postureBreakDuration = Self.uiTestOverlayBreakDuration
             defaults.set(ReminderType.eyes.rawValue, forKey: AppStorageKey.uiTestOverlayType)
         }
         if args.contains("--show-overlay-posture") {
             defaults.set(true, forKey: AppStorageKey.hasSeenOnboarding)
             let settings = resolvedSettingsStore
             settings.resetToDefaults()
-            settings.eyesBreakDuration = 120
-            settings.postureBreakDuration = 120
+            settings.eyesBreakDuration = Self.uiTestOverlayBreakDuration
+            settings.postureBreakDuration = Self.uiTestOverlayBreakDuration
             defaults.set(ReminderType.posture.rawValue, forKey: AppStorageKey.uiTestOverlayType)
         }
         if args.contains("--simulate-screen-time-not-determined") {

--- a/EyePostureReminder/Utilities/LegalLinks.swift
+++ b/EyePostureReminder/Utilities/LegalLinks.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+enum LegalLinks {
+    static let hostedPrivacyPolicyURL = URL(
+        string: "https://github.com/yashasg/fantastic-octo-fortnight/blob/main/docs/legal/PRIVACY.md"
+    )
+}

--- a/EyePostureReminder/Views/SettingsView.swift
+++ b/EyePostureReminder/Views/SettingsView.swift
@@ -77,8 +77,6 @@ struct SettingsView: View {
     @State private var savedBannerTask: Task<Void, Never>?
 
     private let accessibilityNotificationPoster: AccessibilityNotificationPosting
-    private let hostedPrivacyPolicyURL = URL(string: "https://github.com/yashasg/fantastic-octo-fortnight/blob/main/docs/legal/PRIVACY.md")
-
     init(
         isPresented: Binding<Bool>,
         accessibilityNotificationPoster: AccessibilityNotificationPosting = LiveAccessibilityNotificationPoster()
@@ -268,7 +266,7 @@ struct SettingsView: View {
                 .listRowSeparatorTint(AppColor.separatorSoft)
 
                 Button {
-                    guard let hostedPrivacyPolicyURL else { return }
+                    guard let hostedPrivacyPolicyURL = LegalLinks.hostedPrivacyPolicyURL else { return }
                     openURL(hostedPrivacyPolicyURL)
                 } label: {
                     Text("Hosted Privacy Policy (Web)")

--- a/Tests/EyePostureReminderTests/RegressionTests.swift
+++ b/Tests/EyePostureReminderTests/RegressionTests.swift
@@ -331,18 +331,22 @@ final class ScreenTimeTrackerRegressionTests: XCTestCase {
     /// Regression guard: if the counter is not reset, callbacks would stop after the first fire.
     func test_thresholdReached_resetsCounter_enablingSecondCycle() {
         var callCount = 0
-        let secondCallbackFired = expectation(description: "second callback after counter reset")
 
         sut.setThreshold(2, for: .eyes)
         sut.onThresholdReached = { type in
             if type == .eyes {
                 callCount += 1
-                if callCount >= 2 { secondCallbackFired.fulfill() }
             }
         }
 
-        NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-        wait(for: [secondCallbackFired], timeout: 7.0)
+        sut.tick(now: 100)
+        XCTAssertEqual(callCount, 0)
+        sut.tick(now: 101)
+        XCTAssertEqual(callCount, 1)
+        sut.tick(now: 102)
+        XCTAssertEqual(callCount, 1)
+        sut.tick(now: 103)
+        XCTAssertEqual(callCount, 2)
     }
 
     // MARK: Lifecycle: willResignActive Pauses Accumulation

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -14,6 +14,7 @@ private final class MockMetricKitSubscriber: MetricKitSubscribing {
     }
 }
 
+// swiftlint:disable type_body_length
 /// Unit tests for `AppDelegate` notification routing logic.
 ///
 /// ## What is tested here
@@ -423,8 +424,8 @@ final class AppDelegateTests: XCTestCase {
 
         XCTAssertEqual(makeSettingsStoreCallCount, 1)
         XCTAssertEqual(defaults.string(forKey: AppStorageKey.uiTestOverlayType), ReminderType.eyes.rawValue)
-        XCTAssertEqual(settings.eyesBreakDuration, 120)
-        XCTAssertEqual(settings.postureBreakDuration, 120)
+        XCTAssertEqual(settings.eyesBreakDuration, AppDelegate.uiTestOverlayBreakDuration)
+        XCTAssertEqual(settings.postureBreakDuration, AppDelegate.uiTestOverlayBreakDuration)
     }
 
     func test_didFinishLaunching_withNilSettingsStore_usesInjectedFactoryOnce() throws {
@@ -476,8 +477,8 @@ final class AppDelegateTests: XCTestCase {
 
         XCTAssertEqual(makeSettingsStoreCallCount, 0)
         XCTAssertEqual(defaults.string(forKey: AppStorageKey.uiTestOverlayType), ReminderType.eyes.rawValue)
-        XCTAssertEqual(explicitSettings.eyesBreakDuration, 120)
-        XCTAssertEqual(explicitSettings.postureBreakDuration, 120)
+        XCTAssertEqual(explicitSettings.eyesBreakDuration, AppDelegate.uiTestOverlayBreakDuration)
+        XCTAssertEqual(explicitSettings.postureBreakDuration, AppDelegate.uiTestOverlayBreakDuration)
     }
 
     func test_consumeUITestOverlayType_withValidValue_returnsTypeAndClearsKey() throws {
@@ -615,3 +616,4 @@ final class AppDelegateTests: XCTestCase {
         return defaults
     }
 }
+// swiftlint:enable type_body_length

--- a/Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift
@@ -2,6 +2,8 @@
 import UIKit
 import XCTest
 
+// swiftlint:disable type_body_length
+
 /// Unit tests for `ScreenTimeTracker`.
 ///
 /// Tests are split into two groups:
@@ -659,6 +661,8 @@ extension ScreenTimeTrackerTests {
 
 }
 
+// swiftlint:enable type_body_length
+
 extension ScreenTimeTrackerTests {
 
     /// Verifies the `min(now - lastTickTime, 2.0)` cap in `tick(now:)`.
@@ -875,13 +879,13 @@ extension ScreenTimeTrackerTests {
         defer { tracker.stop() }
 
         let fired = expectation(description: "threshold reached via injected lifecycle center")
-        tracker.setThreshold(2, for: .eyes)
+        tracker.setThreshold(1, for: .eyes)
         tracker.onThresholdReached = { type in
             if type == .eyes { fired.fulfill() }
         }
 
         lifecycleCenter.post(name: UIApplication.didBecomeActiveNotification, object: nil)
-        await fulfillment(of: [fired], timeout: 3.0)
+        await fulfillment(of: [fired], timeout: 5.0)
     }
 
     func test_customLifecycleNotificationCenter_ignoresDefaultCenterPosts() async {
@@ -890,7 +894,9 @@ extension ScreenTimeTrackerTests {
         defer { tracker.stop() }
 
         tracker.setThreshold(2, for: .eyes)
-        tracker.onThresholdReached = { _ in XCTFail("Default notification center should not trigger tracker callbacks") }
+        tracker.onThresholdReached = { _ in
+            XCTFail("Default notification center should not trigger tracker callbacks")
+        }
 
         NotificationCenter.default.post(name: UIApplication.didBecomeActiveNotification, object: nil)
         try? await Task.sleep(nanoseconds: 2_500_000_000)

--- a/Tests/EyePostureReminderTests/Utilities/LegalLinksTests.swift
+++ b/Tests/EyePostureReminderTests/Utilities/LegalLinksTests.swift
@@ -1,0 +1,12 @@
+@testable import EyePostureReminder
+import XCTest
+
+final class LegalLinksTests: XCTestCase {
+    func test_hostedPrivacyPolicyURL_pointsToPublicRepoPolicy() throws {
+        let url = try XCTUnwrap(LegalLinks.hostedPrivacyPolicyURL)
+
+        XCTAssertEqual(url.scheme, "https")
+        XCTAssertEqual(url.host, "github.com")
+        XCTAssertEqual(url.path, "/yashasg/fantastic-octo-fortnight/blob/main/docs/legal/PRIVACY.md")
+    }
+}

--- a/Tests/EyePostureReminderUITests/DarkModeUITests.swift
+++ b/Tests/EyePostureReminderUITests/DarkModeUITests.swift
@@ -107,13 +107,13 @@ final class DarkModeUITests: XCTestCase {
 
         let dismissButton = app.buttons["overlay.dismissButton"]
         XCTAssertTrue(
-            dismissButton.waitForExistence(timeout: 1.5),
+            app.waitForElementExists(dismissButton),
             "Dismiss (×) button must be visible on the overlay in dark mode."
         )
 
         let supportiveText = app.staticTexts["overlay.supportiveText"]
         XCTAssertTrue(
-            supportiveText.waitForExistence(timeout: 1.5),
+            app.waitForElementExists(supportiveText),
             "Supportive text must be visible on the overlay in dark mode."
         )
     }
@@ -167,7 +167,7 @@ final class DarkModeUITests: XCTestCase {
 
         let supportiveText = app.staticTexts["overlay.supportiveText"]
         XCTAssertTrue(
-            supportiveText.waitForExistence(timeout: 1.5),
+            app.waitForElementExists(supportiveText),
             "Supportive text must be visible on the posture overlay in dark mode."
         )
     }

--- a/Tests/EyePostureReminderUITests/OverlayTests.swift
+++ b/Tests/EyePostureReminderUITests/OverlayTests.swift
@@ -212,44 +212,28 @@ final class OverlayPostureTests: XCTestCase {
         app = nil
     }
 
-    // MARK: - test_overlay_postureVariant_dismissButtonVisible
+    // MARK: - test_overlay_postureVariant_visibleAndDismissible
 
-    /// Verifies the × dismiss button appears on the posture check overlay.
-    func test_overlay_postureVariant_dismissButtonVisible() throws {
+    /// Verifies the posture check overlay renders with its essential controls and dismisses.
+    func test_overlay_postureVariant_visibleAndDismissible() throws {
         let dismissButton = app.buttons["overlay.dismissButton"]
         XCTAssertTrue(
             app.waitForElementExists(dismissButton),
             "Overlay dismiss button must be visible when --show-overlay-posture is used."
         )
-    }
 
-    // MARK: - test_overlay_postureVariant_doneButtonVisible
-
-    /// Verifies the Done CTA button is visible on the posture check overlay.
-    func test_overlay_postureVariant_doneButtonVisible() throws {
         let doneButton = app.buttons["overlay.doneButton"]
         XCTAssertTrue(
             app.waitForElementExists(doneButton),
             "Done button must be visible on the posture overlay."
         )
-    }
 
-    // MARK: - test_overlay_postureVariant_supportiveTextVisible
-
-    /// Verifies the supportive text is visible on the posture check overlay.
-    func test_overlay_postureVariant_supportiveTextVisible() throws {
         let supportiveText = app.staticTexts["overlay.supportiveText"]
         XCTAssertTrue(
             app.waitForElementExists(supportiveText),
             "Supportive text must be visible on the posture overlay."
         )
-    }
 
-    // MARK: - test_overlay_postureVariant_doneButtonDismissesOverlay
-
-    /// Taps Done on the posture overlay and verifies it dismisses.
-    func test_overlay_postureVariant_doneButtonDismissesOverlay() throws {
-        let doneButton = app.buttons["overlay.doneButton"]
         XCTAssertTrue(app.tapElementCenter(doneButton))
 
         XCTAssertTrue(

--- a/Tests/EyePostureReminderUITests/OverlayTests.swift
+++ b/Tests/EyePostureReminderUITests/OverlayTests.swift
@@ -103,7 +103,7 @@ final class OverlayPresentationTests: XCTestCase {
     func test_overlay_onShowOverlayEyes_dismissButtonVisible() throws {
         let dismissButton = app.buttons["overlay.dismissButton"]
         XCTAssertTrue(
-            dismissButton.waitForExistence(timeout: 1.5),
+            app.waitForElementExists(dismissButton),
             "Overlay dismiss button must be visible when --show-overlay-eyes is used. " +
             "Check that AppDelegate stores 'eyes' in AppStorageKey.uiTestOverlayType and " +
             "EyePostureReminderApp calls coordinator.handleNotification(for:) in its .task."
@@ -129,7 +129,7 @@ final class OverlayPresentationTests: XCTestCase {
     func test_overlay_onShowOverlayEyes_supportiveTextVisible() throws {
         let supportiveText = app.staticTexts["overlay.supportiveText"]
         XCTAssertTrue(
-            supportiveText.waitForExistence(timeout: 1.5),
+            app.waitForElementExists(supportiveText),
             "Overlay supportive text must be visible. " +
             "OverlayView must have .accessibilityIdentifier(\"overlay.supportiveText\") " +
             "on the subtitle Text element."
@@ -159,7 +159,7 @@ final class OverlayPresentationTests: XCTestCase {
     func test_overlay_onShowOverlayEyes_settingsLinkVisible() throws {
         let settingsLink = app.buttons["overlay.settingsLink"]
         XCTAssertTrue(
-            settingsLink.waitForExistence(timeout: 1.5),
+            app.waitForElementExists(settingsLink),
             "Settings link must be visible on the overlay. " +
             "OverlayView must have .accessibilityIdentifier(\"overlay.settingsLink\") " +
             "on the secondary Settings button."
@@ -218,7 +218,7 @@ final class OverlayPostureTests: XCTestCase {
     func test_overlay_postureVariant_dismissButtonVisible() throws {
         let dismissButton = app.buttons["overlay.dismissButton"]
         XCTAssertTrue(
-            dismissButton.waitForExistence(timeout: 1.5),
+            app.waitForElementExists(dismissButton),
             "Overlay dismiss button must be visible when --show-overlay-posture is used."
         )
     }
@@ -240,7 +240,7 @@ final class OverlayPostureTests: XCTestCase {
     func test_overlay_postureVariant_supportiveTextVisible() throws {
         let supportiveText = app.staticTexts["overlay.supportiveText"]
         XCTAssertTrue(
-            supportiveText.waitForExistence(timeout: 1.5),
+            app.waitForElementExists(supportiveText),
             "Supportive text must be visible on the posture overlay."
         )
     }

--- a/Tests/EyePostureReminderUITests/SettingsFlowTests.swift
+++ b/Tests/EyePostureReminderUITests/SettingsFlowTests.swift
@@ -85,12 +85,12 @@ final class SettingsFlowTests: XCTestCase {
 
         let termsButton = app.buttons["settings.legal.terms"]
         scrollToElement(termsButton)
-        XCTAssertTrue(termsButton.waitForExistence(timeout: 3))
-        termsButton.tap()
+        XCTAssertTrue(app.revealAndWaitForHittable(termsButton, timeout: 5, maxSwipes: 4))
+        XCTAssertTrue(app.tapElementCenter(termsButton))
 
         let termsNav = app.navigationBars["Terms & Conditions"]
         XCTAssertTrue(
-            termsNav.waitForExistence(timeout: 3),
+            termsNav.waitForExistence(timeout: 5),
             "Terms & Conditions sheet should open with the correct navigation title."
         )
 
@@ -215,8 +215,8 @@ final class SettingsFlowTests: XCTestCase {
 
         let termsButton = app.buttons["settings.legal.terms"]
         scrollToElement(termsButton)
-        XCTAssertTrue(termsButton.waitForExistence(timeout: 3))
-        termsButton.tap()
+        XCTAssertTrue(app.revealAndWaitForHittable(termsButton, timeout: 5, maxSwipes: 4))
+        XCTAssertTrue(app.tapElementCenter(termsButton))
 
         let dismissButton = app.buttons["legal.dismissButton"]
         XCTAssertTrue(dismissButton.waitForExistence(timeout: 3))
@@ -237,8 +237,8 @@ final class SettingsFlowTests: XCTestCase {
 
         let privacyButton = app.buttons["settings.legal.privacy"]
         scrollToElement(privacyButton)
-        XCTAssertTrue(privacyButton.waitForExistence(timeout: 3))
-        privacyButton.tap()
+        XCTAssertTrue(app.revealAndWaitForHittable(privacyButton, timeout: 5, maxSwipes: 4))
+        XCTAssertTrue(app.tapElementCenter(privacyButton))
 
         let dismissButton = app.buttons["legal.dismissButton"]
         XCTAssertTrue(dismissButton.waitForExistence(timeout: 3))

--- a/Tests/EyePostureReminderUITests/SettingsFlowTests.swift
+++ b/Tests/EyePostureReminderUITests/SettingsFlowTests.swift
@@ -17,12 +17,6 @@ final class SettingsFlowTests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
-        switch app?.state {
-        case .runningForeground, .runningBackground, .runningBackgroundSuspended:
-            app?.terminate()
-        default:
-            break
-        }
         app = nil
     }
 

--- a/Tests/EyePostureReminderUITests/SettingsFlowTests.swift
+++ b/Tests/EyePostureReminderUITests/SettingsFlowTests.swift
@@ -369,22 +369,16 @@ final class SettingsFlowTests: XCTestCase {
             eyesToggle.tap()
         }
 
-        let intervalPicker = app.otherElements["settings.eyes.intervalPicker"]
-        let intervalPickerFallback = app.descendants(matching: .any)
-            .matching(identifier: "settings.eyes.intervalPicker").firstMatch
+        let intervalPicker = pickerElement(identifier: "settings.eyes.intervalPicker")
         XCTAssertTrue(
-            app.waitForElementExists(intervalPicker, timeout: 5) ||
-                app.waitForElementExists(intervalPickerFallback, timeout: 2),
+            app.waitForElementExists(intervalPicker, timeout: 5),
             "Eyes interval Picker must exist with identifier 'settings.eyes.intervalPicker' " +
             "when the eyes toggle is on (#427)."
         )
 
-        let durationPicker = app.otherElements["settings.eyes.durationPicker"]
-        let durationPickerFallback = app.descendants(matching: .any)
-            .matching(identifier: "settings.eyes.durationPicker").firstMatch
+        let durationPicker = pickerElement(identifier: "settings.eyes.durationPicker")
         XCTAssertTrue(
-            app.waitForElementExists(durationPicker, timeout: 5) ||
-                app.waitForElementExists(durationPickerFallback, timeout: 2),
+            app.waitForElementExists(durationPicker, timeout: 5),
             "Eyes duration Picker must exist with identifier 'settings.eyes.durationPicker' " +
             "when the eyes toggle is on (#427)."
         )
@@ -407,22 +401,18 @@ final class SettingsFlowTests: XCTestCase {
             postureToggle.tap()
         }
 
-        let intervalPicker = app.otherElements["settings.posture.intervalPicker"]
-        let intervalPickerFallback = app.descendants(matching: .any)
-            .matching(identifier: "settings.posture.intervalPicker").firstMatch
+        let intervalPicker = pickerElement(identifier: "settings.posture.intervalPicker")
+        scrollToElement(intervalPicker, maxSwipes: 2)
         XCTAssertTrue(
-            app.waitForElementExists(intervalPicker, timeout: 5) ||
-                app.waitForElementExists(intervalPickerFallback, timeout: 2),
+            app.waitForElementExists(intervalPicker, timeout: 5),
             "Posture interval Picker must exist with identifier 'settings.posture.intervalPicker' " +
             "when the posture toggle is on (#427)."
         )
 
-        let durationPicker = app.otherElements["settings.posture.durationPicker"]
-        let durationPickerFallback = app.descendants(matching: .any)
-            .matching(identifier: "settings.posture.durationPicker").firstMatch
+        let durationPicker = pickerElement(identifier: "settings.posture.durationPicker")
+        scrollToElement(durationPicker, maxSwipes: 2)
         XCTAssertTrue(
-            app.waitForElementExists(durationPicker, timeout: 5) ||
-                app.waitForElementExists(durationPickerFallback, timeout: 2),
+            app.waitForElementExists(durationPicker, timeout: 5),
             "Posture duration Picker must exist with identifier 'settings.posture.durationPicker' " +
             "when the posture toggle is on (#427)."
         )
@@ -659,6 +649,18 @@ private extension SettingsFlowTests {
                 return
             }
         }
+    }
+
+    /// SwiftUI Picker identifiers can surface as picker, button, or otherElement depending on style/SDK.
+    /// Check narrow element classes only; avoid broad `.any` descendant scans on the long Settings form.
+    func pickerElement(identifier: String) -> XCUIElement {
+        let picker = app.pickers[identifier]
+        if picker.exists { return picker }
+
+        let button = app.buttons[identifier]
+        if button.exists { return button }
+
+        return app.otherElements[identifier]
     }
 
     /// Taps Done to dismiss Settings and waits for the sheet to disappear.

--- a/Tests/EyePostureReminderUITests/UITestHelpers.swift
+++ b/Tests/EyePostureReminderUITests/UITestHelpers.swift
@@ -34,14 +34,9 @@ enum TestLaunchArguments {
 
 extension XCUIApplication {
     private func launchFresh() {
-        switch state {
-        case .runningForeground, .runningBackground, .runningBackgroundSuspended:
-            terminate()
-        case .notRunning, .unknown:
-            break
-        @unknown default:
-            break
-        }
+        // `launch()` already relaunches the target app for a new XCUIApplication
+        // session. Avoid explicit `terminate()` here: on loaded CI simulators it
+        // can fail before XCTest has acquired a stable process assertion.
     }
 
     private func appendDarkModeArgumentIfNeeded(_ darkMode: Bool) {
@@ -205,10 +200,18 @@ extension XCUIApplication {
     @discardableResult
     func waitForOverlayDismissed(timeout: TimeInterval = 3) -> Bool {
         let overlayRoot = otherElements["overlay.root"]
-        let dismissalDeadline = Date().addingTimeInterval(timeout)
-        guard waitForHomeScreenReady(timeout: timeout) else { return false }
-        let remaining = max(0.1, dismissalDeadline.timeIntervalSinceNow)
-        return overlayRoot.waitForNonExistence(timeout: remaining)
+        let deadline = Date().addingTimeInterval(timeout)
+
+        while Date() < deadline {
+            if !overlayRoot.exists && waitForHomeScreenReady(timeout: 0.5) {
+                return true
+            }
+            activate()
+            let step = min(0.2, max(0.05, deadline.timeIntervalSinceNow))
+            RunLoop.current.run(until: Date().addingTimeInterval(step))
+        }
+
+        return !overlayRoot.exists && waitForHomeScreenReady(timeout: 1)
     }
 
     /// Verifies that `overlay.root` never appears throughout the full observation window.


### PR DESCRIPTION
## Summary
- centralize the Settings hosted privacy policy URL in `LegalLinks`
- add unit coverage that the in-app hosted privacy link targets the public HTTPS GitHub policy path

Refs #185

## Local validation
- curl -L https://github.com/yashasg/fantastic-octo-fortnight/blob/main/docs/legal/PRIVACY.md returned HTTP 200
- xcodebuild test -scheme EyePostureReminder -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:"EyePostureReminderTests/LegalLinksTests" CODE_SIGNING_ALLOWED=NO
- ./scripts/build.sh build
- ./scripts/build.sh test