### PR TITLE
Buffer cold-launch notification routes

### DIFF
--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -77,7 +77,15 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
 
     /// Set by `EyePostureReminderApp.onAppear` — bridges UIKit delegate
     /// callbacks into the SwiftUI-owned coordinator.
-    var coordinator: AppCoordinator?
+    var coordinator: AppCoordinator? {
+        didSet {
+            guard coordinator != nil else { return }
+            Task { @MainActor [weak self] in
+                self?.flushPendingNotificationRoutes()
+            }
+        }
+    }
+    private var pendingNotificationRoutes: [NotificationRoute] = []
 
 #if DEBUG
     /// Pre-seeds UI-test UserDefaults keys in `init()` — before `@StateObject
@@ -228,19 +236,42 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         return .ignore
     }
 
-    private func dispatchNotificationRoute(_ route: NotificationRoute) {
+    func dispatchNotificationRoute(_ route: NotificationRoute) {
+        Task { @MainActor [weak self] in
+            self?.dispatchNotificationRouteOnMainActor(route)
+        }
+    }
+
+    @MainActor
+    private func dispatchNotificationRouteOnMainActor(_ route: NotificationRoute) {
+        guard let coordinator else {
+            if route != .ignore {
+                pendingNotificationRoutes.append(route)
+            }
+            return
+        }
+
         switch route {
         case .reminder(let type):
-            Task { @MainActor [weak self] in
-                self?.coordinator?.handleNotification(for: type)
-            }
+            coordinator.handleNotification(for: type)
         case .snoozeWake:
-            Task { @MainActor [weak self] in
-                self?.coordinator?.cancelSnoozeWakeTaskIfNeeded()
-                await self?.coordinator?.scheduleReminders()
+            coordinator.cancelSnoozeWakeTaskIfNeeded()
+            Task { @MainActor in
+                await coordinator.scheduleReminders()
             }
         case .ignore:
             break
+        }
+    }
+
+    @MainActor
+    private func flushPendingNotificationRoutes() {
+        guard coordinator != nil, !pendingNotificationRoutes.isEmpty else { return }
+
+        let routes = pendingNotificationRoutes
+        pendingNotificationRoutes.removeAll()
+        for route in routes {
+            dispatchNotificationRouteOnMainActor(route)
         }
     }
 

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -584,6 +584,38 @@ final class AppDelegateTests: XCTestCase {
         coordinator.handleNotification(for: .posture)
     }
 
+    func test_dispatchNotificationRoute_beforeCoordinatorWiring_replaysReminderWhenCoordinatorIsSet() async {
+        delegate.coordinator = nil
+        settings.snoozeCount = 4
+
+        delegate.dispatchNotificationRoute(.reminder(.eyes))
+        for _ in 0..<3 { await Task.yield() }
+
+        XCTAssertEqual(
+            settings.snoozeCount,
+            4,
+            "Reminder route should wait for coordinator wiring instead of being dropped."
+        )
+
+        delegate.coordinator = coordinator
+
+        await awaitCondition { self.settings.snoozeCount == 0 }
+        XCTAssertEqual(settings.snoozeCount, 0)
+    }
+
+    func test_dispatchNotificationRoute_ignoreBeforeCoordinatorWiring_isNotReplayed() async {
+        delegate.coordinator = nil
+        settings.snoozeCount = 4
+
+        delegate.dispatchNotificationRoute(.ignore)
+        for _ in 0..<3 { await Task.yield() }
+
+        delegate.coordinator = coordinator
+        for _ in 0..<3 { await Task.yield() }
+
+        XCTAssertEqual(settings.snoozeCount, 4)
+    }
+
     // MARK: - Snooze-wake routing (scheduleReminders path exercised by delegate)
 
     /// The snooze-wake path calls `scheduleReminders()`, which (when auth is granted)


### PR DESCRIPTION
## Summary\n- buffer notification routes that arrive before AppCoordinator is wired\n- replay pending reminder routes once SwiftUI assigns the coordinator\n- add AppDelegate coverage for pre-wiring reminder replay and ignored routes\n\nFixes #596\n\n## Validation\n- xcodebuild test -scheme EyePostureReminder -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:"EyePostureReminderTests/AppDelegateTests" CODE_SIGNING_ALLOWED=NO\n- swiftlint lint --strict --quiet EyePostureReminder/App/AppDelegate.swift Tests/EyePostureReminderTests/Services/AppDelegateTests.swift\n- ./scripts/build.sh build\n- ./scripts/build.sh test