### PR TITLE
Fail UI aggregate check when shards fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -473,7 +473,15 @@ jobs:
     name: UI Tests
     runs-on: macos-15
     needs: uitest-shard
+    if: always()
     timeout-minutes: 10
     steps:
       - name: UI test shards passed
+        if: ${{ needs.uitest-shard.result == 'success' }}
         run: echo "All UI test shards passed."
+
+      - name: Report UI shard failure
+        if: ${{ needs.uitest-shard.result != 'success' }}
+        run: |
+          echo "::error::UI test shards did not all pass (result: ${{ needs.uitest-shard.result }})."
+          exit 1

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -64,7 +64,7 @@ jobs:
               STATUS=$(gh api "repos/${{ github.repository }}/commits/${{ github.sha }}/check-runs" \
                 --jq ".check_runs | map(select(.name == \"${CHECK_NAME}\")) | sort_by(.started_at) | last | .conclusion // empty")
               if [[ "$STATUS" == "success" ]]; then break; fi
-              if [[ "$STATUS" == "failure" || "$STATUS" == "cancelled" || "$STATUS" == "timed_out" ]]; then
+              if [[ "$STATUS" == "failure" || "$STATUS" == "cancelled" || "$STATUS" == "timed_out" || "$STATUS" == "skipped" ]]; then
                 echo "${CHECK_NAME} failed or was cancelled (status: $STATUS). Aborting deploy."
                 exit 1
               fi


### PR DESCRIPTION
## Summary\n- make the aggregate UI Tests job run even when a UI shard fails or is skipped\n- fail the aggregate check explicitly when shard needs are not successful\n- make the TestFlight gate treat skipped required checks as terminal failures\n\nFixes #603\n\n## Validation\n- git diff --check\n- ruby YAML parse for .github/workflows/ci.yml and .github/workflows/testflight.yml\n- ./scripts/build.sh build\n- ./scripts/build.sh test