### PR TITLE
Keep notification permission prompt in onboarding

### DIFF
--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -426,14 +426,6 @@ final class AppCoordinator: ObservableObject {
         // No active snooze — cancel any pending wake artifacts.
         cancelSnoozeWake()
 
-        // First launch: prompt the user for notification permission.
-        // Permission is still used for the snooze-wake silent notification.
-        // Skip in UI test mode — the system alert would block the accessibility
-        // hierarchy and cause all XCUITest element lookups to fail.
-        if notificationAuthStatus == .notDetermined && !isUITestModeEnabled {
-            await requestNotificationPermission()
-        }
-
         // Schedule periodic background UNNotifications only as the fallback path
         // while Screen Time shielding is unavailable.
         if notificationAuthStatus == .authorized, shouldScheduleNotificationFallback {

--- a/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
@@ -10,7 +10,7 @@ import UserNotifications
 
 struct OnboardingPermissionView: View {
     let onNext: () -> Void
-    private let notificationCenter: NotificationScheduling
+    private let requestPermission: () async -> Void
     private let accessibilityEnabledOverride: Bool?
 
     @Environment(\.accessibilityEnabled) private var accessibilityEnabled
@@ -18,9 +18,17 @@ struct OnboardingPermissionView: View {
     init(onNext: @escaping () -> Void,
          notificationCenter: NotificationScheduling? = nil,
          makeNotificationCenter: @escaping () -> NotificationScheduling = { UNUserNotificationCenter.current() },
+         requestPermission: (() async -> Void)? = nil,
          accessibilityEnabledOverride: Bool? = nil) {
         self.onNext = onNext
-        self.notificationCenter = notificationCenter ?? makeNotificationCenter()
+        let resolvedNotificationCenter = notificationCenter ?? makeNotificationCenter()
+        self.requestPermission = requestPermission ?? {
+            do {
+                _ = try await resolvedNotificationCenter.requestAuthorization(options: [.alert, .sound, .badge])
+            } catch {
+                Logger.scheduling.error("Notification permission request failed: \(error)")
+            }
+        }
         self.accessibilityEnabledOverride = accessibilityEnabledOverride
     }
 
@@ -95,11 +103,7 @@ struct OnboardingPermissionView: View {
 
     private func requestNotificationPermission() {
         Task {
-            do {
-                _ = try await notificationCenter.requestAuthorization(options: [.alert, .sound, .badge])
-            } catch {
-                Logger.scheduling.error("Notification permission request failed: \(error)")
-            }
+            await requestPermission()
             await MainActor.run { onNext() }
         }
     }

--- a/EyePostureReminder/Views/Onboarding/OnboardingView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingView.swift
@@ -39,7 +39,8 @@ struct OnboardingView: View {
             // request can be driven by a mock in UI tests without swizzling.
             OnboardingPermissionView(
                 onNext: { currentPage = 2 },
-                notificationCenter: coordinator.notificationCenter
+                notificationCenter: coordinator.notificationCenter,
+                requestPermission: { await coordinator.requestNotificationPermission() }
             )
                 .tag(1)
             // Settings store is forwarded so picker bindings write directly to

--- a/Tests/EyePostureReminderTests/Mocks/MockNotificationCenter.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockNotificationCenter.swift
@@ -21,6 +21,7 @@ final class MockNotificationCenter: NotificationScheduling {
     // MARK: - Configuration
 
     var authorizationGranted = true
+    var authorizationStatus: UNAuthorizationStatus?
     var authorizationError: Error?
     var addError: Error?
 
@@ -32,6 +33,7 @@ final class MockNotificationCenter: NotificationScheduling {
         removedIdentifiers = []
         removeAllCallCount = 0
         authorizationRequestCount = 0
+        authorizationStatus = nil
         authorizationError = nil
         addError = nil
     }
@@ -41,6 +43,7 @@ final class MockNotificationCenter: NotificationScheduling {
     func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool {
         authorizationRequestCount += 1
         if let error = authorizationError { throw error }
+        authorizationStatus = authorizationGranted ? .authorized : .denied
         return authorizationGranted
     }
 
@@ -65,6 +68,7 @@ final class MockNotificationCenter: NotificationScheduling {
     }
 
     func getAuthorizationStatus() async -> UNAuthorizationStatus {
+        if let authorizationStatus { return authorizationStatus }
         return authorizationGranted ? .authorized : .denied
     }
 }

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -1639,6 +1639,29 @@ final class AppCoordinatorTests: XCTestCase {
             "scheduleReminders() with auth=denied must not schedule any reminder notifications")
     }
 
+    func test_scheduleReminders_notDetermined_doesNotRequestNotificationPermission() async {
+        let mockNotif = MockNotificationCenter()
+        mockNotif.authorizationGranted = true
+        mockNotif.authorizationStatus = .notDetermined
+        settings.globalEnabled = true
+        settings.eyesEnabled = true
+        settings.postureEnabled = true
+        let (coordinator, _, _) = makeCoordinator(
+            overlay: MockOverlayPresenting(),
+            notifCenter: mockNotif)
+        defer { coordinator.stopFallbackTimers() }
+
+        await coordinator.scheduleReminders()
+
+        XCTAssertEqual(
+            mockNotif.authorizationRequestCount,
+            0,
+            "scheduleReminders() must not show the system notification prompt before explicit context")
+        XCTAssertTrue(
+            reminderRequests(from: mockNotif).isEmpty,
+            "Notification reminders must not be scheduled until permission is explicitly granted")
+    }
+
     // MARK: - handleNotification: ScreenTimeTracker reset
 
     func test_handleNotification_resetsTrackerExactlyOnce_forDeliveredType() {


### PR DESCRIPTION
## Summary\n- stop startup reminder scheduling from automatically requesting notification permission\n- route the onboarding Enable Notifications CTA through AppCoordinator so auth state refreshes there\n- add a regression that scheduleReminders does not request permission while auth is not determined\n\nFixes #597\n\n## Validation\n- xcodebuild test -scheme EyePostureReminder -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:"EyePostureReminderTests/AppCoordinatorTests" -only-testing:"EyePostureReminderTests/OnboardingViewTests" CODE_SIGNING_ALLOWED=NO\n- swiftlint lint --strict --quiet EyePostureReminder/Services/AppCoordinator.swift EyePostureReminder/Views/Onboarding/OnboardingView.swift EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift Tests/EyePostureReminderTests/Mocks/MockNotificationCenter.swift\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n\nNote: repo-wide ./scripts/build.sh lint currently reports pre-existing violations outside this change set.