### PR TITLE
Surface notification denied recovery

### DIFF
--- a/EyePostureReminder/Resources/Localizable.xcstrings
+++ b/EyePostureReminder/Resources/Localizable.xcstrings
@@ -46,6 +46,17 @@
         }
       }
     },
+    "home.status.notificationsOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications are off"
+          }
+        }
+      }
+    },
     "home.status.paused": {
       "extractionState": "manual",
       "localizations": {
@@ -64,6 +75,28 @@
           "stringUnit": {
             "state": "translated",
             "value": "kshana"
+          }
+        }
+      }
+    },
+    "home.notifications.disabledBody": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn notifications back on in iOS Settings so kshana can deliver reminder alerts outside the app."
+          }
+        }
+      }
+    },
+    "home.notifications.disabledTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications are off"
           }
         }
       }

--- a/EyePostureReminder/Views/HomeView.swift
+++ b/EyePostureReminder/Views/HomeView.swift
@@ -1,4 +1,6 @@
 import SwiftUI
+import UIKit
+import UserNotifications
 
 struct HomeView: View {
     typealias LaunchArgumentsProvider = () -> [String]
@@ -33,11 +35,30 @@ struct HomeView: View {
     }
 
     private var statusLabel: String {
-        if settings.globalEnabled {
-            return String(localized: "home.status.active", bundle: .module)
-        } else {
+        if !settings.globalEnabled {
             return String(localized: "home.status.paused", bundle: .module)
         }
+        if Self.shouldShowNotificationRecovery(
+            globalEnabled: settings.globalEnabled,
+            notificationAuthStatus: coordinator.notificationAuthStatus
+        ) {
+            return String(localized: "home.status.notificationsOff", bundle: .module)
+        }
+        return String(localized: "home.status.active", bundle: .module)
+    }
+
+    private var shouldShowNotificationRecovery: Bool {
+        Self.shouldShowNotificationRecovery(
+            globalEnabled: settings.globalEnabled,
+            notificationAuthStatus: coordinator.notificationAuthStatus
+        )
+    }
+
+    static func shouldShowNotificationRecovery(
+        globalEnabled: Bool,
+        notificationAuthStatus: UNAuthorizationStatus
+    ) -> Bool {
+        globalEnabled && notificationAuthStatus == .denied
     }
 
     private var shouldShowTrueInterruptPrompts: Bool {
@@ -124,6 +145,10 @@ struct HomeView: View {
                trueInterruptBannerDismissed {
                 TrueInterruptSetupPill(onTap: { showSettings = true })
             }
+
+            if shouldShowNotificationRecovery {
+                HomeNotificationWarningBanner(onOpenSettings: openApplicationSettings)
+            }
         }
         .padding(.horizontal, AppSpacing.xl)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -158,6 +183,9 @@ struct HomeView: View {
                 showSettings = true
             }
         }
+        .task {
+            await coordinator.refreshAuthStatus()
+        }
         .onChangeCompat(of: openSettingsOnLaunch) { newValue in
             if newValue {
                 openSettingsOnLaunch = false
@@ -170,6 +198,56 @@ struct HomeView: View {
             guard !showSettings else { return }
             accessibilityNotificationPoster.postAnnouncement(message: statusLabel)
         }
+    }
+
+    private func openApplicationSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url)
+        }
+    }
+}
+
+// MARK: - Notification Warning Banner
+
+struct HomeNotificationWarningBanner: View {
+    let onOpenSettings: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.sm) {
+            HStack(alignment: .top, spacing: AppSpacing.sm) {
+                IconContainer(icon: AppSymbol.warning, color: AppColor.accentWarm, size: 36)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: AppSpacing.xs) {
+                    Text("home.notifications.disabledTitle", bundle: .module)
+                        .font(AppFont.bodyEmphasized)
+                        .foregroundStyle(AppColor.textPrimary)
+                    Text("home.notifications.disabledBody", bundle: .module)
+                        .font(AppFont.caption)
+                        .foregroundStyle(AppColor.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Button(action: onOpenSettings) {
+                Text("settings.notifications.openSettings", bundle: .module)
+                    .font(AppFont.captionEmphasized)
+            }
+            .frame(minHeight: AppLayout.minTapTarget)
+            .contentShape(Rectangle())
+            .foregroundStyle(AppColor.accentWarm)
+            .accessibilityHint(Text("settings.notifications.openSettings.hint", bundle: .module))
+            .accessibilityIdentifier("home.notifications.openSettings")
+        }
+        .padding(AppSpacing.sm)
+        .background(AppColor.accentWarm.opacity(AppOpacity.warningBackground),
+                    in: RoundedRectangle(cornerRadius: AppLayout.radiusSmall))
+        .overlay(
+            RoundedRectangle(cornerRadius: AppLayout.radiusSmall)
+                .strokeBorder(AppColor.accentWarm.opacity(AppOpacity.warningSeparator),
+                              lineWidth: AppLayout.borderHair)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("home.notifications.disabledBanner")
     }
 }
 

--- a/EyePostureReminder/Views/SettingsView.swift
+++ b/EyePostureReminder/Views/SettingsView.swift
@@ -838,8 +838,7 @@ private struct SettingsNotificationWarningSection: View {
     @EnvironmentObject private var coordinator: AppCoordinator
 
     var body: some View {
-        if coordinator.notificationAuthStatus == .denied,
-           coordinator.settings.notificationFallbackEnabled {
+        if coordinator.notificationAuthStatus == .denied {
             Section {
                 HStack(spacing: AppSpacing.sm) {
                     IconContainer(icon: AppSymbol.warning, color: AppColor.accentWarm, size: 36)

--- a/Tests/EyePostureReminderTests/Views/HomeViewLaunchContextResolverTests.swift
+++ b/Tests/EyePostureReminderTests/Views/HomeViewLaunchContextResolverTests.swift
@@ -1,4 +1,5 @@
 @testable import EyePostureReminder
+import UserNotifications
 import XCTest
 
 #if DEBUG
@@ -71,6 +72,27 @@ final class HomeViewLaunchContextResolverTests: XCTestCase {
         )
 
         XCTAssertFalse(result)
+    }
+
+    func test_notificationRecovery_whenGlobalEnabledAndNotificationsDenied_returnsTrue() {
+        XCTAssertTrue(HomeView.shouldShowNotificationRecovery(
+            globalEnabled: true,
+            notificationAuthStatus: .denied
+        ))
+    }
+
+    func test_notificationRecovery_whenGlobalDisabledAndNotificationsDenied_returnsFalse() {
+        XCTAssertFalse(HomeView.shouldShowNotificationRecovery(
+            globalEnabled: false,
+            notificationAuthStatus: .denied
+        ))
+    }
+
+    func test_notificationRecovery_whenNotificationsAuthorized_returnsFalse() {
+        XCTAssertFalse(HomeView.shouldShowNotificationRecovery(
+            globalEnabled: true,
+            notificationAuthStatus: .authorized
+        ))
     }
 }
 #endif


### PR DESCRIPTION
## Summary\n- show Home as a notification recovery state instead of Active when notification permission is denied\n- add a Home recovery banner with an Open Settings CTA and refresh auth state on Home appearance\n- keep the Settings notification warning visible whenever permission is denied, independent of fallback toggle state\n- add regression coverage for Home recovery visibility rules\n\nFixes #598\n\n## Validation\n- ruby JSON parse for EyePostureReminder/Resources/Localizable.xcstrings\n- xcodebuild test -scheme EyePostureReminder -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:"EyePostureReminderTests/HomeViewLaunchContextResolverTests" CODE_SIGNING_ALLOWED=NO\n- swiftlint lint --strict --quiet EyePostureReminder/Views/HomeView.swift EyePostureReminder/Views/SettingsView.swift Tests/EyePostureReminderTests/Views/HomeViewLaunchContextResolverTests.swift\n- ./scripts/build.sh build\n- ./scripts/build.sh test