### PR TITLE
Resync reminders after notification auth changes

### DIFF
--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -110,6 +110,9 @@ final class AppCoordinator: ObservableObject {
     /// `scheduleReminders()` call and after explicit permission requests.
     @Published var notificationAuthStatus: UNAuthorizationStatus = .notDetermined
 
+    /// Authorization status used during the last full reminder scheduling pass.
+    private var lastReminderSchedulingAuthStatus: UNAuthorizationStatus?
+
     // MARK: - Pending Overlay
 
     /// A stashed overlay request awaiting an active scene.
@@ -393,6 +396,7 @@ final class AppCoordinator: ObservableObject {
     /// Call on launch (`.task`) and whenever settings change.
     func scheduleReminders() async {
         await refreshAuthStatus()
+        lastReminderSchedulingAuthStatus = notificationAuthStatus
         recordWatchdogHeartbeat(.scheduleReminders)
 
         // Cold-launch proxy: handleForegroundTransition() sets this for warm paths.
@@ -570,7 +574,11 @@ final class AppCoordinator: ObservableObject {
     func handleForegroundTransition() async {
         foregroundEntryTime = dateProvider.now
         pendingLaunchType = .warm
+        let lastScheduledNotificationAuthStatus = lastReminderSchedulingAuthStatus
         await refreshAuthStatus()
+        let notificationAuthStatusChanged = lastScheduledNotificationAuthStatus.map {
+            $0 != notificationAuthStatus
+        } ?? false
         let recoveryNeeded = await recoverStaleDeviceActivityWatchdogIfNeeded()
         watchdogRecoveryNeededAtForeground = recoveryNeeded
         recordWatchdogHeartbeat(.appForeground)
@@ -594,6 +602,12 @@ final class AppCoordinator: ObservableObject {
                 // swiftlint:disable:next line_length
                 Logger.scheduling.info("Foreground transition: snooze still active; expires in \(snoozeEnd.timeIntervalSinceNow, format: .fixed(precision: 0), privacy: .public)s")
             }
+            return
+        }
+
+        if notificationAuthStatusChanged {
+            Logger.scheduling.info("Foreground transition: notification authorization changed; resyncing reminders")
+            await scheduleReminders()
             return
         }
 

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -639,6 +639,28 @@ final class AppCoordinatorTests: XCTestCase {
         await sut.handleForegroundTransition()
     }
 
+    func test_handleForegroundTransition_deniedToAuthorized_reschedulesReminders() async {
+        let mockNotif = MockNotificationCenter()
+        mockNotif.authorizationStatus = .denied
+        settings.globalEnabled = true
+        settings.eyesEnabled = true
+        settings.postureEnabled = true
+        let (coordinator, _, _) = makeCoordinator(
+            overlay: MockOverlayPresenting(),
+            notifCenter: mockNotif)
+        defer { coordinator.stopFallbackTimers() }
+
+        await coordinator.scheduleReminders()
+        mockNotif.authorizationStatus = .authorized
+
+        await coordinator.handleForegroundTransition()
+
+        XCTAssertEqual(
+            reminderRequests(from: mockNotif).count,
+            2,
+            "Foreground return must schedule reminder notifications after permission changes to authorized")
+    }
+
     // MARK: - appWillResignActive
 
     func test_appWillResignActive_withNoTimers_doesNotCrash() {


### PR DESCRIPTION
## Summary\n- remember the notification authorization status used during the last full scheduling pass\n- on foreground return, rerun scheduling when current authorization differs from that scheduled baseline\n- add a denied-to-authorized regression so enabling notifications in iOS Settings schedules reminder notifications on return\n\nFixes #599\n\n## Validation\n- xcodebuild test -scheme EyePostureReminder -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:"EyePostureReminderTests/AppCoordinatorTests/test_handleForegroundTransition_deniedToAuthorized_reschedulesReminders" -only-testing:"EyePostureReminderTests/AppCoordinatorWatchdogHeartbeatTests" CODE_SIGNING_ALLOWED=NO\n- swiftlint lint --strict --quiet EyePostureReminder/Services/AppCoordinator.swift\n- ./scripts/build.sh build\n- ./scripts/build.sh test