### PR TITLE
Clear shields when session snapshot is missing

### DIFF
--- a/Extensions/DeviceActivityMonitorExtension/DeviceActivityMonitorExtension.swift
+++ b/Extensions/DeviceActivityMonitorExtension/DeviceActivityMonitorExtension.swift
@@ -79,18 +79,24 @@ final class DeviceActivityMonitorExtensionImpl: DeviceActivityMonitor {
     }
 
     override func intervalDidEnd(for activity: DeviceActivityName) {
-        // #347/#405: Read the session identity written before startMonitoring so we
-        // can verify this end event belongs to the session we expect. If a late-
-        // arriving intervalDidEnd fires for an already-cleared (or mismatched)
-        // session, skip clearAllSettings() to avoid wiping a freshly-started break's
-        // shield restrictions. When no session is present the ipcStore returns nil
-        // and we still clear (safe no-op pre-#201, conservative post-#201).
+        // #347/#405/#600: Read the session identity for diagnostics, but never
+        // let missing/corrupt session data block interval-end shield cleanup.
         let session = DeviceActivityMonitorExtensionImpl.readSession()
-        let sessionIsValid = session.triggeredAt != nil
-        if sessionIsValid {
-            // Remove all shield restrictions when the break ends.
-            // clearAllSettings() is safe to call even without FamilyControls at
-            // compile time; it is a no-op until the entitlement is active.
+        let cleanupDecision = ShieldIntervalEndCleanupPolicy.decision(for: ShieldSessionSnapshot(
+            reasonRaw: session.reason?.rawValue,
+            durationSeconds: session.durationSeconds,
+            triggeredAt: session.triggeredAt
+        ))
+        if cleanupDecision.sessionState == .missingOrCorrupt {
+            os_log(
+                "DeviceActivity interval ended without a valid shield session; clearing restrictions conservatively",
+                log: Self.ipcLog,
+                type: .info
+            )
+        }
+        if cleanupDecision.shouldClearRestrictions {
+            // clearAllSettings() is safe without FamilyControls and becomes critical
+            // cleanup once shield restrictions are active.
             store.clearAllSettings()
         }
         recordWatchdogHeartbeat(.deviceActivityIntervalEnded)

--- a/Extensions/Shared/ShieldIntervalEndCleanupPolicy.swift
+++ b/Extensions/Shared/ShieldIntervalEndCleanupPolicy.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public enum ShieldIntervalEndSessionState: Equatable, Sendable {
+    case valid
+    case missingOrCorrupt
+}
+
+public struct ShieldIntervalEndCleanupDecision: Equatable, Sendable {
+    public let shouldClearRestrictions: Bool
+    public let sessionState: ShieldIntervalEndSessionState
+
+    public init(
+        shouldClearRestrictions: Bool,
+        sessionState: ShieldIntervalEndSessionState
+    ) {
+        self.shouldClearRestrictions = shouldClearRestrictions
+        self.sessionState = sessionState
+    }
+}
+
+public enum ShieldIntervalEndCleanupPolicy {
+    public static func decision(
+        for snapshot: ShieldSessionSnapshot
+    ) -> ShieldIntervalEndCleanupDecision {
+        ShieldIntervalEndCleanupDecision(
+            shouldClearRestrictions: true,
+            sessionState: snapshot.triggeredAt == nil ? .missingOrCorrupt : .valid
+        )
+    }
+}

--- a/Tests/EyePostureReminderTests/Services/DeviceActivityMonitoringValidationTests.swift
+++ b/Tests/EyePostureReminderTests/Services/DeviceActivityMonitoringValidationTests.swift
@@ -80,6 +80,35 @@ final class DeviceActivityMonitoringValidationTests: XCTestCase {
         XCTAssertEqual(snapshot, .empty)
     }
 
+    func test_intervalEndCleanupPolicy_validSession_clearsRestrictions() throws {
+        try writeShieldSession(makeEyesSession(), to: testDefaults)
+        let snapshot = ShieldSessionSnapshot.read(from: testDefaults)
+
+        let decision = ShieldIntervalEndCleanupPolicy.decision(for: snapshot)
+
+        XCTAssertTrue(decision.shouldClearRestrictions)
+        XCTAssertEqual(decision.sessionState, .valid)
+    }
+
+    func test_intervalEndCleanupPolicy_missingPayload_clearsRestrictions() {
+        let snapshot = ShieldSessionSnapshot.read(from: testDefaults)
+
+        let decision = ShieldIntervalEndCleanupPolicy.decision(for: snapshot)
+
+        XCTAssertTrue(decision.shouldClearRestrictions)
+        XCTAssertEqual(decision.sessionState, .missingOrCorrupt)
+    }
+
+    func test_intervalEndCleanupPolicy_corruptPayload_clearsRestrictions() {
+        testDefaults.set(Data("not-json".utf8), forKey: ShieldSession.sessionDataKey)
+        let snapshot = ShieldSessionSnapshot.read(from: testDefaults)
+
+        let decision = ShieldIntervalEndCleanupPolicy.decision(for: snapshot)
+
+        XCTAssertTrue(decision.shouldClearRestrictions)
+        XCTAssertEqual(decision.sessionState, .missingOrCorrupt)
+    }
+
     /// Clearing the shield must remove the payload and legacy keys so a stale extension read
     /// doesn't re-apply an old break session.
     func test_shieldSession_appGroupClear_removesAllKeys() throws {


### PR DESCRIPTION
## Summary\n- add an extension-safe interval-end cleanup policy that always clears shield restrictions\n- treat missing/corrupt shield session snapshots as diagnostics instead of cleanup gates\n- add coverage for valid, missing, and corrupt interval-end snapshot states\n\nFixes #600\n\n## Validation\n- swiftlint lint --strict --quiet Extensions/Shared/ShieldIntervalEndCleanupPolicy.swift Extensions/DeviceActivityMonitorExtension/DeviceActivityMonitorExtension.swift Tests/EyePostureReminderTests/Services/DeviceActivityMonitoringValidationTests.swift\n- xcodebuild test -scheme EyePostureReminder -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:"EyePostureReminderTests/DeviceActivityMonitoringValidationTests" CODE_SIGNING_ALLOWED=NO\n- ./scripts/setup-screentime.sh\n- xcodebuild build -project ScreenTimeExtensions/EyePostureReminderExtensions.xcodeproj -scheme EyePostureReminderExtensions -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO\n- ./scripts/build.sh build\n- ./scripts/build.sh test