### PR TITLE
Avoid redundant Screen Time authorization requests

### DIFF
--- a/EyePostureReminder/Resources/Localizable.xcstrings
+++ b/EyePostureReminder/Resources/Localizable.xcstrings
@@ -2497,7 +2497,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No apps selected yet. Tap 'Select Apps' to choose which apps to shield during breaks."
+            "value": "No apps selected yet. App selection will be available in an upcoming update."
           }
         }
       }
@@ -2552,7 +2552,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Opens the app and category picker for True Interrupt Mode."
+            "value": "Shows the app and category selection surface for True Interrupt Mode."
           }
         }
       }

--- a/EyePostureReminder/Views/AppCategoryPickerView.swift
+++ b/EyePostureReminder/Views/AppCategoryPickerView.swift
@@ -33,6 +33,8 @@ struct AppCategoryPickerView: View {
     let onRequestAuthorization: () -> Void
     /// Called when authorization is denied and iOS Settings is the recovery path.
     var onOpenSettings: () -> Void = {}
+    /// Called when authorization is approved and the app/category picker is available.
+    var onSelectApps: () -> Void = {}
     let onDone: () -> Void
 
     var body: some View {
@@ -103,10 +105,14 @@ struct AppCategoryPickerView: View {
 
     func performPrimaryAction() {
         switch authorizationStatus {
+        case .unavailable:
+            return
+        case .notDetermined:
+            onRequestAuthorization()
         case .denied:
             onOpenSettings()
-        case .unavailable, .notDetermined, .approved:
-            onRequestAuthorization()
+        case .approved:
+            onSelectApps()
         }
     }
 

--- a/EyePostureReminder/Views/Onboarding/OnboardingView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingView.swift
@@ -53,7 +53,7 @@ struct OnboardingView: View {
             // is pending. Users can skip without losing core reminder functionality.
             OnboardingInterruptModeView(
                 onGetStarted: finishOnboarding,
-                onSetUp: { showAppCategoryPicker = true },
+                onSetUp: onboardingSetUpAction,
                 onCustomize: finishOnboardingAndCustomize,
                 authorizationStatus: coordinator.screenTimeAuthorization.authorizationStatus
             )
@@ -74,9 +74,16 @@ struct OnboardingView: View {
                     Task { _ = await coordinator.screenTimeAuthorization.requestAuthorization() }
                 },
                 onOpenSettings: openApplicationSettings,
+                onSelectApps: {},
                 onDone: { showAppCategoryPicker = false }
             )
         }
+    }
+
+    private var onboardingSetUpAction: (() -> Void)? {
+        coordinator.screenTimeAuthorization.authorizationStatus == .unavailable
+            ? nil
+            : { showAppCategoryPicker = true }
     }
 
     func finishOnboarding() {

--- a/EyePostureReminder/Views/SettingsView.swift
+++ b/EyePostureReminder/Views/SettingsView.swift
@@ -826,6 +826,7 @@ private struct SettingsTrueInterruptSection: View {
                     Task { _ = await coordinator.screenTimeAuthorization.requestAuthorization() }
                 },
                 onOpenSettings: openApplicationSettings,
+                onSelectApps: {},
                 onDone: { showPicker = false }
             )
         }

--- a/Tests/EyePostureReminderTests/Views/TrueInterruptViewCoverageTests.swift
+++ b/Tests/EyePostureReminderTests/Views/TrueInterruptViewCoverageTests.swift
@@ -229,38 +229,44 @@ final class TrueInterruptViewCoverageTests: XCTestCase {
         XCTAssertFalse(settingsOpened)
     }
 
-    func test_appCategoryPickerView_approvedPrimaryAction_requestsAuthorizationOnly() {
+    func test_appCategoryPickerView_approvedPrimaryAction_selectsAppsOnly() {
         var authorizationRequested = false
         var settingsOpened = false
+        var selectAppsCalled = false
         let view = AppCategoryPickerView(
             appsState: makeSelectedAppsState(),
             authorizationStatus: .approved,
             onRequestAuthorization: { authorizationRequested = true },
             onOpenSettings: { settingsOpened = true },
+            onSelectApps: { selectAppsCalled = true },
             onDone: {}
         )
 
         view.performPrimaryAction()
 
-        XCTAssertTrue(authorizationRequested)
+        XCTAssertFalse(authorizationRequested)
         XCTAssertFalse(settingsOpened)
+        XCTAssertTrue(selectAppsCalled)
     }
 
-    func test_appCategoryPickerView_unavailablePrimaryAction_requestsAuthorizationOnly() {
+    func test_appCategoryPickerView_unavailablePrimaryAction_isNoOp() {
         var authorizationRequested = false
         var settingsOpened = false
+        var selectAppsCalled = false
         let view = AppCategoryPickerView(
             appsState: makeSelectedAppsState(),
             authorizationStatus: .unavailable,
             onRequestAuthorization: { authorizationRequested = true },
             onOpenSettings: { settingsOpened = true },
+            onSelectApps: { selectAppsCalled = true },
             onDone: {}
         )
 
         view.performPrimaryAction()
 
-        XCTAssertTrue(authorizationRequested)
+        XCTAssertFalse(authorizationRequested)
         XCTAssertFalse(settingsOpened)
+        XCTAssertFalse(selectAppsCalled)
     }
 
     // MARK: - Accessibility Hint Body Tests

--- a/Tests/EyePostureReminderUITests/OnboardingFlowTests.swift
+++ b/Tests/EyePostureReminderUITests/OnboardingFlowTests.swift
@@ -138,10 +138,10 @@ final class OnboardingFlowTests: XCTestCase {
         )
     }
 
-    // MARK: - test_onboarding_interruptMode_actionsExistAndSetupPreviewOpensAppPicker
+    // MARK: - test_onboarding_interruptMode_actionsExistAndComingSoonIsDisabled
 
-    /// Verifies True Interrupt Mode exposes skip, customize, and setup-preview actions.
-    func test_onboarding_interruptMode_actionsExistAndSetupPreviewOpensAppPicker() throws {
+    /// Verifies True Interrupt Mode exposes skip/customize actions and keeps pre-entitlement setup disabled.
+    func test_onboarding_interruptMode_actionsExistAndComingSoonIsDisabled() throws {
         navigateToInterruptMode()
 
         let interruptSkipButton = app.buttons["onboarding.interrupt.skipButton"]
@@ -156,10 +156,6 @@ final class OnboardingFlowTests: XCTestCase {
             "True Interrupt screen must expose the setup preview button."
         )
 
-        if !setupPreviewButton.isHittable {
-            app.swipeUp()
-        }
-
         let customizeButton = app.buttons["onboarding.interrupt.customizeButton"]
         XCTAssertTrue(
             app.revealAndWaitForHittable(customizeButton, timeout: 5, maxSwipes: 4),
@@ -168,14 +164,9 @@ final class OnboardingFlowTests: XCTestCase {
             ".accessibilityIdentifier(\"onboarding.interrupt.customizeButton\") is set."
         )
         XCTAssertTrue(customizeButton.isHittable, "\"Customize Settings\" button must be tappable.")
-
-        XCTAssertTrue(setupPreviewButton.isHittable, "Setup preview button must be tappable during onboarding.")
-        setupPreviewButton.tap()
-
-        let unavailableBanner = onboardingElement(identifier: "appCategoryPicker.unavailableBanner")
-        XCTAssertTrue(
-            unavailableBanner.waitForExistence(timeout: 3),
-            "App/category setup preview must open and explain the current Screen Time availability state."
+        XCTAssertFalse(
+            setupPreviewButton.isEnabled,
+            "Pre-entitlement setup preview must remain disabled instead of opening a locked picker flow."
         )
     }
 


### PR DESCRIPTION
## Summary\n- route approved Screen Time picker CTAs through a dedicated select-apps action instead of requesting authorization again\n- keep unavailable onboarding True Interrupt setup disabled by not passing setup action pre-entitlement\n- align placeholder copy and onboarding UI coverage with the pre-entitlement behavior\n\nFixes #601\n\n## Validation\n- python3 -m json.tool EyePostureReminder/Resources/Localizable.xcstrings >/dev/null\n- swiftlint lint --strict --quiet EyePostureReminder/Views/AppCategoryPickerView.swift EyePostureReminder/Views/Onboarding/OnboardingView.swift EyePostureReminder/Views/SettingsView.swift Tests/EyePostureReminderTests/Views/TrueInterruptViewCoverageTests.swift Tests/EyePostureReminderUITests/OnboardingFlowTests.swift\n- xcodebuild test -scheme EyePostureReminder -destination "platform=iOS Simulator,name=iPhone 17 Pro" -only-testing:"EyePostureReminderTests/TrueInterruptViewCoverageTests" CODE_SIGNING_ALLOWED=NO\n- ./scripts/build.sh uitest --only-testing "EyePostureReminderUITests/OnboardingFlowTests/test_onboarding_interruptMode_actionsExistAndComingSoonIsDisabled"\n- ./scripts/build.sh build\n- ./scripts/build.sh test