### PR TITLE
Use project version settings for release archives

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,32 +61,24 @@ jobs:
           xcrun simctl list devices available | grep -i iphone | head -5
 
       # ── Versioning ──────────────────────────────────────────────────────────
-      # CFBundleShortVersionString is managed via: ./scripts/build.sh version <x.y.z>
-      # CFBundleVersion is auto-incremented here from github.run_number (guaranteed unique + increasing).
-      # EPRCommitHash is a custom key for traceability (not used by Apple — informational only).
-      #
-      # NOTE: agvtool requires an .xcodeproj. Once the Xcode project is created,
-      # replace the PlistBuddy calls below with:
-      #   agvtool new-version -all ${{ github.run_number }}
-      - name: Set build number + inject commit hash
+      # MARKETING_VERSION is managed via: ./scripts/build.sh version <x.y.z>
+      # CURRENT_PROJECT_VERSION is overridden here from github.run_number (guaranteed unique + increasing).
+      # GIT_COMMIT_HASH is exported for traceability in build logs/artifacts.
+      - name: Set version build settings
         run: |
           COMMIT_HASH=$(git rev-parse --short HEAD)
           BUILD_NUMBER=${{ github.run_number }}
           echo "BUILD_NUMBER=$BUILD_NUMBER" >> $GITHUB_ENV
           echo "GIT_COMMIT_HASH=$COMMIT_HASH" >> $GITHUB_ENV
 
-          PLIST="EyePostureReminder/Info.plist"
-          if [[ -f "$PLIST" ]]; then
-            /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" "$PLIST" 2>/dev/null || true
-            /usr/libexec/PlistBuddy -c "Add :EPRCommitHash string $COMMIT_HASH" "$PLIST" 2>/dev/null || \
-            /usr/libexec/PlistBuddy -c "Set :EPRCommitHash $COMMIT_HASH" "$PLIST"
-            MARKETING_VER=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$PLIST" 2>/dev/null || echo "unknown")
-            echo "MARKETING_VERSION=$MARKETING_VER" >> $GITHUB_ENV
-            echo "Injected build=$BUILD_NUMBER commit=$COMMIT_HASH marketing=$MARKETING_VER into $PLIST"
-          else
-            echo "MARKETING_VERSION=unknown" >> $GITHUB_ENV
-            echo "note: Info.plist not found — versioning will be applied when .xcodeproj is created"
+          MARKETING_VER=$(awk '$1 == "MARKETING_VERSION:" { gsub(/"/, "", $2); print $2; exit }' project.yml)
+          if [[ -z "$MARKETING_VER" ]]; then
+            echo "::error file=project.yml::MARKETING_VERSION is missing."
+            exit 1
           fi
+          echo "MARKETING_VERSION=$MARKETING_VER" >> $GITHUB_ENV
+          echo "CURRENT_PROJECT_VERSION=$BUILD_NUMBER" >> $GITHUB_ENV
+          echo "Version settings: marketing=$MARKETING_VER build=$BUILD_NUMBER commit=$COMMIT_HASH"
 
       # ── Dependency cache ─────────────────────────────────────────────────────
       - name: Cache DerivedData

--- a/EyePostureReminder/Info.plist
+++ b/EyePostureReminder/Info.plist
@@ -7,9 +7,9 @@
 	<key>CFBundleName</key>
 	<string>kshana</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundlePackageType</key>

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,7 +9,7 @@
 #   ./scripts/build.sh all             # build + lint + test
 #   ./scripts/build.sh check           # Quick syntax check (compile only, no tests)
 #   ./scripts/build.sh version         # Show current marketing version
-#   ./scripts/build.sh version 0.2.0   # Set marketing version in Info.plist
+#   ./scripts/build.sh version 0.2.0   # Set marketing version in project.yml
 
 set -euo pipefail
 
@@ -33,8 +33,25 @@ TEST_SCHEME="EyePostureReminderTests"
 UI_TEST_SCHEME="EyePostureReminderUITests"
 PACKAGE_PATH="$(cd "$(dirname "$0")/.." && pwd)"
 DERIVED_DATA_PATH="${PACKAGE_PATH}/DerivedData"
+PROJECT_SPEC_PATH="${PACKAGE_PATH}/project.yml"
+
+project_setting_value() {
+  local key="$1"
+  local value
+  value="$(awk -v key="$key" '$1 == key ":" { gsub(/"/, "", $2); print $2; exit }' "$PROJECT_SPEC_PATH")"
+  if [[ -z "$value" ]]; then
+    fail "Missing ${key} in project.yml"
+    exit 1
+  fi
+  echo "$value"
+}
+
+DEFAULT_MARKETING_VERSION="$(project_setting_value MARKETING_VERSION)"
+DEFAULT_CURRENT_PROJECT_VERSION="$(project_setting_value CURRENT_PROJECT_VERSION)"
 
 XCODE_FLAGS=(
+  MARKETING_VERSION="${MARKETING_VERSION:-$DEFAULT_MARKETING_VERSION}"
+  CURRENT_PROJECT_VERSION="${CURRENT_PROJECT_VERSION:-$DEFAULT_CURRENT_PROJECT_VERSION}"
   CODE_SIGN_IDENTITY=""
   CODE_SIGNING_REQUIRED=NO
   CODE_SIGNING_ALLOWED=NO
@@ -630,8 +647,8 @@ cmd_all() {
 }
 
 # ── Version management ────────────────────────────────────────────────────────
-# Marketing version lives in EyePostureReminder/Info.plist (CFBundleShortVersionString).
-# Build number (CFBundleVersion) is auto-incremented by CI via github.run_number.
+# Marketing version lives in project.yml (MARKETING_VERSION).
+# Build number (CFBundleVersion) defaults to project.yml and is overridden by CI via CURRENT_PROJECT_VERSION.
 # To bump manually: ./scripts/build.sh version <new-version>
 PLIST="${PACKAGE_PATH}/EyePostureReminder/Info.plist"
 
@@ -639,30 +656,54 @@ cmd_version() {
   local new_version="${1:-}"
 
   if [[ -z "$new_version" ]]; then
-    # Show current version
-    if [[ ! -f "$PLIST" ]]; then
-      fail "Info.plist not found at: $PLIST"
+    if [[ ! -f "$PROJECT_SPEC_PATH" ]]; then
+      fail "project.yml not found at: $PROJECT_SPEC_PATH"
       exit 1
     fi
     local current
-    current=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$PLIST" 2>/dev/null)
+    current="$(project_setting_value MARKETING_VERSION)"
     local build
-    build=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$PLIST" 2>/dev/null)
+    build="$(project_setting_value CURRENT_PROJECT_VERSION)"
     echo -e "${BOLD}Marketing version:${RESET} ${current}"
-    echo -e "${BOLD}Build number:${RESET}     ${build} (overwritten by CI with github.run_number)"
+    echo -e "${BOLD}Build number:${RESET}     ${build} (overridden by CI with github.run_number)"
   else
     # Validate semver format (digits only — Apple requires numeric segments)
     if ! [[ "$new_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
       fail "Version must be numeric semver, e.g. 0.2.0 (no pre-release labels)"
       exit 1
     fi
-    if [[ ! -f "$PLIST" ]]; then
-      fail "Info.plist not found at: $PLIST"
+    if [[ ! -f "$PROJECT_SPEC_PATH" ]]; then
+      fail "project.yml not found at: $PROJECT_SPEC_PATH"
       exit 1
     fi
-    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $new_version" "$PLIST"
-    pass "Marketing version set to ${new_version}"
-    info "Remember to commit Info.plist and tag: git tag -a v${new_version} -m 'Release ${new_version}'"
+    local update_count
+    update_count="$(python3 - "$PROJECT_SPEC_PATH" "$new_version" <<'PY'
+import re
+import sys
+
+path, version = sys.argv[1], sys.argv[2]
+with open(path, encoding="utf-8") as handle:
+    contents = handle.read()
+
+updated, count = re.subn(
+    r'(^\s*MARKETING_VERSION:\s*)"[0-9]+\.[0-9]+\.[0-9]+"',
+    rf'\1"{version}"',
+    contents,
+    flags=re.MULTILINE,
+)
+
+if count == 0:
+    print("0")
+    sys.exit(1)
+
+with open(path, "w", encoding="utf-8") as handle:
+    handle.write(updated)
+
+print(count)
+PY
+)"
+    pass "Marketing version set to ${new_version} in project.yml (${update_count} target settings)"
+    info "Remember to commit project.yml and tag: git tag -a v${new_version} -m 'Release ${new_version}'"
   fi
 }
 
@@ -682,7 +723,7 @@ usage() {
   echo "  all                build + lint + test"
   echo "  check              Alias for build (xcodebuild has no syntax-only mode)"
   echo "  version            Show current marketing version"
-  echo "  version <x.y.z>   Set marketing version in Info.plist"
+  echo "  version <x.y.z>   Set marketing version in project.yml"
 }
 
 # ── Entry point ───────────────────────────────────────────────────────────────

--- a/scripts/build_signed.sh
+++ b/scripts/build_signed.sh
@@ -49,6 +49,7 @@ DERIVED_DATA_PATH="${PACKAGE_PATH}/DerivedData"
 SIGNED_BUILD_PATH="${DERIVED_DATA_PATH}/SignedBuild"
 PROJECT_DIR="${SIGNED_BUILD_PATH}/Project"
 PROJECT_SPEC="${PROJECT_DIR}/project.yml"
+PROJECT_SOURCE_SPEC="${PACKAGE_PATH}/project.yml"
 PROJECT_PATH="${PROJECT_DIR}/${APP_TARGET}Signed.xcodeproj"
 ARCHIVE_DIR="${SIGNED_BUILD_PATH}/Archives"
 ARCHIVE_PATH="${ARCHIVE_DIR}/${APP_TARGET}.xcarchive"
@@ -66,6 +67,7 @@ ALLOW_PROVISIONING_UPDATES="${ALLOW_PROVISIONING_UPDATES:-YES}"
 EXPORT_METHOD="${EXPORT_METHOD:-app-store-connect}"
 TESTFLIGHT_INTERNAL_ONLY="${TESTFLIGHT_INTERNAL_ONLY:-NO}"
 UPLOAD_SYMBOLS="${UPLOAD_SYMBOLS:-YES}"
+RESOLVED_BUILD_NUMBER=""
 
 # Extension target support (future-safe; set YES only when extension provisioning
 # profiles are available — requires FamilyControls entitlement approval, issue #201).
@@ -363,6 +365,38 @@ count_lines() {
   fi
 }
 
+project_setting_value() {
+  local key="$1"
+  local value
+  value="$(awk -v key="$key" '$1 == key ":" { gsub(/"/, "", $2); print $2; exit }' "$PROJECT_SOURCE_SPEC")"
+  if [[ -z "$value" ]]; then
+    fail "Missing ${key} in project.yml"
+    exit 1
+  fi
+  echo "$value"
+}
+
+archive_marketing_version() {
+  if [[ -n "${MARKETING_VERSION:-}" ]]; then
+    echo "$MARKETING_VERSION"
+  else
+    project_setting_value MARKETING_VERSION
+  fi
+}
+
+archive_build_number() {
+  if [[ -z "$RESOLVED_BUILD_NUMBER" ]]; then
+    if [[ -n "${BUILD_NUMBER:-}" ]]; then
+      RESOLVED_BUILD_NUMBER="$BUILD_NUMBER"
+    else
+      RESOLVED_BUILD_NUMBER="$(date +%Y%m%d%H%M)"
+      info "BUILD_NUMBER not set — using timestamp fallback: $RESOLVED_BUILD_NUMBER" >&2
+    fi
+  fi
+
+  echo "$RESOLVED_BUILD_NUMBER"
+}
+
 ensure_manual_distribution_profile() {
   [[ "$SIGNING_STYLE" == "manual" ]] || return 0
 
@@ -440,12 +474,7 @@ inject_build_number() {
   fi
 
   local build_num
-  if [[ -n "${BUILD_NUMBER:-}" ]]; then
-    build_num="$BUILD_NUMBER"
-  else
-    build_num="$(date +%Y%m%d%H%M)"
-    info "BUILD_NUMBER not set — using timestamp fallback: $build_num"
-  fi
+  build_num="$(archive_build_number)"
 
   /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $build_num" "$archive_plist"
   pass "CFBundleVersion set to $build_num in main app archive (source Info.plist unchanged)"
@@ -463,6 +492,36 @@ inject_build_number() {
       fi
     done
   fi
+}
+
+verify_archived_version() {
+  local archive_plist="${ARCHIVE_PATH}/Products/Applications/${APP_TARGET}.app/Info.plist"
+
+  if [[ ! -f "$archive_plist" ]]; then
+    fail "Archive Info.plist not found at: $archive_plist"
+    return 1
+  fi
+
+  local expected_marketing
+  local expected_build
+  local actual_marketing
+  local actual_build
+  expected_marketing="$(archive_marketing_version)"
+  expected_build="$(archive_build_number)"
+  actual_marketing=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$archive_plist" 2>/dev/null || true)
+  actual_build=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$archive_plist" 2>/dev/null || true)
+
+  if [[ "$actual_marketing" != "$expected_marketing" ]]; then
+    fail "Archive marketing version mismatch: expected ${expected_marketing}, got ${actual_marketing:-<missing>}"
+    return 1
+  fi
+
+  if [[ "$actual_build" != "$expected_build" ]]; then
+    fail "Archive build number mismatch: expected ${expected_build}, got ${actual_build:-<missing>}"
+    return 1
+  fi
+
+  pass "Archive version verified: ${actual_marketing} (${actual_build})"
 }
 
 verify_archived_extensions() {
@@ -557,8 +616,12 @@ generate_project() {
   mkdir -p "$PROJECT_DIR"
 
   local style_value
+  local marketing_version
+  local build_number
   local manual_signing_settings=""
   style_value="$(code_sign_style_value)"
+  marketing_version="$(archive_marketing_version)"
+  build_number="$(archive_build_number)"
 
   # Scope manual signing only to the generated app-wrapper target. Passing these
   # as command-line build settings makes Xcode apply them to Swift Package
@@ -630,6 +693,8 @@ generate_project() {
         ENABLE_BITCODE: \"NO\"
         ENABLE_APP_INTENTS_METADATA_EXTRACTION: \"NO\"
         ENABLE_APPINTENTS_METADATA_EXTRACTION: \"NO\"
+        MARKETING_VERSION: $(yaml_quote "$marketing_version")
+        CURRENT_PROJECT_VERSION: $(yaml_quote "$build_number")
 ${sc_manual_signing_settings}
 ${sc_profile_line}
 
@@ -660,6 +725,8 @@ ${sc_profile_line}
         ENABLE_BITCODE: \"NO\"
         ENABLE_APP_INTENTS_METADATA_EXTRACTION: \"NO\"
         ENABLE_APPINTENTS_METADATA_EXTRACTION: \"NO\"
+        MARKETING_VERSION: $(yaml_quote "$marketing_version")
+        CURRENT_PROJECT_VERSION: $(yaml_quote "$build_number")
 ${da_manual_signing_settings}
 ${da_profile_line}"
   else
@@ -710,6 +777,8 @@ ${ext_app_deps}
         ENABLE_BITCODE: "NO"
         ENABLE_APP_INTENTS_METADATA_EXTRACTION: "NO"
         ENABLE_APPINTENTS_METADATA_EXTRACTION: "NO"
+        MARKETING_VERSION: $(yaml_quote "$marketing_version")
+        CURRENT_PROJECT_VERSION: $(yaml_quote "$build_number")
 ${manual_signing_settings}
     postBuildScripts:
       - name: "Assemble App Bundle"
@@ -958,6 +1027,7 @@ cmd_archive() {
   fi
 
   inject_build_number
+  verify_archived_version
   verify_archived_extensions
   pass "Archive created: $ARCHIVE_PATH"
 }


### PR DESCRIPTION
Fixes #606

## Summary
- Make app Info.plist use MARKETING_VERSION and CURRENT_PROJECT_VERSION build settings.
- Move build.sh version management to project.yml and pass version build settings into local xcodebuild.
- Set CI version build settings without mutating Info.plist and verify signed archives report the intended marketing/build version.

## Validation
- bash -n scripts/build.sh scripts/build_signed.sh
- Ruby YAML parse for CI/TestFlight/project.yml
- ./scripts/build.sh build
- ./scripts/build.sh test

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>