### PR TITLE
Harden True Interrupt UI coverage

### DIFF
--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -100,12 +100,19 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
                 ScreenTimeAuthorizationStatus.notDetermined.rawValue,
                 forKey: AppStorageKey.uiTestScreenTimeStatus
             )
-            // Ensure the banner-dismissed flag is clear so the banner renders.
-            uiTestDefaults.set(false, forKey: AppStorageKey.trueInterruptSkippedBannerDismissed)
+            uiTestDefaults.set(
+                launchArguments.contains("--dismiss-true-interrupt-banner") &&
+                    !launchArguments.contains("--show-true-interrupt-banner"),
+                forKey: AppStorageKey.trueInterruptSkippedBannerDismissed
+            )
         } else {
             // Remove any stale stub key so non-True-Interrupt launches use the
             // real ScreenTimeAuthorizationNoop and don't accidentally show the banner.
             uiTestDefaults.removeObject(forKey: AppStorageKey.uiTestScreenTimeStatus)
+            if launchArguments.contains("--skip-onboarding"),
+               !launchArguments.contains("--dismiss-true-interrupt-banner") {
+                uiTestDefaults.set(false, forKey: AppStorageKey.trueInterruptSkippedBannerDismissed)
+            }
         }
     }
 #endif
@@ -192,6 +199,11 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
             defaults.set(
                 ScreenTimeAuthorizationStatus.notDetermined.rawValue,
                 forKey: AppStorageKey.uiTestScreenTimeStatus
+            )
+            defaults.set(
+                args.contains("--dismiss-true-interrupt-banner") &&
+                    !args.contains("--show-true-interrupt-banner"),
+                forKey: AppStorageKey.trueInterruptSkippedBannerDismissed
             )
         }
     }

--- a/EyePostureReminder/Services/AppCoordinator+UITestMode.swift
+++ b/EyePostureReminder/Services/AppCoordinator+UITestMode.swift
@@ -33,7 +33,9 @@ extension AppCoordinator {
             launchArguments.contains("--reset-onboarding") ||
             launchArguments.contains("--show-overlay-eyes") ||
             launchArguments.contains("--show-overlay-posture") ||
-            launchArguments.contains("--simulate-screen-time-not-determined")
+            launchArguments.contains("--simulate-screen-time-not-determined") ||
+            launchArguments.contains("--dismiss-true-interrupt-banner") ||
+            launchArguments.contains("--show-true-interrupt-banner")
     }
 #else
     static var isUITestMode: Bool { false }

--- a/EyePostureReminder/Views/HomeView.swift
+++ b/EyePostureReminder/Views/HomeView.swift
@@ -12,6 +12,9 @@ struct HomeView: View {
     @State private var showSettings = false
     @AppStorage(AppStorageKey.openSettingsOnLaunch) private var openSettingsOnLaunch = false
     @AppStorage(AppStorageKey.trueInterruptSkippedBannerDismissed) private var trueInterruptBannerDismissed = false
+#if DEBUG
+    @AppStorage(AppStorageKey.uiTestScreenTimeStatus) private var uiTestScreenTimeStatusRaw = ""
+#endif
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private let accessibilityNotificationPoster: AccessibilityNotificationPosting
@@ -66,6 +69,9 @@ struct HomeView: View {
             return true
         }
 #if DEBUG
+        if uiTestScreenTimeStatusRaw == ScreenTimeAuthorizationStatus.notDetermined.rawValue {
+            return true
+        }
         if Self.resolveShouldShowUITestScreenTimePrompt(
             launchArguments: launchArguments,
             launchArgumentsProvider: launchArgumentsProvider,
@@ -78,7 +84,44 @@ struct HomeView: View {
         return false
     }
 
+    private var effectiveTrueInterruptBannerDismissed: Bool {
 #if DEBUG
+        if let uiTestDismissed = Self.resolveUITestTrueInterruptBannerDismissed(
+            processEnvironment: processEnvironment,
+            processEnvironmentProvider: processEnvironmentProvider
+        ) {
+            return uiTestDismissed
+        }
+#endif
+        return trueInterruptBannerDismissed
+    }
+
+#if DEBUG
+    static func resolveUITestTrueInterruptBannerDismissed(
+        launchArguments: [String]? = nil,
+        launchArgumentsProvider: LaunchArgumentsProvider = { CommandLine.arguments },
+        processEnvironment: [String: String]? = nil,
+        processEnvironmentProvider: ProcessEnvironmentProvider = { ProcessInfo.processInfo.environment }
+    ) -> Bool? {
+        let resolvedLaunchArguments = launchArguments ?? launchArgumentsProvider()
+        if resolvedLaunchArguments.contains("--show-true-interrupt-banner") {
+            return false
+        }
+        if resolvedLaunchArguments.contains("--dismiss-true-interrupt-banner") {
+            return true
+        }
+
+        let resolvedProcessEnvironment = processEnvironment ?? processEnvironmentProvider()
+        switch resolvedProcessEnvironment["UITEST_TRUE_INTERRUPT_BANNER_DISMISSED"] {
+        case "true":
+            return true
+        case "false":
+            return false
+        default:
+            return nil
+        }
+    }
+
     static func resolveShouldShowUITestScreenTimePrompt(
         launchArguments: [String]? = nil,
         launchArgumentsProvider: LaunchArgumentsProvider = { CommandLine.arguments },
@@ -127,7 +170,7 @@ struct HomeView: View {
             // Post-onboarding True Interrupt discoverability banner (#258).
             // Shown only when setup was skipped (notDetermined) and not yet dismissed.
             if shouldShowTrueInterruptPrompts,
-               !trueInterruptBannerDismissed {
+               !effectiveTrueInterruptBannerDismissed {
                 TrueInterruptSkippedBanner(
                     onSetUp: {
                         trueInterruptBannerDismissed = true
@@ -142,7 +185,7 @@ struct HomeView: View {
             // Persistent low-noise rediscovery affordance (#280).
             // Shown after the banner is dismissed while setup is still pending.
             if shouldShowTrueInterruptPrompts,
-               trueInterruptBannerDismissed {
+               effectiveTrueInterruptBannerDismissed {
                 TrueInterruptSetupPill(onTap: { showSettings = true })
             }
 
@@ -345,7 +388,6 @@ struct TrueInterruptSkippedBanner: View {
             RoundedRectangle(cornerRadius: AppLayout.radiusSmall)
                 .strokeBorder(AppColor.separatorSoft, lineWidth: AppLayout.borderHair)
         )
-        .accessibilityIdentifier("home.trueInterrupt.skippedBanner")
     }
 }
 

--- a/Tests/EyePostureReminderUITests/HomeScreenTests.swift
+++ b/Tests/EyePostureReminderUITests/HomeScreenTests.swift
@@ -19,7 +19,7 @@ final class HomeScreenTests: XCTestCase {
         app = nil
     }
 
-    private func relaunchWithTrueInterruptPending() {
+    private func relaunchWithTrueInterruptPending(bannerDismissed: Bool = false) {
         switch app.state {
         case .runningForeground, .runningBackground, .runningBackgroundSuspended:
             app.terminate()
@@ -29,7 +29,7 @@ final class HomeScreenTests: XCTestCase {
             break
         }
         app = XCUIApplication()
-        app.launchWithTrueInterruptPending()
+        app.launchWithTrueInterruptPending(bannerDismissed: bannerDismissed)
         XCTAssertTrue(
             app.waitForHomeScreenReady(timeout: 5),
             "Home screen should be ready before True Interrupt assertions."
@@ -204,58 +204,32 @@ final class HomeScreenTests: XCTestCase {
     func test_homeScreen_trueInterruptBanner_exists() throws {
         relaunchWithTrueInterruptPending()
 
-        let banner = app.otherElements["home.trueInterrupt.skippedBanner"]
-        let setupPill = app.buttons["home.trueInterrupt.setupPill"]
-        if !banner.waitForExistence(timeout: 2) {
-            app.swipeUp()
-        }
-        if banner.waitForExistence(timeout: 5) {
-            let setUpButton = app.buttons["home.trueInterrupt.skippedBanner.setUp"]
-            XCTAssertTrue(
-                setUpButton.waitForExistence(timeout: 3),
-                "Set Up CTA must be present in TrueInterruptSkippedBanner."
-            )
-            XCTAssertTrue(setUpButton.isHittable, "Set Up CTA must be hittable.")
+        let setUpButton = app.buttons["home.trueInterrupt.skippedBanner.setUp"]
+        XCTAssertTrue(
+            app.waitForElementHittable(setUpButton, timeout: 5),
+            "Set Up CTA must render and be hittable when TrueInterruptSkippedBanner is visible."
+        )
 
-            let dismissButton = app.buttons["home.trueInterrupt.skippedBanner.dismiss"]
-            XCTAssertTrue(
-                dismissButton.waitForExistence(timeout: 3),
-                "Dismiss CTA must be present in TrueInterruptSkippedBanner."
-            )
-            XCTAssertTrue(dismissButton.isHittable, "Dismiss CTA must be hittable.")
-            XCTAssertTrue(
-                banner.isHittable,
-                "TrueInterruptSkippedBanner should be reachable in the accessibility tree."
-            )
-            return
-        }
-        if setupPill.waitForExistence(timeout: 2) {
-            XCTAssertTrue(setupPill.isHittable, "If banner is already dismissed, setup pill must be tappable.")
-            return
-        }
-        throw XCTSkip("True Interrupt prompt did not render on this simulator run.")
+        let dismissButton = app.buttons["home.trueInterrupt.skippedBanner.dismiss"]
+        XCTAssertTrue(
+            app.waitForElementHittable(dismissButton, timeout: 3),
+            "Dismiss CTA must render and be hittable when TrueInterruptSkippedBanner is visible."
+        )
     }
 
     // MARK: - test_homeScreen_trueInterruptSetupPill_exists
 
-    /// Verifies that tapping the Dismiss CTA on TrueInterruptSkippedBanner removes the
-    /// banner and reveals TrueInterruptSetupPill in its place.
+    /// Verifies the TrueInterruptSetupPill renders after the skipped-banner
+    /// dismissed state is pre-seeded by the UI test launch arguments.
     ///
-    /// Flow: launch with `.notDetermined` state → dismiss banner → pill visible.
+    /// Flow: launch with `.notDetermined` state + dismissed banner → pill visible.
     func test_homeScreen_trueInterruptSetupPill_exists() throws {
-        relaunchWithTrueInterruptPending()
+        relaunchWithTrueInterruptPending(bannerDismissed: true)
 
-        let dismissButton = app.buttons["home.trueInterrupt.skippedBanner.dismiss"]
         let pill = app.buttons["home.trueInterrupt.setupPill"]
-        if app.revealAndWaitForHittable(dismissButton, timeout: 5, maxSwipes: 4) {
-            dismissButton.tap()
-        } else if !pill.waitForExistence(timeout: 2) {
-            throw XCTSkip("True Interrupt banner/pill unavailable on this simulator run.")
-        }
         XCTAssertTrue(
-            pill.waitForExistence(timeout: 5),
-            "TrueInterruptSetupPill must appear after the banner is dismissed."
+            app.waitForElementHittable(pill, timeout: 5),
+            "TrueInterruptSetupPill must appear and be hittable when the banner is dismissed."
         )
-        XCTAssertTrue(pill.isHittable, "TrueInterruptSetupPill must be hittable.")
     }
 }

--- a/Tests/EyePostureReminderUITests/UITestHelpers.swift
+++ b/Tests/EyePostureReminderUITests/UITestHelpers.swift
@@ -24,6 +24,12 @@ enum TestLaunchArguments {
     /// The simulator's real FamilyControls status is `.unavailable`; without this arg
     /// neither element would ever appear (#399).
     static let simulateScreenTimeNotDetermined = "--simulate-screen-time-not-determined"
+    /// Pre-seeds the True Interrupt skipped-banner dismissed flag so UITests can
+    /// assert the setup pill directly without depending on an earlier banner tap.
+    static let dismissTrueInterruptBanner = "--dismiss-true-interrupt-banner"
+    /// Forces the non-dismissed True Interrupt banner state for deterministic
+    /// UITest coverage, even if a prior run persisted the dismissed flag.
+    static let showTrueInterruptBanner = "--show-true-interrupt-banner"
     /// System-provided launch argument key for interface style override.
     static let appleInterfaceStyle = "-AppleInterfaceStyle"
     /// System-provided dark appearance value for `-AppleInterfaceStyle`.
@@ -91,13 +97,23 @@ extension XCUIApplication {
     /// Use in tests that verify `TrueInterruptSkippedBanner` (banner not yet dismissed) and
     /// `TrueInterruptSetupPill` (banner dismissed). The simulator's real FamilyControls status
     /// is `.unavailable`, so this argument is required to reach either element (#399).
-    func launchWithTrueInterruptPending(darkMode: Bool = false) {
+    func launchWithTrueInterruptPending(darkMode: Bool = false, bannerDismissed: Bool = false) {
         launchFresh()
         launchArguments += [
             TestLaunchArguments.skipOnboarding,
-            TestLaunchArguments.simulateScreenTimeNotDetermined
+            TestLaunchArguments.simulateScreenTimeNotDetermined,
+            "-kshana.ui-test.screenTimeStatus",
+            "notDetermined",
+            "-kshana.trueInterruptSkippedBannerDismissed",
+            bannerDismissed ? "true" : "false"
         ]
+        if bannerDismissed {
+            launchArguments += [TestLaunchArguments.dismissTrueInterruptBanner]
+        } else {
+            launchArguments += [TestLaunchArguments.showTrueInterruptBanner]
+        }
         launchEnvironment["UITEST_SCREEN_TIME_STATUS"] = "notDetermined"
+        launchEnvironment["UITEST_TRUE_INTERRUPT_BANNER_DISMISSED"] = bannerDismissed ? "true" : "false"
         appendDarkModeArgumentIfNeeded(darkMode)
         launch()
     }


### PR DESCRIPTION
Fixes #605

## Summary
- Replace True Interrupt UI-test skip paths with deterministic banner and setup-pill launch states.
- Add debug-only launch controls for the dismissed/non-dismissed banner state.
- Stop the banner container identifier from masking the Set Up and Dismiss CTA identifiers.

## Validation
- ./scripts/build.sh uitest --only-testing EyePostureReminderUITests/HomeScreenTests/test_homeScreen_trueInterruptBanner_exists --only-testing EyePostureReminderUITests/HomeScreenTests/test_homeScreen_trueInterruptSetupPill_exists
- ./scripts/build.sh uitest --only-testing EyePostureReminderUITests/HomeScreenTests
- ./scripts/build.sh build
- ./scripts/build.sh test

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>