### PR TITLE
Show no-reminders state on Home

### DIFF
--- a/EyePostureReminder/Resources/Localizable.xcstrings
+++ b/EyePostureReminder/Resources/Localizable.xcstrings
@@ -68,6 +68,61 @@
         }
       }
     },
+    "home.status.noReminders": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No reminders configured"
+          }
+        }
+      }
+    },
+    "home.noReminders.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No reminders are enabled"
+          }
+        }
+      }
+    },
+    "home.noReminders.body": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Turn on eye or posture reminders in Settings so kshana can help when it is time to pause."
+          }
+        }
+      }
+    },
+    "home.noReminders.openSettings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Settings"
+          }
+        }
+      }
+    },
+    "home.noReminders.openSettings.hint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens Settings to turn eye or posture reminders back on"
+          }
+        }
+      }
+    },
     "home.title": {
       "extractionState": "manual",
       "localizations": {

--- a/EyePostureReminder/Views/HomeView.swift
+++ b/EyePostureReminder/Views/HomeView.swift
@@ -38,16 +38,13 @@ struct HomeView: View {
     }
 
     private var statusLabel: String {
-        if !settings.globalEnabled {
-            return String(localized: "home.status.paused", bundle: .module)
-        }
-        if Self.shouldShowNotificationRecovery(
+        let key = Self.statusLocalizationKey(
             globalEnabled: settings.globalEnabled,
+            eyesEnabled: settings.eyesEnabled,
+            postureEnabled: settings.postureEnabled,
             notificationAuthStatus: coordinator.notificationAuthStatus
-        ) {
-            return String(localized: "home.status.notificationsOff", bundle: .module)
-        }
-        return String(localized: "home.status.active", bundle: .module)
+        )
+        return String(localized: String.LocalizationValue(key), bundle: .module)
     }
 
     private var shouldShowNotificationRecovery: Bool {
@@ -57,11 +54,52 @@ struct HomeView: View {
         )
     }
 
+    private var shouldShowNoRemindersConfigured: Bool {
+        Self.shouldShowNoRemindersConfigured(
+            globalEnabled: settings.globalEnabled,
+            eyesEnabled: settings.eyesEnabled,
+            postureEnabled: settings.postureEnabled
+        )
+    }
+
+    static func statusLocalizationKey(
+        globalEnabled: Bool,
+        eyesEnabled: Bool,
+        postureEnabled: Bool,
+        notificationAuthStatus: UNAuthorizationStatus
+    ) -> String {
+        if !globalEnabled {
+            return "home.status.paused"
+        }
+        if shouldShowNoRemindersConfigured(
+            globalEnabled: globalEnabled,
+            eyesEnabled: eyesEnabled,
+            postureEnabled: postureEnabled
+        ) {
+            return "home.status.noReminders"
+        }
+        if shouldShowNotificationRecovery(
+            globalEnabled: globalEnabled,
+            notificationAuthStatus: notificationAuthStatus
+        ) {
+            return "home.status.notificationsOff"
+        }
+        return "home.status.active"
+    }
+
     static func shouldShowNotificationRecovery(
         globalEnabled: Bool,
         notificationAuthStatus: UNAuthorizationStatus
     ) -> Bool {
         globalEnabled && notificationAuthStatus == .denied
+    }
+
+    static func shouldShowNoRemindersConfigured(
+        globalEnabled: Bool,
+        eyesEnabled: Bool,
+        postureEnabled: Bool
+    ) -> Bool {
+        globalEnabled && !eyesEnabled && !postureEnabled
     }
 
     private var shouldShowTrueInterruptPrompts: Bool {
@@ -189,8 +227,12 @@ struct HomeView: View {
                 TrueInterruptSetupPill(onTap: { showSettings = true })
             }
 
-            if shouldShowNotificationRecovery {
+            if shouldShowNotificationRecovery && !shouldShowNoRemindersConfigured {
                 HomeNotificationWarningBanner(onOpenSettings: openApplicationSettings)
+            }
+
+            if shouldShowNoRemindersConfigured {
+                HomeNoRemindersConfiguredBanner(onOpenSettings: { showSettings = true })
             }
         }
         .padding(.horizontal, AppSpacing.xl)
@@ -291,6 +333,50 @@ struct HomeNotificationWarningBanner: View {
         )
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("home.notifications.disabledBanner")
+    }
+}
+
+// MARK: - No Reminders Configured Banner
+
+struct HomeNoRemindersConfiguredBanner: View {
+    let onOpenSettings: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.sm) {
+            HStack(alignment: .top, spacing: AppSpacing.sm) {
+                IconContainer(icon: AppSymbol.warning, color: AppColor.accentWarm, size: 36)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: AppSpacing.xs) {
+                    Text("home.noReminders.title", bundle: .module)
+                        .font(AppFont.bodyEmphasized)
+                        .foregroundStyle(AppColor.textPrimary)
+                    Text("home.noReminders.body", bundle: .module)
+                        .font(AppFont.caption)
+                        .foregroundStyle(AppColor.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+
+            Button(action: onOpenSettings) {
+                Text("home.noReminders.openSettings", bundle: .module)
+                    .font(AppFont.captionEmphasized)
+            }
+            .frame(minHeight: AppLayout.minTapTarget)
+            .contentShape(Rectangle())
+            .foregroundStyle(AppColor.accentWarm)
+            .accessibilityHint(Text("home.noReminders.openSettings.hint", bundle: .module))
+            .accessibilityIdentifier("home.noReminders.openSettings")
+        }
+        .padding(AppSpacing.sm)
+        .background(AppColor.accentWarm.opacity(AppOpacity.warningBackground),
+                    in: RoundedRectangle(cornerRadius: AppLayout.radiusSmall))
+        .overlay(
+            RoundedRectangle(cornerRadius: AppLayout.radiusSmall)
+                .strokeBorder(AppColor.accentWarm.opacity(AppOpacity.warningSeparator),
+                              lineWidth: AppLayout.borderHair)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("home.noReminders.configuredBanner")
     }
 }
 

--- a/Tests/EyePostureReminderTests/Mocks/MockDeviceActivityMonitorProviding.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockDeviceActivityMonitorProviding.swift
@@ -26,6 +26,7 @@ final class MockDeviceActivityMonitorProviding: DeviceActivityMonitorProviding {
     /// When non-nil, `scheduleBreakMonitoring(for:)` throws this error.
     var stubbedScheduleError: Error?
     var scheduleDelayNanoseconds: UInt64 = 0
+    var scheduleSuspension: (() async -> Void)?
     /// When non-nil, `cancelBreakMonitoring()` throws this error.
     var stubbedCancelError: Error?
 
@@ -48,6 +49,9 @@ final class MockDeviceActivityMonitorProviding: DeviceActivityMonitorProviding {
         scheduledSessions.append(session)
         if scheduleDelayNanoseconds > 0 {
             try await Task.sleep(nanoseconds: scheduleDelayNanoseconds)
+        }
+        if let scheduleSuspension {
+            await scheduleSuspension()
         }
         if let error = stubbedScheduleError { throw error }
         activeSession = session
@@ -76,6 +80,7 @@ final class MockDeviceActivityMonitorProviding: DeviceActivityMonitorProviding {
         stubbedIsAvailable = false
         stubbedScheduleError = nil
         scheduleDelayNanoseconds = 0
+        scheduleSuspension = nil
         stubbedCancelError = nil
         activeSession = nil
         scheduleCallCount = 0

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorNotificationFallbackTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorNotificationFallbackTests.swift
@@ -431,18 +431,24 @@ final class AppCoordinatorNotificationFallbackTests: XCTestCase {
 
     func test_deviceActivityScheduleFailure_afterOverlayDismiss_suppressesFallbackNotification() async throws {
         struct ScheduleFailure: Error {}
+        var scheduleContinuation: CheckedContinuation<Void, Never>?
         deviceActivityMonitor.stubbedIsAvailable = true
         deviceActivityMonitor.stubbedScheduleError = ScheduleFailure()
-        deviceActivityMonitor.scheduleDelayNanoseconds = 100_000_000
+        deviceActivityMonitor.scheduleSuspension = {
+            await withCheckedContinuation { continuation in
+                scheduleContinuation = continuation
+            }
+        }
         ipcStore.trueInterruptEnabled = true
         ipcStore.selectApps()
         await coordinator.refreshAuthStatus()
 
         tracker.simulateThresholdReached(for: .eyes)
         await awaitCondition { overlay.showCallCount >= 1 }
-        await awaitCondition { deviceActivityMonitor.scheduleCallCount >= 1 }
+        await awaitCondition { scheduleContinuation != nil }
         overlay.simulateDismiss()
-        await awaitCondition {
+        scheduleContinuation?.resume()
+        await awaitCondition(timeout: 3.0) {
             deviceActivityMonitor.cancelCallCount >= 1 &&
             ipcStore.events.contains { $0.kind == .notificationFallbackSuppressed }
         }

--- a/Tests/EyePostureReminderTests/Views/HomeViewLaunchContextResolverTests.swift
+++ b/Tests/EyePostureReminderTests/Views/HomeViewLaunchContextResolverTests.swift
@@ -94,5 +94,57 @@ final class HomeViewLaunchContextResolverTests: XCTestCase {
             notificationAuthStatus: .authorized
         ))
     }
+
+    func test_noRemindersConfigured_whenGlobalEnabledAndBothReminderTypesDisabled_returnsTrue() {
+        XCTAssertTrue(HomeView.shouldShowNoRemindersConfigured(
+            globalEnabled: true,
+            eyesEnabled: false,
+            postureEnabled: false
+        ))
+    }
+
+    func test_noRemindersConfigured_whenGlobalDisabled_returnsFalse() {
+        XCTAssertFalse(HomeView.shouldShowNoRemindersConfigured(
+            globalEnabled: false,
+            eyesEnabled: false,
+            postureEnabled: false
+        ))
+    }
+
+    func test_statusLocalizationKey_whenNoReminderTypesEnabled_returnsNoReminders() {
+        XCTAssertEqual(
+            HomeView.statusLocalizationKey(
+                globalEnabled: true,
+                eyesEnabled: false,
+                postureEnabled: false,
+                notificationAuthStatus: .authorized
+            ),
+            "home.status.noReminders"
+        )
+    }
+
+    func test_statusLocalizationKey_whenNoRemindersAndNotificationsDenied_prefersNoReminders() {
+        XCTAssertEqual(
+            HomeView.statusLocalizationKey(
+                globalEnabled: true,
+                eyesEnabled: false,
+                postureEnabled: false,
+                notificationAuthStatus: .denied
+            ),
+            "home.status.noReminders"
+        )
+    }
+
+    func test_statusLocalizationKey_whenOneReminderEnabledAndNotificationsDenied_returnsNotificationsOff() {
+        XCTAssertEqual(
+            HomeView.statusLocalizationKey(
+                globalEnabled: true,
+                eyesEnabled: true,
+                postureEnabled: false,
+                notificationAuthStatus: .denied
+            ),
+            "home.status.notificationsOff"
+        )
+    }
 }
 #endif

--- a/Tests/EyePostureReminderTests/Views/StringCatalogTests.swift
+++ b/Tests/EyePostureReminderTests/Views/StringCatalogTests.swift
@@ -55,6 +55,10 @@ final class StringCatalogTests: XCTestCase {
         XCTAssertTrue(isTranslated("home.status.paused"))
     }
 
+    func test_homeStatusNoReminders_resolvesToEnglish() {
+        XCTAssertTrue(isTranslated("home.status.noReminders"))
+    }
+
     func test_settingsNavTitle_resolvesToEnglish() {
         XCTAssertTrue(isTranslated("settings.navTitle"))
     }
@@ -136,6 +140,7 @@ final class StringCatalogTests: XCTestCase {
     func test_allExpectedKeys_resolveToNonEmptyStrings() {
         let expectedKeys = [
             "home.navTitle", "home.title", "home.status.active", "home.status.paused",
+            "home.status.noReminders",
             "home.settingsButton",
             "settings.navTitle", "settings.doneButton", "settings.masterToggle",
             "settings.pausedBanner", "settings.section.eyes", "settings.section.posture",
@@ -234,7 +239,13 @@ final class StringCatalogTests: XCTestCase {
             "appCategoryPicker.doneButton.hint",
             // home.trueInterrupt.setupPill.* — rediscovery affordance keys (#280)
             "home.trueInterrupt.setupPill",
-            "home.trueInterrupt.setupPill.hint"
+            "home.trueInterrupt.setupPill.hint",
+            // home.noReminders.* — zero-reminder recovery banner (#612)
+            "home.status.noReminders",
+            "home.noReminders.title",
+            "home.noReminders.body",
+            "home.noReminders.openSettings",
+            "home.noReminders.openSettings.hint"
         ]
         for key in expectedKeys {
             XCTAssertFalse(str(key).isEmpty, "Key '\(key)' must resolve to a non-empty string")
@@ -244,7 +255,9 @@ final class StringCatalogTests: XCTestCase {
     func test_noDuplicateKeys_homeScreen() {
         let keys = [
             "home.navTitle", "home.title", "home.status.active",
-            "home.status.paused", "home.settingsButton"
+            "home.status.paused", "home.status.noReminders", "home.settingsButton",
+            "home.noReminders.title", "home.noReminders.body",
+            "home.noReminders.openSettings", "home.noReminders.openSettings.hint"
         ]
         XCTAssertEqual(Set(keys).count, keys.count, "Home screen keys must be unique")
     }
@@ -445,6 +458,7 @@ final class StringCatalogTests: XCTestCase {
     func test_keyConvention_noEmptyKeys() {
         let allKeys = [
             "home.navTitle", "home.title",
+            "home.status.noReminders",
             "settings.navTitle", "settings.masterToggle",
             "overlay.dismissButton", "onboarding.welcome.title"
         ]
@@ -459,6 +473,7 @@ final class StringCatalogTests: XCTestCase {
     func test_keyConvention_allKeysHaveAtLeastTwoComponents() {
         let allKeys = [
             "home.navTitle", "home.title", "home.status.active",
+            "home.status.noReminders",
             "settings.doneButton", "settings.section.eyes",
             "overlay.dismissButton", "overlay.countdown.label",
             "onboarding.welcome.title", "onboarding.setup.getStartedButton"


### PR DESCRIPTION
Fixes #612

## Summary
- Add a Home status for the zero-reminder state when both eye and posture reminders are disabled.
- Show a Home warning banner that opens Settings so users can re-enable a reminder type.
- Cover the status selection and localized strings with unit tests.

## Validation
- Ruby JSON parse for Localizable.xcstrings
- Targeted HomeView status/string tests
- ./scripts/build.sh build
- ./scripts/build.sh test

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>