### PR TITLE
Hide saved banner icon from VoiceOver

### DIFF
--- a/EyePostureReminder/Views/SettingsView.swift
+++ b/EyePostureReminder/Views/SettingsView.swift
@@ -511,12 +511,15 @@ struct SettingsView: View {
 // MARK: - Saved Banner (#434)
 
 /// Pill-shaped transient confirmation shown for 1.5 s after any setting change.
-private struct SettingsSavedBanner: View {
+struct SettingsSavedBanner: View {
     var body: some View {
-        Label(
-            String(localized: "settings.savedBanner", bundle: .module),
-            systemImage: "checkmark.circle.fill"
-        )
+        HStack(spacing: AppSpacing.xs) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(AppColor.primaryRest)
+                .accessibilityHidden(true)
+
+            Text(String(localized: "settings.savedBanner", bundle: .module))
+        }
         .font(AppFont.bodyEmphasized)
         .foregroundStyle(AppColor.textPrimary)
         .accessibilityIdentifier("settings.savedBanner")

--- a/Tests/EyePostureReminderTests/Views/SettingsAccessibilityTests.swift
+++ b/Tests/EyePostureReminderTests/Views/SettingsAccessibilityTests.swift
@@ -1,0 +1,67 @@
+@testable import EyePostureReminder
+import Foundation
+import XCTest
+
+@MainActor
+final class SettingsAccessibilityTests: XCTestCase {
+    func test_settingsSavedBanner_bodyEvaluates() {
+        let described = String(describing: SettingsSavedBanner().body)
+
+        XCTAssertFalse(
+            described.isEmpty,
+            "SettingsSavedBanner body must evaluate after splitting decorative image from accessible text (#613)."
+        )
+    }
+
+    func test_settingsSavedBanner_decorativeCheckmarkIsAccessibilityHidden() throws {
+        let source = try String(contentsOf: settingsViewSourceURL, encoding: .utf8)
+        let bannerSource = try XCTUnwrap(
+            source.slice(from: "struct SettingsSavedBanner: View", to: "// MARK: - Snooze"),
+            "SettingsSavedBanner source should be present in SettingsView.swift."
+        )
+
+        XCTAssertFalse(
+            bannerSource.contains("Label("),
+            "SettingsSavedBanner must not use Label because its decorative SF Symbol can be exposed to VoiceOver."
+        )
+        XCTAssertTrue(
+            bannerSource.contains("Image(systemName: \"checkmark.circle.fill\")"),
+            "SettingsSavedBanner should keep the visual checkmark as an explicit Image."
+        )
+        XCTAssertTrue(
+            bannerSource.contains(".accessibilityHidden(true)"),
+            "SettingsSavedBanner checkmark Image must be hidden from VoiceOver."
+        )
+    }
+
+    private var settingsViewSourceURL: URL {
+        repositoryRoot
+            .appendingPathComponent("EyePostureReminder")
+            .appendingPathComponent("Views")
+            .appendingPathComponent("SettingsView.swift")
+    }
+
+    private var repositoryRoot: URL {
+        var url = URL(fileURLWithPath: #filePath)
+        while url.path != "/" {
+            url = url.deletingLastPathComponent()
+            if FileManager.default.fileExists(
+                atPath: url.appendingPathComponent("Package.swift").path
+            ) {
+                return url
+            }
+        }
+        preconditionFailure("Cannot locate repo root from \(#filePath)")
+    }
+}
+
+private extension String {
+    func slice(from start: String, to end: String) -> String? {
+        guard let startRange = range(of: start) else { return nil }
+        let searchRange = startRange.upperBound..<endIndex
+        guard let endRange = range(of: end, range: searchRange) else {
+            return String(self[startRange.lowerBound...])
+        }
+        return String(self[startRange.lowerBound..<endRange.lowerBound])
+    }
+}


### PR DESCRIPTION
Fixes #613

## Summary
- Split the Settings saved banner from Label into explicit decorative Image plus Text.
- Hide the checkmark SF Symbol from VoiceOver while preserving the visible confirmation text.
- Add regression coverage for the saved banner accessibility structure.

## Validation
- xcodebuild test -scheme EyePostureReminder -destination "platform=iOS Simulator,name=iPhone 17" -only-testing:"EyePostureReminderTests/SettingsAccessibilityTests" CODE_SIGNING_ALLOWED=NO
- ./scripts/build.sh build
- ./scripts/build.sh test

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>