### PR TITLE
Add branded App Store support URLs

### DIFF
--- a/docs/APP_STORE_LISTING.md
+++ b/docs/APP_STORE_LISTING.md
@@ -186,8 +186,8 @@ All App Store age rating questionnaire answers are "No" / "None".
 | **Bundle ID** | com.yashasg.eyeposturereminder |
 | **SKU** | kshana |
 | **Copyright** | © 2026 Yashasg |
-| **Support URL** | https://github.com/yashasg/fantastic-octo-fortnight |
-| **Marketing URL** | https://github.com/yashasg/fantastic-octo-fortnight |
+| **Support URL** | https://yashasg.github.io/fantastic-octo-fortnight/support.html |
+| **Marketing URL** | https://yashasg.github.io/fantastic-octo-fortnight/ |
 | **Version** | 0.2.0 |
 | **Build** | (CI-assigned via `github.run_number`) |
 | **Availability** | All territories |
@@ -202,7 +202,7 @@ Complete every item before submitting for App Review.
 
 ### Legal & Privacy
 
-- [ ] Privacy Policy hosted at a public HTTPS URL (link it in App Store Connect and in-app)
+- [ ] Privacy Policy hosted at a public HTTPS URL: `https://yashasg.github.io/fantastic-octo-fortnight/privacy.html` (link it in App Store Connect and in-app)
 - [ ] EULA supplement with Apple's 7 required clauses added to TERMS.md
 - [ ] Privacy Nutrition Labels filled in App Store Connect (see [`docs/PRIVACY_NUTRITION_LABELS.md`](PRIVACY_NUTRITION_LABELS.md))
 - [ ] Health/wellness disclaimers included in app description ("not medical advice")
@@ -221,7 +221,8 @@ Complete every item before submitting for App Review.
   - `com.yashasg.eyeposturereminder.shieldconfiguration`
   - `com.yashasg.eyeposturereminder.deviceactivitymonitor`
 - [ ] SKU set in App Store Connect: `kshana` (must be unique; cannot be changed after creation)
-- [ ] Support URL set: `https://github.com/yashasg/fantastic-octo-fortnight`
+- [ ] Support URL set: `https://yashasg.github.io/fantastic-octo-fortnight/support.html`
+- [ ] Marketing URL set: `https://yashasg.github.io/fantastic-octo-fortnight/`
 - [ ] App name, subtitle, keywords, and description finalized (Sections 1–4 above)
 - [ ] Age rating questionnaire completed (all answers "No" / "None" → 4+)
 - [ ] Primary category: Health & Fitness; Secondary: Productivity

--- a/docs/app-store-submission-status.md
+++ b/docs/app-store-submission-status.md
@@ -39,11 +39,12 @@ Legend: ✅ Done · ⚠️ In progress / partial · ❌ Not started · 🔒 Bloc
 | A1 | Bundle ID finalized: `com.yashasg.eyeposturereminder` | ✅ Done | Set in `project.yml` |
 | A2 | App Group `group.com.yashasg.kshana` registered and associated with all three bundle IDs | ❌ Not started | Requires Apple Developer Portal — screen time extensions depend on this |
 | A3 | SKU set: `kshana` | ❌ Not started | Must be set in ASC before first build upload |
-| A4 | Support URL set: `https://github.com/yashasg/fantastic-octo-fortnight` | ❌ Not started | Enter in App Store Connect |
-| A5 | App name, subtitle, keywords, description finalized | ✅ Done | See `APP_STORE_LISTING.md` Sections 1–4 |
-| A6 | Age rating questionnaire completed | ❌ Not started | All answers "No" / "None" → 4+ |
-| A7 | Primary category: Health & Fitness; Secondary: Productivity | ❌ Not started | Enter in App Store Connect |
-| A8 | Price: Free, all territories | ❌ Not started | Enter in App Store Connect |
+| A4 | Support URL set: `https://yashasg.github.io/fantastic-octo-fortnight/support.html` | ⚠️ Partial | Branded static page exists in `docs/support.html`; enter final hosted URL in App Store Connect |
+| A5 | Marketing URL set: `https://yashasg.github.io/fantastic-octo-fortnight/` | ⚠️ Partial | Branded static page exists in `docs/index.html`; enter final hosted URL in App Store Connect |
+| A6 | App name, subtitle, keywords, description finalized | ✅ Done | See `APP_STORE_LISTING.md` Sections 1–4 |
+| A7 | Age rating questionnaire completed | ❌ Not started | All answers "No" / "None" → 4+ |
+| A8 | Primary category: Health & Fitness; Secondary: Productivity | ❌ Not started | Enter in App Store Connect |
+| A9 | Price: Free, all territories | ❌ Not started | Enter in App Store Connect |
 
 ---
 
@@ -86,19 +87,19 @@ Legend: ✅ Done · ⚠️ In progress / partial · ❌ Not started · 🔒 Bloc
 |----------|------|---------|-------------|---------|
 | Legal & Privacy | 1 | 1 | 2 | 2 (ext) |
 | Entitlements | 2 | 1 | 0 | 0 |
-| ASC Configuration | 2 | 0 | 6 | 0 |
+| ASC Configuration | 2 | 2 | 5 | 0 |
 | Assets | 0 | 1 | 2 | 0 |
 | Name Search | 3 | 0 | 1 | 0 |
 | Final Checks | 0 | 2 | 2 | 0 |
-| **Total (18 items)** | **8** | **5** | **13** | **2 ext** |
+| **Total (27 items)** | **8** | **7** | **12** | **2 ext** |
 
-**Overall:** ~44% complete. Two external blockers (#185, #196) gate the ASC configuration phase. Name search is complete. Entitlements are buildable today.
+**Overall:** ~30% complete. Two external blockers (#185, #196) gate the ASC configuration phase. Name search is complete. Entitlements are buildable today.
 
 ---
 
 ## Recommended Next Actions
 
-1. **Close #185 follow-through** — hosted privacy URL is now available at `https://github.com/yashasg/fantastic-octo-fortnight/blob/main/docs/legal/PRIVACY.md`; remaining manual step is adding this URL in App Store Connect metadata.
+1. **Close #185 follow-through** — privacy URL content is staged at `docs/privacy.html` for `https://yashasg.github.io/fantastic-octo-fortnight/privacy.html`; remaining manual step is confirming GitHub Pages is enabled and adding this URL in App Store Connect metadata.
 2. **Unblock #196** — upload `docs/legal/TERMS.md` content to App Store Connect License Agreement field.
 3. **Capture screenshots** — 5 screens on iPhone 15 Pro + Pro Max.
 4. **Export app icon** — 1024×1024 PNG, no alpha.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,111 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>kshana - Eye & Posture Wellness</title>
+  <meta name="description" content="kshana gently reminds you to take healthier eye and posture breaks without accounts, ads, or tracking.">
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f8f4ec;
+      --surface: #fffdf8;
+      --text: #22352d;
+      --muted: #5f6f67;
+      --primary: #2f6f5e;
+      --border: #d8e4dc;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #101714;
+        --surface: #18221e;
+        --text: #eef7f1;
+        --muted: #b9c8bf;
+        --primary: #8ed2b1;
+        --border: #314039;
+      }
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.6;
+    }
+    main {
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 56px 20px;
+    }
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 28px;
+      padding: 32px;
+      box-shadow: 0 14px 40px rgb(34 53 45 / 12%);
+    }
+    h1 {
+      margin: 0 0 8px;
+      font-size: clamp(2.4rem, 9vw, 4rem);
+      line-height: 1;
+      letter-spacing: -0.05em;
+    }
+    h2 {
+      margin-top: 32px;
+    }
+    p {
+      margin: 0 0 16px;
+    }
+    .subtitle {
+      color: var(--muted);
+      font-size: 1.25rem;
+      margin-bottom: 24px;
+    }
+    .actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      margin-top: 28px;
+    }
+    a {
+      color: var(--primary);
+      font-weight: 650;
+    }
+    .button {
+      border: 1px solid var(--primary);
+      border-radius: 999px;
+      padding: 10px 16px;
+      text-decoration: none;
+    }
+    ul {
+      padding-left: 1.25rem;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="card" aria-labelledby="title">
+      <h1 id="title">kshana</h1>
+      <p class="subtitle">Eye &amp; Posture Wellness</p>
+      <p>
+        kshana helps you build healthier screen habits with gentle eye-break and posture reminders.
+        It is privacy-first: no accounts, no ads, no tracking, and no custom analytics backend.
+      </p>
+      <h2>What kshana does</h2>
+      <ul>
+        <li>Custom eye-break and posture-check intervals</li>
+        <li>Calm full-screen break guidance with snooze options</li>
+        <li>Smart Pause during Focus, CarPlay, and driving</li>
+        <li>True Interrupt Mode planned after Apple's Screen Time entitlement approval</li>
+      </ul>
+      <div class="actions" aria-label="Helpful links">
+        <a class="button" href="support.html">Support</a>
+        <a class="button" href="privacy.html">Privacy Policy</a>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -1,0 +1,119 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>kshana Privacy Policy</title>
+  <meta name="description" content="Privacy policy for kshana.">
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f8f4ec;
+      --surface: #fffdf8;
+      --text: #22352d;
+      --muted: #5f6f67;
+      --primary: #2f6f5e;
+      --border: #d8e4dc;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #101714;
+        --surface: #18221e;
+        --text: #eef7f1;
+        --muted: #b9c8bf;
+        --primary: #8ed2b1;
+        --border: #314039;
+      }
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.6;
+    }
+    main {
+      max-width: 860px;
+      margin: 0 auto;
+      padding: 48px 20px;
+    }
+    article {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 28px;
+      padding: 32px;
+      box-shadow: 0 14px 40px rgb(34 53 45 / 12%);
+    }
+    h1 {
+      margin-top: 0;
+      letter-spacing: -0.04em;
+    }
+    h2 {
+      margin-top: 32px;
+    }
+    a {
+      color: var(--primary);
+      font-weight: 650;
+    }
+    .muted {
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <article aria-labelledby="title">
+      <h1 id="title">kshana Privacy Policy</h1>
+      <p class="muted">Last updated: April 26, 2026</p>
+      <p>
+        kshana is designed to be privacy-preserving. Your app settings stay on your
+        device, motion and Focus information are used only transiently for reminder
+        pause logic, and the app does not use advertising, tracking, user accounts,
+        third-party analytics SDKs, or a custom analytics backend.
+      </p>
+
+      <h2>What kshana stores locally</h2>
+      <p>
+        kshana stores app settings, reminder preferences, and app state locally using
+        Apple's UserDefaults storage. If Screen Time features become available after
+        Apple entitlement approval, local App Group coordination metadata may also be
+        stored so the main app and extensions can coordinate reminders and shielding.
+      </p>
+
+      <h2>What kshana accesses in memory</h2>
+      <p>
+        kshana may read motion activity and Focus status transiently to pause reminders
+        while you are driving, using CarPlay, or in Focus. This information is not sent
+        to a developer server.
+      </p>
+
+      <h2>Diagnostics</h2>
+      <p>
+        Apple may provide aggregated App Store Connect analytics, crash diagnostics, and
+        performance data to the developer. kshana also uses Apple's os.Logger framework
+        for on-device diagnostics; sensitive values are marked private/redacted in
+        release logging.
+      </p>
+
+      <h2>What kshana does not do</h2>
+      <ul>
+        <li>No accounts or login</li>
+        <li>No ads or tracking</li>
+        <li>No sale of data</li>
+        <li>No third-party analytics SDKs</li>
+        <li>No custom analytics backend</li>
+      </ul>
+
+      <h2>Contact</h2>
+      <p>
+        For privacy questions, email <a href="mailto:support@yashasg.dev">support@yashasg.dev</a>.
+      </p>
+
+      <p><a href="support.html">Support</a> · <a href="index.html">Marketing page</a></p>
+    </article>
+  </main>
+</body>
+</html>

--- a/docs/support.html
+++ b/docs/support.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>kshana Support</title>
+  <meta name="description" content="Support, FAQ, and contact information for kshana.">
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #f8f4ec;
+      --surface: #fffdf8;
+      --text: #22352d;
+      --muted: #5f6f67;
+      --primary: #2f6f5e;
+      --border: #d8e4dc;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #101714;
+        --surface: #18221e;
+        --text: #eef7f1;
+        --muted: #b9c8bf;
+        --primary: #8ed2b1;
+        --border: #314039;
+      }
+    }
+    * {
+      box-sizing: border-box;
+    }
+    body {
+      margin: 0;
+      background: var(--bg);
+      color: var(--text);
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.6;
+    }
+    main {
+      max-width: 760px;
+      margin: 0 auto;
+      padding: 48px 20px;
+    }
+    .card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 28px;
+      padding: 32px;
+      box-shadow: 0 14px 40px rgb(34 53 45 / 12%);
+    }
+    h1 {
+      margin-top: 0;
+      letter-spacing: -0.04em;
+    }
+    h2 {
+      margin-top: 32px;
+    }
+    a {
+      color: var(--primary);
+      font-weight: 650;
+    }
+    .muted {
+      color: var(--muted);
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <section class="card" aria-labelledby="title">
+      <h1 id="title">kshana Support</h1>
+      <p class="muted">Help for Eye &amp; Posture Wellness reminders.</p>
+
+      <h2>Contact</h2>
+      <p>
+        For support, privacy, or safety questions, email
+        <a href="mailto:support@yashasg.dev">support@yashasg.dev</a>.
+      </p>
+
+      <h2>Frequently asked questions</h2>
+      <h3>Does kshana collect my data?</h3>
+      <p>
+        No. kshana stores settings locally on your device and does not use accounts,
+        ads, tracking, third-party analytics SDKs, or a custom backend.
+      </p>
+
+      <h3>Why are reminders not appearing?</h3>
+      <p>
+        Check that reminders are enabled in kshana, notification permission is allowed
+        in iOS Settings, and Snooze is not active.
+      </p>
+
+      <h3>What is True Interrupt Mode?</h3>
+      <p>
+        True Interrupt Mode is a planned Screen Time shielding feature. It will remain
+        unavailable until Apple approves the required Family Controls entitlement.
+      </p>
+
+      <h2>Links</h2>
+      <p><a href="index.html">Marketing page</a> · <a href="privacy.html">Privacy Policy</a></p>
+    </section>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
Fixes #609

## Summary
- Add branded static marketing, support, and privacy pages under docs/.
- Update App Store listing support/marketing/privacy URLs away from the raw source repository.
- Update the submission tracker to reflect the staged public URL work and remaining App Store Connect/GitHub Pages activation steps.

## Validation
- Parsed docs/index.html, docs/support.html, and docs/privacy.html with Python HTMLParser
- git diff --check
- ./scripts/build.sh build
- ./scripts/build.sh test

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>