### PR TITLE
Disclose Focus and CarPlay privacy access

### DIFF
--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorNotificationFallbackTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorNotificationFallbackTests.swift
@@ -444,14 +444,12 @@ final class AppCoordinatorNotificationFallbackTests: XCTestCase {
         await coordinator.refreshAuthStatus()
 
         tracker.simulateThresholdReached(for: .eyes)
-        await awaitCondition { overlay.showCallCount >= 1 }
+        await awaitCondition { overlay.onDismissCalls.count >= 1 }
         await awaitCondition { scheduleContinuation != nil }
         overlay.simulateDismiss()
+        let dismissalMonitorTask = coordinator.deviceActivityMonitorTask
         scheduleContinuation?.resume()
-        await awaitCondition(timeout: 3.0) {
-            deviceActivityMonitor.cancelCallCount >= 1 &&
-            ipcStore.events.contains { $0.kind == .notificationFallbackSuppressed }
-        }
+        _ = await dismissalMonitorTask?.result
 
         XCTAssertEqual(deviceActivityMonitor.scheduleCallCount, 1)
         XCTAssertEqual(deviceActivityMonitor.cancelCallCount, 1)

--- a/Tests/EyePostureReminderTests/Services/DeviceActivityMonitorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/DeviceActivityMonitorTests.swift
@@ -361,6 +361,7 @@ final class DeviceActivityMonitorTests: XCTestCase {
         defer { coordinator.stopFallbackTimers() }
 
         mockTracker.simulateThresholdReached(for: .posture)
+        await awaitCondition { mockOverlay.showCallCount >= 1 }
         mockOverlay.simulateDismiss()
         await awaitCondition(timeout: 2.0) {
             mockMonitor.operationLog == ["schedule", "cancel"] &&

--- a/docs/APP_STORE_LISTING.md
+++ b/docs/APP_STORE_LISTING.md
@@ -99,7 +99,7 @@ Download kshana on the App Store and start building healthier break habits today
 ### kshana — Privacy Policy
 
 **Effective date:** 2026-04-24  
-**Last updated:** 2026-04-26
+**Last updated:** 2026-05-05
 
 #### What we collect
 
@@ -110,14 +110,14 @@ The app uses Apple's built-in diagnostics and analytics tools, including **Metri
 #### How the app works
 
 - All your settings (reminder intervals, break durations, preferences) are stored locally on your device using iOS UserDefaults.
-- Motion activity and Focus status are accessed transiently in memory to pause reminders — they are never stored or transmitted.
+- Motion activity, Focus status, and CarPlay/audio-route status are accessed transiently in memory to pause reminders — they are never stored or transmitted.
 - Current builds use local reminder alerts as the primary reminder mechanism. True Interrupt Mode (app-level shielding) is not available in v0.2.0 and will arrive in a future update when Apple's entitlement approval is complete.
 - The app uses Apple's `os.Logger` framework for on-device diagnostic logging. These logs remain on your device. In release builds, values that could be sensitive are marked private/redacted. If you choose to share diagnostics with Apple or a TestFlight developer, some diagnostic logs may be included according to Apple's diagnostic-sharing settings.
 - No third-party SDKs or frameworks are used — the app is built exclusively with Apple's native iOS libraries (SwiftUI, UIKit, UserNotifications, MetricKit).
 
 #### Permissions
 
-The app requests **notification permission** to deliver reminder alerts when in the background. It requests **motion activity permission** to detect driving and pause reminders. No other permissions are requested beyond what is declared in the app's Info.plist.
+The app requests **notification permission** to deliver reminder alerts when in the background, **motion activity permission** to detect driving and pause reminders, and **Focus Status permission** to pause reminders during active Focus modes. It also reads the current audio output route to detect CarPlay so reminders can pause while you are driving; it does not record audio, access microphone input, store route history, or transmit route status. No other permissions are requested beyond what is declared in the app's Info.plist.
 
 #### Data sharing
 

--- a/docs/PRIVACY_NUTRITION_LABELS.md
+++ b/docs/PRIVACY_NUTRITION_LABELS.md
@@ -130,7 +130,8 @@ These data types are accessed or stored locally for App Functionality and are no
 |---|---|---|
 | App preferences / settings | `UserDefaults` | Stored locally in app sandbox. Never transmitted. |
 | Motion activity state | `CMMotionActivityManager` | Transient, in-memory only. Used to pause reminders while driving. Never stored or sent. |
-| Focus status | `INFocusStatusCenter` | Transient, in-memory only. Used to pause reminders during Focus modes. Never stored or sent. |
+| Focus status | `INFocusStatusCenter` | User-authorized and transient, in-memory only. Used to pause reminders during Focus modes. Never stored or sent. |
+| CarPlay / audio-route status | `AVAudioSession.currentRoute` | Transient, in-memory only. Used to detect CarPlay and pause reminders while driving. The app does not record audio, access microphone input, store route history, or transmit route status. |
 | Screen Time / Device activity data (if authorized) | `FamilyControls` / `DeviceActivity` (pending approval) | User-authorized data is used locally for interval scheduling and selected-app shielding. Current builds keep backup alerts active while entitlement-gated shielding is pending Apple approval (case ID 102881605113). |
 | App Group IPC metadata | `UserDefaults(suiteName:)` | Local-only enabled/disabled intent, aggregate app/category selection counts, shield-session timestamps, last access-request timestamp, and capped shield/fallback/watchdog event log. Used so the main app and Screen Time extensions coordinate without a backend. Never transmitted by kshana. |
 | Diagnostic logs | `os.Logger` | On-device only in release builds. Sensitive values redacted with `.private`. |
@@ -230,6 +231,7 @@ If a future release transmits Screen Time, Device Activity, selected-app metadat
 | App Group IPC metadata | ❌ Not Collected | — | — | — |
 | Motion activity | ❌ Not Collected | — | — | — |
 | Focus status | ❌ Not Collected | — | — | — |
+| CarPlay / audio-route status | ❌ Not Collected | — | — | — |
 | Screen Time (if approved*) | ❌ Not Collected | — | — | — |
 | os.Logger logs | ❌ Not Collected | — | — | — |
 | MetricKit crash data | ✅ Collected | Not Linked | Not Tracking | App Functionality |

--- a/docs/legal/PRIVACY.md
+++ b/docs/legal/PRIVACY.md
@@ -1,14 +1,14 @@
 # Privacy Policy
 
 **App:** kshana  
-**Last Updated:** April 26, 2026  
+**Last Updated:** May 5, 2026
 **Publisher:** Yashasg
 
 ---
 
 ## Overview
 
-Your privacy matters. kshana is designed to be privacy-preserving: your app settings stay on your device, motion and Focus information are used only transiently for reminder pause logic, and the App does not use advertising, tracking, user accounts, or third-party analytics SDKs.
+Your privacy matters. kshana is designed to be privacy-preserving: your app settings stay on your device, motion, Focus, and CarPlay/audio-route information are used only transiently for reminder pause logic, and the App does not use advertising, tracking, user accounts, or third-party analytics SDKs.
 
 The App does use Apple's built-in diagnostics and analytics tools, including MetricKit and App Store Connect analytics, to understand aggregate app performance, reliability, crashes, hangs, launch times, memory use, and similar technical metrics. These reports are processed through Apple's systems and are provided to the developer in aggregated or diagnostic form. They are not used to identify you, track you across apps or websites, build advertising profiles, or sell data.
 
@@ -37,7 +37,8 @@ This data exists solely to remember your preferences and coordinate local remind
 The App also accesses the following device data **in memory only** — this data is never stored or transmitted by the App:
 
 - **Motion activity data** — the App reads your device's motion activity state (via `CMMotionActivityManager`) to detect when you are driving, so that reminders are automatically paused. This data is read in memory for the sole purpose of pause logic and is discarded immediately; it is never written to disk, sent to any server, or associated with your identity.
-- **Focus mode status** — the App reads your device's Focus mode state (e.g., Do Not Disturb, Work, Personal) to pause reminders during active Focus sessions. This information is read in memory and is never stored or transmitted by the App.
+- **Focus mode status** — the App requests Focus Status authorization and reads your device's Focus mode state (e.g., Do Not Disturb, Work, Personal) to pause reminders during active Focus sessions. This information is read in memory and is never stored or transmitted by the App.
+- **CarPlay / audio-route status** — the App reads the current `AVAudioSession` output route to detect whether CarPlay is connected, so reminders can pause while you are driving. The App checks only the route/port status needed for pause logic; it does not record audio, access microphone content, inspect media content, store route history, or transmit this information.
 - **Device activity and screen time data (if authorized)** — If you authorize kshana to access Screen Time information via the FamilyControls framework, the App reads aggregate data about your total continuous screen-on time and any user-authorized app/category selections you have configured. This data is used locally to schedule and deliver wellness breaks at your configured intervals. When Screen Time features are configured, kshana stores the local coordination metadata listed above, but it does not transmit Screen Time data or coordination metadata to external servers or share it with third parties. **As of April 2026, Screen Time integration is pending Apple approval (case ID 102881605113) and is not yet available to users.**
 
 The App uses Apple's built-in diagnostics and analytics systems:
@@ -54,7 +55,7 @@ To be explicit about what does **not** happen:
 - **No personal information** — we do not collect your name, email address, phone number, date of birth, or other directly identifying information
 - **No health or biometric data** — we do not collect eye strain data, posture measurements, or any health-related metrics; physical activity (motion) data is accessed transiently in memory to pause reminders while driving and is never stored or transmitted by the App
 - **No location data** — we do not access your GPS or location services
-- **No camera or microphone access** — the App does not request access to camera or microphone
+- **No camera or microphone access** — the App does not request access to camera or microphone. CarPlay detection uses audio-route status only, not audio recording or microphone input
 - **No device identifiers for tracking** — we do not collect the advertising identifier (IDFA) or use persistent identifiers to track you across apps or websites
 - **No user accounts** — the App does not require registration, login, or account creation
 - **No third-party advertising or analytics SDKs** — there are no Firebase, Mixpanel, advertising SDK, data broker, or third-party data collection libraries in this App
@@ -140,7 +141,7 @@ If you are a parent or guardian and believe your child has somehow provided pers
 
 Because the App stores only local preferences and operational coordination metadata on your device, the primary security protection is your device's own security (passcode, Face ID, Touch ID). We encourage you to keep your device secure and up to date.
 
-The App does not transmit local preferences, motion activity data, or Focus status to a developer server. Apple-native diagnostics and analytics are processed through Apple's systems and are subject to Apple's security and privacy practices.
+The App does not transmit local preferences, motion activity data, Focus status, or CarPlay/audio-route status to a developer server. Apple-native diagnostics and analytics are processed through Apple's systems and are subject to Apple's security and privacy practices.
 
 ---
 

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -67,12 +67,12 @@
   <main>
     <article aria-labelledby="title">
       <h1 id="title">kshana Privacy Policy</h1>
-      <p class="muted">Last updated: April 26, 2026</p>
+      <p class="muted">Last updated: May 5, 2026</p>
       <p>
         kshana is designed to be privacy-preserving. Your app settings stay on your
-        device, motion and Focus information are used only transiently for reminder
-        pause logic, and the app does not use advertising, tracking, user accounts,
-        third-party analytics SDKs, or a custom analytics backend.
+        device, motion, Focus, and CarPlay/audio-route information are used only
+        transiently for reminder pause logic, and the app does not use advertising,
+        tracking, user accounts, third-party analytics SDKs, or a custom analytics backend.
       </p>
 
       <h2>What kshana stores locally</h2>
@@ -85,9 +85,11 @@
 
       <h2>What kshana accesses in memory</h2>
       <p>
-        kshana may read motion activity and Focus status transiently to pause reminders
-        while you are driving, using CarPlay, or in Focus. This information is not sent
-        to a developer server.
+        kshana may read motion activity, user-authorized Focus status, and current
+        audio output route status transiently to pause reminders while you are driving,
+        using CarPlay, or in Focus. CarPlay detection uses route/port status only:
+        kshana does not record audio, access microphone input, store route history,
+        or send this information to a developer server.
       </p>
 
       <h2>Diagnostics</h2>


### PR DESCRIPTION
Fixes #608

## Summary
- Update the legal/privacy policy, hosted privacy page, App Store listing privacy copy, and privacy nutrition guide to disclose Focus Status authorization.
- Document transient CarPlay/audio-route status access and explicitly state the app does not record audio, use microphone input, store route history, or transmit route status.

## Validation
- Parsed docs/privacy.html with Python HTMLParser
- git diff --check
- ./scripts/build.sh build
- ./scripts/build.sh test

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>