### PR TITLE
Point Settings to hosted privacy page

### DIFF
--- a/EyePostureReminder/Resources/Localizable.xcstrings
+++ b/EyePostureReminder/Resources/Localizable.xcstrings
@@ -1345,6 +1345,28 @@
         }
       }
     },
+    "settings.legal.privacyHosted": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Privacy Policy on the Web"
+          }
+        }
+      }
+    },
+    "settings.legal.privacyHosted.hint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opens the public privacy policy in your browser"
+          }
+        }
+      }
+    },
     "legal.dismissButton": {
       "extractionState": "manual",
       "localizations": {

--- a/EyePostureReminder/Utilities/LegalLinks.swift
+++ b/EyePostureReminder/Utilities/LegalLinks.swift
@@ -2,6 +2,6 @@ import Foundation
 
 enum LegalLinks {
     static let hostedPrivacyPolicyURL = URL(
-        string: "https://github.com/yashasg/fantastic-octo-fortnight/blob/main/docs/legal/PRIVACY.md"
+        string: "https://yashasg.github.io/fantastic-octo-fortnight/privacy.html"
     )
 }

--- a/EyePostureReminder/Views/SettingsView.swift
+++ b/EyePostureReminder/Views/SettingsView.swift
@@ -269,11 +269,11 @@ struct SettingsView: View {
                     guard let hostedPrivacyPolicyURL = LegalLinks.hostedPrivacyPolicyURL else { return }
                     openURL(hostedPrivacyPolicyURL)
                 } label: {
-                    Text("Hosted Privacy Policy (Web)")
+                    Text("settings.legal.privacyHosted", bundle: .module)
                 }
                 .font(AppFont.body)
                 .foregroundStyle(AppColor.primaryRest)
-                .accessibilityHint(Text("Opens the public privacy policy URL in your browser."))
+                .accessibilityHint(Text("settings.legal.privacyHosted.hint", bundle: .module))
                 .accessibilityIdentifier("settings.legal.privacyHosted")
                 .listRowBackground(AppColor.surface)
                 .listRowSeparatorTint(AppColor.separatorSoft)

--- a/Tests/EyePostureReminderTests/Utilities/LegalLinksTests.swift
+++ b/Tests/EyePostureReminderTests/Utilities/LegalLinksTests.swift
@@ -2,11 +2,11 @@
 import XCTest
 
 final class LegalLinksTests: XCTestCase {
-    func test_hostedPrivacyPolicyURL_pointsToPublicRepoPolicy() throws {
+    func test_hostedPrivacyPolicyURL_pointsToPublicHostedPolicy() throws {
         let url = try XCTUnwrap(LegalLinks.hostedPrivacyPolicyURL)
 
         XCTAssertEqual(url.scheme, "https")
-        XCTAssertEqual(url.host, "github.com")
-        XCTAssertEqual(url.path, "/yashasg/fantastic-octo-fortnight/blob/main/docs/legal/PRIVACY.md")
+        XCTAssertEqual(url.host, "yashasg.github.io")
+        XCTAssertEqual(url.path, "/fantastic-octo-fortnight/privacy.html")
     }
 }

--- a/Tests/EyePostureReminderTests/Views/SettingsAccessibilityTests.swift
+++ b/Tests/EyePostureReminderTests/Views/SettingsAccessibilityTests.swift
@@ -34,6 +34,21 @@ final class SettingsAccessibilityTests: XCTestCase {
         )
     }
 
+    func test_hostedPrivacyLink_usesLocalizedUserFacingCopy() throws {
+        let source = try String(contentsOf: settingsViewSourceURL, encoding: .utf8)
+        let hostedPrivacySource = try XCTUnwrap(
+            source.slice(
+                from: "guard let hostedPrivacyPolicyURL = LegalLinks.hostedPrivacyPolicyURL",
+                to: ".accessibilityIdentifier(\"settings.legal.privacyHosted\")"
+            ),
+            "Hosted privacy policy row should be present in SettingsView.swift."
+        )
+
+        XCTAssertTrue(hostedPrivacySource.contains("Text(\"settings.legal.privacyHosted\", bundle: .module)"))
+        XCTAssertTrue(hostedPrivacySource.contains("Text(\"settings.legal.privacyHosted.hint\", bundle: .module)"))
+        XCTAssertFalse(hostedPrivacySource.contains("Hosted Privacy Policy (Web)"))
+    }
+
     private var settingsViewSourceURL: URL {
         repositoryRoot
             .appendingPathComponent("EyePostureReminder")

--- a/docs/app-store-submission-status.md
+++ b/docs/app-store-submission-status.md
@@ -13,7 +13,7 @@ Legend: ✅ Done · ⚠️ In progress / partial · ❌ Not started · 🔒 Bloc
 
 | # | Item | Status | Blocker / Notes |
 |---|------|--------|-----------------|
-| L1 | Privacy Policy hosted at public HTTPS URL | ❌ Not started | Blocks submission — #185 |
+| L1 | Privacy Policy hosted at public HTTPS URL | ⚠️ Partial | Branded page exists at `docs/privacy.html` and in-app Settings points to the GitHub Pages URL; final Pages reachability and ASC metadata verification remain — #185 |
 | L2 | EULA supplement with Apple's 7 required clauses added to TERMS.md | ⚠️ Partial | `docs/legal/TERMS.md` exists; Apple clause review pending — #196 |
 | L3 | Privacy Nutrition Labels filled in App Store Connect | ❌ Not started | Answers documented in `docs/PRIVACY_NUTRITION_LABELS.md`; not yet entered in ASC |
 | L4 | Health/wellness disclaimers included in app description | ✅ Done | "Not medical advice" copy finalized in `APP_STORE_LISTING.md` Section 3 |
@@ -85,13 +85,13 @@ Legend: ✅ Done · ⚠️ In progress / partial · ❌ Not started · 🔒 Bloc
 
 | Category | Done | Partial | Not Started | Blocked |
 |----------|------|---------|-------------|---------|
-| Legal & Privacy | 1 | 1 | 2 | 2 (ext) |
+| Legal & Privacy | 1 | 2 | 1 | 2 (ext) |
 | Entitlements | 2 | 1 | 0 | 0 |
 | ASC Configuration | 2 | 2 | 5 | 0 |
 | Assets | 1 | 0 | 2 | 0 |
 | Name Search | 3 | 0 | 1 | 0 |
 | Final Checks | 0 | 2 | 2 | 0 |
-| **Total (27 items)** | **9** | **6** | **12** | **2 ext** |
+| **Total (27 items)** | **9** | **7** | **11** | **2 ext** |
 
 **Overall:** ~33% complete. Two external blockers (#185, #196) gate the ASC configuration phase. Name search is complete. Entitlements are buildable today.
 


### PR DESCRIPTION
## Summary
- point the shared hosted privacy policy URL at the branded GitHub Pages privacy page
- localize the Settings hosted privacy link label and accessibility hint
- update regression coverage and the submission tracker for the repo-side privacy URL work

Advances #185. The remaining #185 acceptance is external/manual: enable or verify GitHub Pages reachability and enter the final URL in App Store Connect.

## Validation
- jq empty EyePostureReminder/Resources/Localizable.xcstrings
- xcodebuild test -scheme EyePostureReminder -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:'EyePostureReminderTests/LegalLinksTests' -only-testing:'EyePostureReminderTests/SettingsAccessibilityTests' CODE_SIGNING_ALLOWED=NO
- ./scripts/build.sh build
- ./scripts/build.sh test

## Note
- The target GitHub Pages URL currently returns 404 until Pages is enabled/published for the repository.