### PR TITLE
Route legal contact through support page

### DIFF
--- a/docs/app-store-submission-status.md
+++ b/docs/app-store-submission-status.md
@@ -39,7 +39,7 @@ Legend: ✅ Done · ⚠️ In progress / partial · ❌ Not started · 🔒 Bloc
 | A1 | Bundle ID finalized: `com.yashasg.eyeposturereminder` | ✅ Done | Set in `project.yml` |
 | A2 | App Group `group.com.yashasg.kshana` registered and associated with all three bundle IDs | ❌ Not started | Requires Apple Developer Portal — screen time extensions depend on this |
 | A3 | SKU set: `kshana` | ❌ Not started | Must be set in ASC before first build upload |
-| A4 | Support URL set: `https://yashasg.github.io/fantastic-octo-fortnight/support.html` | ⚠️ Partial | Branded static page exists in `docs/support.html`; enter final hosted URL in App Store Connect |
+| A4 | Support URL set: `https://yashasg.github.io/fantastic-octo-fortnight/support.html` | ⚠️ Partial | Branded static page exists in `docs/support.html` and routes contact requests through the public GitHub issue tracker; enter final hosted URL in App Store Connect |
 | A5 | Marketing URL set: `https://yashasg.github.io/fantastic-octo-fortnight/` | ⚠️ Partial | Branded static page exists in `docs/index.html`; enter final hosted URL in App Store Connect |
 | A6 | App name, subtitle, keywords, description finalized | ✅ Done | See `APP_STORE_LISTING.md` Sections 1–4 |
 | A7 | Age rating questionnaire completed | ❌ Not started | All answers "No" / "None" → 4+ |

--- a/docs/legal/PRIVACY.md
+++ b/docs/legal/PRIVACY.md
@@ -133,7 +133,7 @@ The App is distributed through the Apple App Store. Apple may collect certain da
 
 kshana does not knowingly collect personal information from children under the age of 13 (or the applicable age of digital consent in your jurisdiction). The App does not require accounts, direct identifiers, advertising identifiers, or third-party tracking.
 
-If you are a parent or guardian and believe your child has somehow provided personal information through this App, contact us through the [kshana support page](https://yashasg.github.io/fantastic-octo-fortnight/support.html). We will promptly address the concern.
+If you are a parent or guardian and believe your child has somehow provided personal information through this App, contact us through the [kshana GitHub issue tracker](https://github.com/yashasg/fantastic-octo-fortnight/issues). We will promptly address the concern.
 
 ---
 
@@ -165,13 +165,13 @@ California residents have the following rights under the California Consumer Pri
 
 **How to submit a CCPA request:**
 
-Use the [kshana support page](https://yashasg.github.io/fantastic-octo-fortnight/support.html) and include "CCPA Request" in your request. Do not include sensitive personal, medical, or financial information in public support requests. Because the App does not maintain user accounts or a developer-hosted user database, we will explain what local data the App stores and how to remove it from your device.
+Use the [kshana GitHub issue tracker](https://github.com/yashasg/fantastic-octo-fortnight/issues) and include "CCPA Request" in your request. Do not include sensitive personal, medical, or financial information in public support requests. Because the App does not maintain user accounts or a developer-hosted user database, we will explain what local data the App stores and how to remove it from your device.
 
 **Business address for service of legal notices:**
 
 Yashasg designates the following contact method for service of consumer-rights notices:
 
-**Support page:** https://yashasg.github.io/fantastic-octo-fortnight/support.html
+**Support channel:** https://github.com/yashasg/fantastic-octo-fortnight/issues
 
 ---
 
@@ -186,7 +186,7 @@ Yashasg may update this Privacy Policy from time to time. When changes are made,
 If you have questions or concerns about this Privacy Policy, contact:
 
 **Yashasg**  
-**Support page:** https://yashasg.github.io/fantastic-octo-fortnight/support.html
+**Support channel:** https://github.com/yashasg/fantastic-octo-fortnight/issues
 
 ---
 

--- a/docs/legal/PRIVACY.md
+++ b/docs/legal/PRIVACY.md
@@ -133,7 +133,7 @@ The App is distributed through the Apple App Store. Apple may collect certain da
 
 kshana does not knowingly collect personal information from children under the age of 13 (or the applicable age of digital consent in your jurisdiction). The App does not require accounts, direct identifiers, advertising identifiers, or third-party tracking.
 
-If you are a parent or guardian and believe your child has somehow provided personal information through this App, please contact us at support@yashasg.dev. We will promptly address the concern.
+If you are a parent or guardian and believe your child has somehow provided personal information through this App, contact us through the [kshana support page](https://yashasg.github.io/fantastic-octo-fortnight/support.html). We will promptly address the concern.
 
 ---
 
@@ -165,15 +165,13 @@ California residents have the following rights under the California Consumer Pri
 
 **How to submit a CCPA request:**
 
-Email: **support@yashasg.dev**
-
-Please include "CCPA Request" in the subject line, describe your request, and include sufficient information for us to verify your identity.
+Use the [kshana support page](https://yashasg.github.io/fantastic-octo-fortnight/support.html) and include "CCPA Request" in your request. Do not include sensitive personal, medical, or financial information in public support requests. Because the App does not maintain user accounts or a developer-hosted user database, we will explain what local data the App stores and how to remove it from your device.
 
 **Business address for service of legal notices:**
 
 Yashasg designates the following contact method for service of consumer-rights notices:
 
-**Email:** support@yashasg.dev
+**Support page:** https://yashasg.github.io/fantastic-octo-fortnight/support.html
 
 ---
 
@@ -188,7 +186,7 @@ Yashasg may update this Privacy Policy from time to time. When changes are made,
 If you have questions or concerns about this Privacy Policy, contact:
 
 **Yashasg**  
-**Email:** support@yashasg.dev
+**Support page:** https://yashasg.github.io/fantastic-octo-fortnight/support.html
 
 ---
 

--- a/docs/legal/TERMS.md
+++ b/docs/legal/TERMS.md
@@ -166,7 +166,7 @@ Yashasg may update these Terms at any time. When changes are made, the "Last Upd
 If you have questions about these Terms, contact:
 
 **Yashasg**  
-**Support page:** https://yashasg.github.io/fantastic-octo-fortnight/support.html
+**Support channel:** https://github.com/yashasg/fantastic-octo-fortnight/issues
 
 ---
 

--- a/docs/legal/TERMS.md
+++ b/docs/legal/TERMS.md
@@ -166,7 +166,7 @@ Yashasg may update these Terms at any time. When changes are made, the "Last Upd
 If you have questions about these Terms, contact:
 
 **Yashasg**  
-**Email:** support@yashasg.dev
+**Support page:** https://yashasg.github.io/fantastic-octo-fortnight/support.html
 
 ---
 

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -111,8 +111,8 @@
 
       <h2>Contact</h2>
       <p>
-        For privacy questions, use the
-        <a href="support.html">kshana support page</a>.
+        For privacy questions, open a request in the
+        <a href="https://github.com/yashasg/fantastic-octo-fortnight/issues">kshana GitHub issue tracker</a>.
       </p>
 
       <p><a href="support.html">Support</a> · <a href="index.html">Marketing page</a></p>

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -111,7 +111,8 @@
 
       <h2>Contact</h2>
       <p>
-        For privacy questions, email <a href="mailto:support@yashasg.dev">support@yashasg.dev</a>.
+        For privacy questions, use the
+        <a href="support.html">kshana support page</a>.
       </p>
 
       <p><a href="support.html">Support</a> · <a href="index.html">Marketing page</a></p>

--- a/docs/support.html
+++ b/docs/support.html
@@ -71,8 +71,9 @@
 
       <h2>Contact</h2>
       <p>
-        For support, privacy, or safety questions, email
-        <a href="mailto:support@yashasg.dev">support@yashasg.dev</a>.
+        For support, privacy, or safety questions, open a request in the
+        <a href="https://github.com/yashasg/fantastic-octo-fortnight/issues">kshana GitHub issue tracker</a>.
+        Do not include sensitive personal, medical, or financial information in public support requests.
       </p>
 
       <h2>Frequently asked questions</h2>


### PR DESCRIPTION
## Summary\n- replace non-routable support@yashasg.dev legal/contact references with the public support page\n- route support page contact requests through the GitHub issue tracker\n- update App Store submission tracker notes for the support URL contact path\n\n## Validation\n- ./scripts/build.sh build\n- ./scripts/build.sh test\n- confirmed docs no longer reference support@yashasg.dev