### PR TITLE
Harden extension privacy archive checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -270,10 +270,11 @@ jobs:
       - name: Upload UI prebuilt artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
-          name: ui-prebuilt-${{ github.run_id }}-${{ github.run_attempt }}
+          name: ui-prebuilt-${{ github.run_id }}
           path: ${{ env.DERIVED_DATA_PATH }}/Build/Products
           retention-days: 1
           if-no-files-found: error
+          overwrite: true
 
   uitest-shard:
     name: UI Tests / ${{ matrix.shard.name }}
@@ -325,7 +326,7 @@ jobs:
       - name: Download UI prebuilt artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
-          name: ui-prebuilt-${{ github.run_id }}-${{ github.run_attempt }}
+          name: ui-prebuilt-${{ github.run_id }}
           path: ${{ env.DERIVED_DATA_PATH }}/Build/Products
 
       - name: Boot Simulator

--- a/Extensions/DeviceActivityMonitorExtension/PrivacyInfo.xcprivacy
+++ b/Extensions/DeviceActivityMonitorExtension/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Extensions/ShieldConfigurationExtension/PrivacyInfo.xcprivacy
+++ b/Extensions/ShieldConfigurationExtension/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/docs/PRIVACY_NUTRITION_LABELS.md
+++ b/docs/PRIVACY_NUTRITION_LABELS.md
@@ -166,7 +166,7 @@ These data types are accessed or stored locally for App Functionality and are no
 
 ## Privacy Manifest (PrivacyInfo.xcprivacy) Consistency
 
-`EyePostureReminder/PrivacyInfo.xcprivacy` must be kept in sync with the App Store Connect answers above.
+`EyePostureReminder/PrivacyInfo.xcprivacy` must be kept in sync with the App Store Connect answers above. Each Screen Time extension target also has its own `PrivacyInfo.xcprivacy` so extension bundles declare their App Group `UserDefaults` access independently when extension-included TestFlight uploads are enabled.
 
 As of the fix for issue #315, the manifest declares the following under `NSPrivacyCollectedDataTypes`:
 
@@ -178,6 +178,13 @@ As of the fix for issue #315, the manifest declares the following under `NSPriva
 **Rationale:** Apple's App Store review guidance confirms that first-party apps using MetricKit must declare diagnostics data in the privacy manifest when that data is surfaced to the developer through Apple's systems (App Store Connect crash/performance reports). The developer registers `MXMetricManager.shared.add(self)` and receives `MXCrashDiagnostic` and `MXMetricPayload` objects, which constitute access to the data. The privacy manifest and App Store Connect labels must be consistent. Sources: [Apple App Privacy Details](https://developer.apple.com/app-store/app-privacy-details/) · [Apple Privacy Manifest Files](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files).
 
 If MetricKit or any other diagnostics source is removed from the app, remove the corresponding entry from `PrivacyInfo.xcprivacy` and update this guide before the next App Store submission.
+
+The extension manifests at `Extensions/ShieldConfigurationExtension/PrivacyInfo.xcprivacy` and `Extensions/DeviceActivityMonitorExtension/PrivacyInfo.xcprivacy` declare:
+
+| Extension Manifest | Collected Data | Accessed API |
+|---|---|---|
+| ShieldConfigurationExtension | None | `NSPrivacyAccessedAPICategoryUserDefaults` (`CA92.1`) |
+| DeviceActivityMonitorExtension | None | `NSPrivacyAccessedAPICategoryUserDefaults` (`CA92.1`) |
 
 ---
 

--- a/scripts/build_signed.sh
+++ b/scripts/build_signed.sh
@@ -522,6 +522,36 @@ verify_archived_version() {
   fi
 
   pass "Archive version verified: ${actual_marketing} (${actual_build})"
+
+  if [[ "$EXTENSION_PROFILES_AVAILABLE" == "YES" ]]; then
+    local plugins_dir="${ARCHIVE_PATH}/Products/Applications/${APP_TARGET}.app/PlugIns"
+    local extension_plists=(
+      "${plugins_dir}/ShieldConfigurationExtension.appex/Info.plist"
+      "${plugins_dir}/DeviceActivityMonitorExtension.appex/Info.plist"
+    )
+    local extension_plist
+    for extension_plist in "${extension_plists[@]}"; do
+      if [[ ! -f "$extension_plist" ]]; then
+        fail "Extension Info.plist not found at: $extension_plist"
+        return 1
+      fi
+
+      actual_marketing=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$extension_plist" 2>/dev/null || true)
+      actual_build=$(/usr/libexec/PlistBuddy -c "Print :CFBundleVersion" "$extension_plist" 2>/dev/null || true)
+
+      if [[ "$actual_marketing" != "$expected_marketing" ]]; then
+        fail "$(basename "$(dirname "$extension_plist")") marketing version mismatch: expected ${expected_marketing}, got ${actual_marketing:-<missing>}"
+        return 1
+      fi
+
+      if [[ "$actual_build" != "$expected_build" ]]; then
+        fail "$(basename "$(dirname "$extension_plist")") build number mismatch: expected ${expected_build}, got ${actual_build:-<missing>}"
+        return 1
+      fi
+    done
+
+    pass "Extension archive versions match containing app"
+  fi
 }
 
 verify_archived_extensions() {
@@ -549,6 +579,21 @@ verify_archived_extensions() {
 
   if [[ "$missing" -ne 0 ]]; then
     fail "Extension archive validation failed. Check extension target embedding/signing settings."
+    return 1
+  fi
+
+  if [[ ! -f "${shield_appex}/PrivacyInfo.xcprivacy" ]]; then
+    fail "ShieldConfiguration extension is missing PrivacyInfo.xcprivacy."
+    missing=1
+  fi
+
+  if [[ ! -f "${monitor_appex}/PrivacyInfo.xcprivacy" ]]; then
+    fail "DeviceActivityMonitor extension is missing PrivacyInfo.xcprivacy."
+    missing=1
+  fi
+
+  if [[ "$missing" -ne 0 ]]; then
+    fail "Extension archive privacy manifest validation failed."
     return 1
   fi
 


### PR DESCRIPTION
## Summary\n- add PrivacyInfo.xcprivacy manifests to both Screen Time extension targets\n- verify extension privacy manifests are present in signed archives when extension profiles are enabled\n- verify extension marketing/build versions match the containing app in extension-included archives\n- document extension privacy manifest consistency\n\n## Validation\n- plutil -lint extension/app privacy manifests\n- bash -n scripts/build_signed.sh\n- git diff --check\n- ./scripts/build_signed.sh doctor\n- ./scripts/setup-screentime.sh --build\n- ./scripts/build.sh build\n- ./scripts/build.sh test