### PR TITLE
Prepare App Store custom EULA text

### DIFF
--- a/docs/APP_STORE_LISTING.md
+++ b/docs/APP_STORE_LISTING.md
@@ -274,7 +274,7 @@ Follow this sequence to avoid mid-submission blockers. The two Legal & Privacy b
 2. **[WEEKS BEFORE]** Upload Custom EULA to App Store Connect (#196)
    - Verify `docs/legal/TERMS.md` includes Apple's 7 required clauses
    - Log into App Store Connect → My Apps → kshana → App Information
-   - Paste TERMS.md content into "License Agreement" field
+   - Paste `docs/legal/APP_STORE_CUSTOM_EULA.txt` into the "License Agreement" field
    - Save and verify it displays correctly
 
 3. **[1 WEEK BEFORE]** Run comprehensive pre-submission checks

--- a/docs/app-store-submission-status.md
+++ b/docs/app-store-submission-status.md
@@ -13,8 +13,8 @@ Legend: ✅ Done · ⚠️ In progress / partial · ❌ Not started · 🔒 Bloc
 
 | # | Item | Status | Blocker / Notes |
 |---|------|--------|-----------------|
-| L1 | Privacy Policy hosted at public HTTPS URL | ⚠️ Partial | Branded page exists at `docs/privacy.html` and in-app Settings points to the GitHub Pages URL; final Pages reachability and ASC metadata verification remain — #185 |
-| L2 | EULA supplement with Apple's 7 required clauses added to TERMS.md | ⚠️ Partial | `docs/legal/TERMS.md` exists; Apple clause review pending — #196 |
+| L1 | Privacy Policy hosted at public HTTPS URL | ⚠️ Partial | GitHub Pages URL is live and in-app Settings points to it; App Store Connect metadata verification remains — #185 |
+| L2 | EULA supplement with Apple's 7 required clauses added to TERMS.md | ⚠️ Partial | `docs/legal/TERMS.md` exists and ASC-ready plain text is staged at `docs/legal/APP_STORE_CUSTOM_EULA.txt`; upload/verify in ASC remains — #196 |
 | L3 | Privacy Nutrition Labels filled in App Store Connect | ❌ Not started | Answers documented in `docs/PRIVACY_NUTRITION_LABELS.md`; not yet entered in ASC |
 | L4 | Health/wellness disclaimers included in app description | ✅ Done | "Not medical advice" copy finalized in `APP_STORE_LISTING.md` Section 3 |
 
@@ -99,8 +99,8 @@ Legend: ✅ Done · ⚠️ In progress / partial · ❌ Not started · 🔒 Bloc
 
 ## Recommended Next Actions
 
-1. **Close #185 follow-through** — privacy URL content is staged at `docs/privacy.html` for `https://yashasg.github.io/fantastic-octo-fortnight/privacy.html`; remaining manual step is confirming GitHub Pages is enabled and adding this URL in App Store Connect metadata.
-2. **Unblock #196** — upload `docs/legal/TERMS.md` content to App Store Connect License Agreement field.
+1. **Close #185 follow-through** — privacy URL is live at `https://yashasg.github.io/fantastic-octo-fortnight/privacy.html`; remaining manual step is adding this URL in App Store Connect metadata.
+2. **Unblock #196** — upload `docs/legal/APP_STORE_CUSTOM_EULA.txt` content to App Store Connect License Agreement field.
 3. **Capture screenshots** — 5 screens on iPhone 15 Pro + Pro Max.
 4. **Export app icon** — 1024×1024 PNG, no alpha.
 5. **Register App Group** in Apple Developer Portal for all three bundle IDs.

--- a/docs/legal/APP_STORE_CUSTOM_EULA.txt
+++ b/docs/legal/APP_STORE_CUSTOM_EULA.txt
@@ -1,0 +1,143 @@
+Terms and Conditions
+
+App: kshana
+Last Updated: April 26, 2026
+Publisher: Yashasg
+
+1. Acceptance of Terms
+
+By downloading, installing, or using kshana ("the App"), you agree to be bound by these Terms and Conditions ("Terms"). If you do not agree, do not use the App.
+
+These Terms apply to all users of the App. Yashasg reserves the right to update these Terms at any time. Continued use of the App after changes are posted constitutes acceptance of the revised Terms.
+
+2. Description of the App
+
+kshana is a personal wellness reminder tool for iOS. It monitors screen-on time and notifies you at configurable intervals to:
+
+- Take short eye breaks using the 20-20-20 guideline (look at something 20 feet away for 20 seconds every 20 minutes)
+- Check and correct your posture
+
+The App also reads device motion activity data via CMMotionActivityManager in memory, solely to automatically pause reminders while you are driving. This data is never stored or transmitted. See the Privacy Policy for full details.
+
+If approved and released in a future version, the App may use Apple's Screen Time, FamilyControls, DeviceActivity, ManagedSettings, and ManagedSettingsUI APIs to place user-configured wellness break screens over apps or categories you choose. These features are intended only for your own personal device and self-care routine. kshana is not parental control software, employee monitoring software, or a tool for supervising another person's device usage.
+
+The App is a reminder tool only. It does not monitor, measure, diagnose, or treat any health condition. It does not track your physical state, assess your actual eye health, evaluate your posture biomechanics, read app content, or report device activity to another person. It simply delivers reminders at intervals you configure.
+
+3. Health Disclaimer - Not Medical Advice
+
+This is the most important section. Read it carefully.
+
+kshana is not a medical device, medical application, or health management tool. The App does not:
+
+- Provide medical advice of any kind
+- Diagnose, treat, cure, or prevent any eye condition, musculoskeletal condition, or any other medical condition
+- Replace or substitute for the advice of a qualified physician, optometrist, ophthalmologist, physiotherapist, chiropractor, or other licensed healthcare professional
+- Guarantee any improvement in eye comfort, posture, or any other health outcome
+
+The 20-20-20 rule is a general wellness guideline commonly cited by eye health organizations. It is not a medical prescription. Its effectiveness varies by individual, and it is not a treatment for diagnosed conditions such as computer vision syndrome, dry eye disease, myopia, or any other eye disorder.
+
+If you have any existing medical condition - including but not limited to eye disease, vision problems, chronic pain, spine or neck disorders, or any condition affecting your posture or musculoskeletal health - consult a qualified healthcare professional before relying on any reminder-based wellness routine.
+
+Nothing in this App or these Terms constitutes a doctor-patient relationship or any other professional-client relationship between you and Yashasg.
+
+USE THIS APP AT YOUR OWN RISK. Any wellness or health-related decisions you make based on reminders from this App are solely your own responsibility.
+
+4. Limitation of Liability
+
+To the fullest extent permitted by applicable law:
+
+Yashasg shall not be liable for any direct, indirect, incidental, special, consequential, exemplary, or punitive damages - including but not limited to loss of health, physical injury, vision deterioration, musculoskeletal injury, loss of data, loss of profits, or any other loss or damage - arising out of or in connection with:
+
+- Your use of, or inability to use, the App
+- Any reliance on reminders, suggestions, or content delivered by the App
+- Any health outcome, positive or negative, associated with using the App
+- Technical failures, missed reminders, or inaccurate screen-on-time tracking
+
+This limitation of liability applies regardless of the legal theory (contract, tort, negligence, strict liability, or otherwise) and even if Yashasg has been advised of the possibility of such damages.
+
+In jurisdictions that do not allow the exclusion of certain warranties or limitation of liability, Yashasg's liability is limited to the maximum extent permitted by law.
+
+5. Warranty Disclaimer
+
+The App is provided "as is" and "as available" without warranty of any kind, express or implied, including but not limited to:
+
+- Warranties of merchantability
+- Fitness for a particular purpose
+- Non-infringement
+- Accuracy or reliability of any reminders or timing functions
+- Uninterrupted or error-free operation
+
+Yashasg does not warrant that the App will function correctly on all devices, iOS versions, or in all usage conditions. Timer accuracy, overlay behavior, and notification delivery depend on iOS system conditions beyond Yashasg's control.
+
+6. User Responsibilities
+
+By using the App, you agree that:
+
+- You are solely responsible for your health and wellness decisions
+- You will consult a healthcare professional if you have any medical concerns
+- You will not use the App as a substitute for professional medical care
+- You will configure reminder intervals that are appropriate for your individual situation
+- You are responsible for ensuring the App is compatible with your device and iOS version
+- You will not use the App in any manner that violates applicable law
+- You will use any Screen Time interruption features only on devices you own or control for your own self-care, and not to monitor, supervise, or restrict another person's device usage
+
+7. Intellectual Property
+
+All content, design, code, branding, and assets within kshana are the intellectual property of Yashasg and are protected by applicable copyright, trademark, and intellectual property laws.
+
+You are granted a limited, non-exclusive, non-transferable, revocable license to use the App on your personal iOS device for personal, non-commercial purposes, subject to these Terms and Apple's App Store Terms of Service.
+
+You may not copy, modify, distribute, sell, reverse-engineer, or create derivative works from the App or any part of it.
+
+8. Third-Party Services
+
+kshana does not integrate with third-party analytics, advertising, or data platforms, and it does not transmit data to a developer-operated backend. The App stores settings and operational coordination metadata locally on your device. Apple may process App Store downloads, TestFlight feedback, diagnostics, crash reports, and analytics through Apple's own systems.
+
+The App is distributed through the Apple App Store. Apple's own terms of service govern the download and installation process. Yashasg is not responsible for Apple's policies or services.
+
+9. Apple App Store Terms
+
+If you downloaded the App from the Apple App Store, the following additional terms apply:
+
+1. Acknowledgement. These Terms are concluded between you and Yashasg only, and not with Apple. Yashasg, not Apple, is solely responsible for the App and its content.
+2. Scope of License. The license granted to you for the App is a limited, non-transferable license to use the App on any Apple-branded products that you own or control, and as permitted by the Apple Media Services Terms and Conditions and applicable Usage Rules.
+3. Maintenance and Support. Yashasg is solely responsible for providing any maintenance and support services for the App, as specified in these Terms or as required under applicable law. Apple has no obligation to furnish any maintenance or support services for the App.
+4. Warranty. To the extent any warranty is not effectively disclaimed under these Terms or applicable law, Yashasg is solely responsible for any product warranties. If the App fails to conform to any applicable warranty, you may notify Apple, and Apple will refund the purchase price for the App, if any. To the maximum extent permitted by applicable law, Apple has no other warranty obligation for the App.
+5. Product Claims. Yashasg, not Apple, is responsible for addressing any claims by you or any third party relating to the App or your possession or use of the App, including product liability claims, claims that the App fails to conform to legal or regulatory requirements, and claims arising under consumer protection, privacy, or similar laws.
+6. Intellectual Property Claims. If a third party claims that the App or your possession and use of the App infringes that third party's intellectual property rights, Yashasg, not Apple, is solely responsible for the investigation, defense, settlement, and discharge of that intellectual property infringement claim.
+7. Third-Party Beneficiary. Apple and Apple's subsidiaries are third-party beneficiaries of these Terms. Upon your acceptance of these Terms, Apple has the right, and is deemed to have accepted the right, to enforce these Terms against you as a third-party beneficiary.
+
+9a. Pricing, Refunds, and Cancellation
+
+kshana is a free app. It is available at no charge on the Apple App Store and has no in-app purchases, subscriptions, or premium tiers at this time.
+
+- No purchase required. You can download, install, and use all current app features at no cost.
+- No subscriptions. There are no recurring charges or subscription plans associated with this App.
+- No in-app purchases. The App does not offer paid upgrades, unlockable content, or consumable items.
+- Refunds. Because the App is free, there is no purchase price to refund. If Apple ever charges for a future version or in-app purchase, refund requests for those transactions are handled directly by Apple through the App Store. Yashasg does not process payments and cannot issue refunds for App Store transactions. To request a refund from Apple, visit https://reportaproblem.apple.com.
+- Cancellation. You may stop using the App at any time by deleting it from your device. No cancellation process is required.
+
+If paid features or subscriptions are introduced in a future version, this section will be updated to reflect the applicable pricing, cancellation, and refund terms before those features are released.
+
+10. Termination
+
+You may stop using the App at any time by deleting it from your device. Yashasg reserves the right to discontinue the App or modify its functionality at any time without notice.
+
+Sections 3 (Health Disclaimer), 4 (Limitation of Liability), 5 (Warranty Disclaimer), and 7 (Intellectual Property) survive termination.
+
+11. Governing Law
+
+These Terms are governed by the laws of California, United States, without regard to conflict of law principles. Any disputes arising from these Terms or your use of the App shall be resolved in the courts of California, United States.
+
+12. Changes to These Terms
+
+Yashasg may update these Terms at any time. When changes are made, the "Last Updated" date at the top of this document will be revised. It is your responsibility to review these Terms periodically. Continued use of the App after changes are posted constitutes your acceptance of the updated Terms.
+
+13. Contact
+
+If you have questions about these Terms, contact:
+
+Yashasg
+Support channel: https://github.com/yashasg/fantastic-octo-fortnight/issues
+
+These Terms and Conditions were last updated on April 26, 2026.


### PR DESCRIPTION
## Summary\n- add an App Store Connect-ready plain-text custom EULA artifact\n- update App Store listing workflow to paste the prepared EULA text\n- update release tracker now that the privacy URL is live and the EULA upload artifact exists\n\n## Validation\n- git diff --check\n- EULA clause smoke checks\n- ./scripts/build.sh build\n- ./scripts/build.sh test