### PR TITLE
Raise UI test execution timeout allowance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,6 +390,7 @@ jobs:
           UITEST_SHARD_TIMEOUT_SECONDS: "1800"
           UITEST_HEARTBEAT_SECONDS: "60"
           UITEST_XCODEBUILD_TEST_ITERATIONS: "2"
+          UITEST_XCODEBUILD_MAX_TEST_SECONDS: "600"
         run: |
           XCTESTRUN_PATH=$(find "${{ env.DERIVED_DATA_PATH }}/Build/Products" \
             -name "EyePostureReminderUITests_*.xctestrun" -maxdepth 1 -print | sort | tail -1)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -680,7 +680,9 @@ cmd_uitest() {
   # session remains warm. The default is one deterministic pass; set
   # UITEST_XCODEBUILD_TEST_ITERATIONS > 1 to opt into XCTest-level retry.
   local test_iterations="${UITEST_XCODEBUILD_TEST_ITERATIONS:-1}"
-  local max_test_execution_time="${UITEST_XCODEBUILD_MAX_TEST_SECONDS:-180}"
+  # Keep xcodebuild's per-test allowance below the shard watchdog, but high
+  # enough that slow CI shards fail only on real hangs instead of false timeouts.
+  local max_test_execution_time="${UITEST_XCODEBUILD_MAX_TEST_SECONDS:-600}"
   if ! [[ "$test_iterations" =~ ^[1-9][0-9]*$ ]]; then
     fail "UITEST_XCODEBUILD_TEST_ITERATIONS must be a positive integer (got: $test_iterations)"
     exit 1


### PR DESCRIPTION
## Summary
- raise the default UI test xcodebuild max execution allowance from 180s to 600s
- set the same allowance explicitly in CI UI shard env
- keep XCTest retry iterations within the warm simulator session

Fixes #637

## Validation
- bash -n scripts/build.sh
- git diff --check
- ./scripts/build.sh build
- ./scripts/build.sh test
- UITEST_XCODEBUILD_MAX_TEST_SECONDS=600 UITEST_XCODEBUILD_TEST_ITERATIONS=2 ./scripts/build.sh uitest --only-testing EyePostureReminderUITests/OverlayTests