### PR TITLE
Validate main app privacy manifest in signed archives (#639)

### DIFF
--- a/scripts/build_signed.sh
+++ b/scripts/build_signed.sh
@@ -567,6 +567,19 @@ verify_archived_version() {
   fi
 }
 
+verify_archived_main_app_privacy_manifest() {
+  local privacy_manifest="${ARCHIVE_PATH}/Products/Applications/${APP_TARGET}.app/PrivacyInfo.xcprivacy"
+
+  if [[ ! -f "$privacy_manifest" ]]; then
+    fail "Main app archive is missing PrivacyInfo.xcprivacy at: ${privacy_manifest}"
+    fail "App Store privacy manifest acceptance requires the archived .app to bundle PrivacyInfo.xcprivacy."
+    fail "Confirm EyePostureReminder/PrivacyInfo.xcprivacy is copied into the bundle by the archive build."
+    return 1
+  fi
+
+  pass "Main app archive includes PrivacyInfo.xcprivacy"
+}
+
 verify_archived_extensions() {
   [[ "$EXTENSION_PROFILES_AVAILABLE" == "YES" ]] || return 0
 
@@ -1086,6 +1099,7 @@ cmd_archive() {
 
   inject_build_number
   verify_archived_version
+  verify_archived_main_app_privacy_manifest
   verify_archived_extensions
   pass "Archive created: $ARCHIVE_PATH"
 }


### PR DESCRIPTION
## Summary

Adds a pre-export check that fails the signed archive build when the main app bundle is missing `PrivacyInfo.xcprivacy`. App Store privacy manifest acceptance depends on the archived `.app` containing the manifest, so release tooling now fails fast before export/upload.

## Changes

- `scripts/build_signed.sh`:
  - New helper `verify_archived_main_app_privacy_manifest` mirrors the existing `verify_archived_extensions` pattern.
  - Called from `cmd_archive` after `verify_archived_version`, so it runs for `archive`, `export`, and `upload` paths.
  - Emits an actionable failure message pointing to the source manifest at `EyePostureReminder/PrivacyInfo.xcprivacy` when missing.

## Validation

- `bash -n scripts/build_signed.sh` — syntax OK
- `./scripts/build_signed.sh doctor` — passes (existing flow unchanged)
- Local function test (mocked archive): missing manifest returns 1 with actionable `fail` output; present manifest returns 0 with `pass`.

## Risk

Low. Pure additive shell function. No behavior change unless the archive is genuinely missing the main app privacy manifest, in which case the script now exits 1 instead of silently uploading a non-compliant artifact.

Closes #639