### PR TITLE
Fix import ordering per Google Swift Style §Import Statements (#647)

### DIFF
--- a/Tests/EyePostureReminderTests/Integration/IntegrationTests.swift
+++ b/Tests/EyePostureReminderTests/Integration/IntegrationTests.swift
@@ -1,6 +1,7 @@
 import Combine
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 // MARK: - SettingsStore ↔ SettingsViewModel Integration
 

--- a/Tests/EyePostureReminderTests/Integration/MultiServicePipelineIntegrationTests.swift
+++ b/Tests/EyePostureReminderTests/Integration/MultiServicePipelineIntegrationTests.swift
@@ -1,6 +1,7 @@
 import Combine
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 // MARK: - Multi-service Pipeline Integration
 

--- a/Tests/EyePostureReminderTests/Mocks/MockAppGroupIPCRecorder.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockAppGroupIPCRecorder.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import Foundation
+
+@testable import EyePostureReminder
 @testable import ScreenTimeExtensionShared
 
 final class MockAppGroupIPCRecorder: AppGroupIPCProviding {

--- a/Tests/EyePostureReminderTests/Mocks/MockAppStateProvider.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockAppStateProvider.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import UIKit
+
+@testable import EyePostureReminder
 
 /// In-memory stub of `AppStateProviding` for unit tests.
 ///

--- a/Tests/EyePostureReminderTests/Mocks/MockDateProvider.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockDateProvider.swift
@@ -1,7 +1,8 @@
 // MockDateProvider.swift
 
-@testable import EyePostureReminder
 import Foundation
+
+@testable import EyePostureReminder
 
 /// Test double for `DateProviding`.
 ///

--- a/Tests/EyePostureReminderTests/Mocks/MockDetectors.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockDetectors.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import Foundation
+
+@testable import EyePostureReminder
 
 /// Mock implementations of the detector protocols used by `PauseConditionManager`.
 ///

--- a/Tests/EyePostureReminderTests/Mocks/MockDeviceActivityMonitorProviding.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockDeviceActivityMonitorProviding.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import Foundation
+
+@testable import EyePostureReminder
 
 /// Mock implementation of `DeviceActivityMonitorProviding` for unit tests.
 ///

--- a/Tests/EyePostureReminderTests/Mocks/MockMediaControlling.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockMediaControlling.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import Foundation
+
+@testable import EyePostureReminder
 
 /// Mock implementation of `MediaControlling` for unit tests.
 ///

--- a/Tests/EyePostureReminderTests/Mocks/MockMediaControllingTests.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockMediaControllingTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for `MockMediaControlling` — verifies the mock itself behaves correctly
 /// so that tests relying on it have a trustworthy foundation.

--- a/Tests/EyePostureReminderTests/Mocks/MockNotificationCenter.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockNotificationCenter.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import Foundation
 import UserNotifications
+
+@testable import EyePostureReminder
 
 /// Mock implementation of `NotificationScheduling` for unit tests.
 ///

--- a/Tests/EyePostureReminderTests/Mocks/MockOverlayPresenting.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockOverlayPresenting.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import Foundation
+
+@testable import EyePostureReminder
 
 /// Mock implementation of `OverlayPresenting` for unit tests.
 ///

--- a/Tests/EyePostureReminderTests/Mocks/MockPauseConditionProvider.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockPauseConditionProvider.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import Foundation
+
+@testable import EyePostureReminder
 
 /// Mock implementation of `PauseConditionProviding` for use in `AppCoordinatorTests`
 /// and any test that needs to control pause-condition state without real Focus mode,

--- a/Tests/EyePostureReminderTests/Mocks/MockRecordingTests.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockRecordingTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for `ServiceLifecycle` protocol conformance and the mock detectors
 /// used in PauseConditionManager tests. Validates mock recording fidelity.

--- a/Tests/EyePostureReminderTests/Mocks/MockReminderScheduler.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockReminderScheduler.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import Foundation
+
+@testable import EyePostureReminder
 
 /// Mock implementation of `ReminderScheduling` for SettingsViewModel unit tests.
 ///

--- a/Tests/EyePostureReminderTests/Mocks/MockScreenTimeAuthorizationProviding.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockScreenTimeAuthorizationProviding.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import Foundation
+
+@testable import EyePostureReminder
 
 /// Mock implementation of `ScreenTimeAuthorizationProviding` for unit tests.
 ///

--- a/Tests/EyePostureReminderTests/Mocks/MockScreenTimeShieldProviding.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockScreenTimeShieldProviding.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import Foundation
+
+@testable import EyePostureReminder
 
 /// Mock implementation of `ScreenTimeShieldProviding` for use in
 /// `AppCoordinator` integration tests (M3.3+).

--- a/Tests/EyePostureReminderTests/Mocks/MockScreenTimeTracker.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockScreenTimeTracker.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import Foundation
+
+@testable import EyePostureReminder
 
 /// Mock implementation of `ScreenTimeTracking` for use in `AppCoordinatorTests`
 /// and any test that needs to control or observe screen-time tracking behaviour

--- a/Tests/EyePostureReminderTests/Mocks/MockSettingsPersisting.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockSettingsPersisting.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import Foundation
+
+@testable import EyePostureReminder
 
 /// In-memory implementation of `SettingsPersisting` for unit tests.
 ///

--- a/Tests/EyePostureReminderTests/Mocks/TestBundleHelper.swift
+++ b/Tests/EyePostureReminderTests/Mocks/TestBundleHelper.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import Foundation
 import UIKit
+
+@testable import EyePostureReminder
 
 /// Resolves the EyePostureReminder module's resource bundle for use in tests.
 ///

--- a/Tests/EyePostureReminderTests/Models/AppConfigTests.swift
+++ b/Tests/EyePostureReminderTests/Models/AppConfigTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 // Tests for `AppConfig` — the data-driven default configuration loaded from `defaults.json`.
 //

--- a/Tests/EyePostureReminderTests/Models/OnboardingTests.swift
+++ b/Tests/EyePostureReminderTests/Models/OnboardingTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for the `hasSeenOnboarding` UserDefaults flag that gates
 /// the first-launch vs. returning-user flow in `ContentView`.

--- a/Tests/EyePostureReminderTests/Models/PauseConditionSourceTests.swift
+++ b/Tests/EyePostureReminderTests/Models/PauseConditionSourceTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for `PauseConditionSource` and `LegalDocument` enums.
 final class PauseConditionSourceTests: XCTestCase {

--- a/Tests/EyePostureReminderTests/Models/ReminderSettingsTests.swift
+++ b/Tests/EyePostureReminderTests/Models/ReminderSettingsTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for `ReminderSettings` — the immutable value type carrying schedule parameters.
 final class ReminderSettingsTests: XCTestCase {

--- a/Tests/EyePostureReminderTests/Models/ReminderTypeExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/Models/ReminderTypeExtendedTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Extended tests for `ReminderType` — computed display properties, notification
 /// identity, and the failable `init(categoryIdentifier:)`.

--- a/Tests/EyePostureReminderTests/Models/ReminderTypeTests.swift
+++ b/Tests/EyePostureReminderTests/Models/ReminderTypeTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 final class ReminderTypeTests: XCTestCase {
 

--- a/Tests/EyePostureReminderTests/Models/SettingsStoreConfigTests.swift
+++ b/Tests/EyePostureReminderTests/Models/SettingsStoreConfigTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Integration tests for `SettingsStore` + `AppConfig` (data-driven defaults.json system).
 ///

--- a/Tests/EyePostureReminderTests/Models/SettingsStorePhase2Tests.swift
+++ b/Tests/EyePostureReminderTests/Models/SettingsStorePhase2Tests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Phase 2 unit tests for `SettingsStore` covering haptics and snooze-count persistence.
 @MainActor

--- a/Tests/EyePostureReminderTests/Models/SettingsStoreTests.swift
+++ b/Tests/EyePostureReminderTests/Models/SettingsStoreTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 @MainActor
 // swiftlint:disable:next type_body_length

--- a/Tests/EyePostureReminderTests/RegressionTests.swift
+++ b/Tests/EyePostureReminderTests/RegressionTests.swift
@@ -13,10 +13,11 @@
 // Bug #118: ScreenTimeTracker double-resign — second willResignActive must cancel first reset Task (one reset, not two)
 // Bug #117: OverlayManager queue-on-no-scene — showOverlay with no UIWindowScene must queue, not drop
 
-@testable import EyePostureReminder
 import SwiftUI
 import UIKit
 import XCTest
+
+@testable import EyePostureReminder
 
 // MARK: ─── Bug 1: SettingsView Done Button ───────────────────────────────────
 

--- a/Tests/EyePostureReminderTests/Services/AnalyticsEventTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AnalyticsEventTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import ScreenTimeExtensionShared
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for `AnalyticsEvent` enum — validates associated values, exhaustiveness,
 /// and the `DismissMethod` nested enum.

--- a/Tests/EyePostureReminderTests/Services/AnalyticsLoggerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AnalyticsLoggerTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import ScreenTimeExtensionShared
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for `AnalyticsLogger` and `AnalyticsEvent`.
 ///

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorCancelReminderTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorCancelReminderTests.swift
@@ -1,6 +1,7 @@
+import XCTest
+
 @testable import EyePostureReminder
 @testable import ScreenTimeExtensionShared
-import XCTest
 
 /// Tests for `cancelReminder(for:)` DeviceActivity cancellation behaviour introduced in issue #291.
 ///

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorNotificationFallbackTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorNotificationFallbackTests.swift
@@ -1,6 +1,7 @@
+import XCTest
+
 @testable import EyePostureReminder
 @testable import ScreenTimeExtensionShared
-import XCTest
 
 @MainActor
 final class AppCoordinatorNotificationFallbackTests: XCTestCase {

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -1,6 +1,7 @@
+import XCTest
+
 @testable import EyePostureReminder
 @testable import ScreenTimeExtensionShared
-import XCTest
 
 // swiftlint:disable file_length
 /// Unit tests for `AppCoordinator`.

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorThresholdGuardTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorThresholdGuardTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Regression tests for issue #407:
 /// `AppCoordinator.onThresholdReached` must guard on `settings.isEnabled(for:)`

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestLaunchContextTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestLaunchContextTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 @MainActor
 final class AppCoordinatorUITestLaunchContextTests: XCTestCase {

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestModeResolverTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestModeResolverTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 @MainActor
 final class AppCoordinatorUITestModeResolverTests: XCTestCase {

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestStatusStoreTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorUITestStatusStoreTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 @MainActor
 final class AppCoordinatorUITestStatusStoreTests: XCTestCase {

--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorWatchdogHeartbeatTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorWatchdogHeartbeatTests.swift
@@ -1,6 +1,7 @@
+import XCTest
+
 @testable import EyePostureReminder
 @testable import ScreenTimeExtensionShared
-import XCTest
 
 @MainActor
 final class AppCoordinatorWatchdogHeartbeatTests: XCTestCase {

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import UIKit
 import XCTest
+
+@testable import EyePostureReminder
 
 private final class MockUserNotificationCenter: UserNotificationCenterDelegating {
     weak var delegate: UNUserNotificationCenterDelegate?

--- a/Tests/EyePostureReminderTests/Services/AppGroupIPCStoreTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppGroupIPCStoreTests.swift
@@ -1,7 +1,8 @@
-@testable import EyePostureReminder
 import Foundation
-@testable import ScreenTimeExtensionShared
 import XCTest
+
+@testable import EyePostureReminder
+@testable import ScreenTimeExtensionShared
 
 @MainActor
 // swiftlint:disable:next type_body_length

--- a/Tests/EyePostureReminderTests/Services/AudioInterruptionManagerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AudioInterruptionManagerTests.swift
@@ -1,6 +1,7 @@
 import AVFoundation
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 final class AudioInterruptionManagerTests: XCTestCase {
     private final class MockAudioSession: AudioSessionControlling {

--- a/Tests/EyePostureReminderTests/Services/DeviceActivityMonitorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/DeviceActivityMonitorTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Unit tests for the DeviceActivity monitoring service layer added in #205.
 ///

--- a/Tests/EyePostureReminderTests/Services/DeviceActivityMonitoringValidationTests.swift
+++ b/Tests/EyePostureReminderTests/Services/DeviceActivityMonitoringValidationTests.swift
@@ -1,6 +1,7 @@
+import XCTest
+
 @testable import EyePostureReminder
 @testable import ScreenTimeExtensionShared
-import XCTest
 
 /// Pre-implementation validation tests for M3.5 "DeviceActivity Monitoring Service" (#205).
 ///

--- a/Tests/EyePostureReminderTests/Services/DrivingDetectionExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/Services/DrivingDetectionExtendedTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 // MARK: - DrivingDetectionExtendedTests
 //

--- a/Tests/EyePostureReminderTests/Services/FocusModeExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/Services/FocusModeExtendedTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 // MARK: - FocusModeExtendedTests
 //

--- a/Tests/EyePostureReminderTests/Services/LiveCarPlayDetectorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/LiveCarPlayDetectorTests.swift
@@ -1,6 +1,7 @@
 import AVFoundation
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 @MainActor
 final class LiveCarPlayDetectorTests: XCTestCase {

--- a/Tests/EyePostureReminderTests/Services/LiveDrivingActivityDetectorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/LiveDrivingActivityDetectorTests.swift
@@ -1,6 +1,7 @@
 import CoreMotion
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 // MARK: - LiveDrivingActivityDetectorTests
 //

--- a/Tests/EyePostureReminderTests/Services/LiveFocusStatusDetectorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/LiveFocusStatusDetectorTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 // MARK: - LiveFocusStatusDetectorTests
 

--- a/Tests/EyePostureReminderTests/Services/MetricKitSubscriberTests.swift
+++ b/Tests/EyePostureReminderTests/Services/MetricKitSubscriberTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import MetricKit
 import XCTest
+
+@testable import EyePostureReminder
 
 private final class MockMetricKitManager: MetricKitManaging {
     private(set) var addCallCount = 0

--- a/Tests/EyePostureReminderTests/Services/NoopServicesTests.swift
+++ b/Tests/EyePostureReminderTests/Services/NoopServicesTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for `NoopScreenTimeTracker` and `NoopPauseConditionManager`.
 ///

--- a/Tests/EyePostureReminderTests/Services/OverlayManagerExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/Services/OverlayManagerExtendedTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import UIKit
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Extended tests for `OverlayManager` — clearQueue(for:) per-type filtering,
 /// additional queue management, and MockOverlayPresenting edge cases.

--- a/Tests/EyePostureReminderTests/Services/OverlayManagerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/OverlayManagerTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Unit tests for `OverlayManager`.
 ///

--- a/Tests/EyePostureReminderTests/Services/PauseConditionManagerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/PauseConditionManagerTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 // MARK: - PauseConditionManagerTests
 

--- a/Tests/EyePostureReminderTests/Services/ReminderSchedulerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/ReminderSchedulerTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import UserNotifications
 import XCTest
+
+@testable import EyePostureReminder
 
 @MainActor
 // swiftlint:disable:next type_body_length

--- a/Tests/EyePostureReminderTests/Services/ScreenTimeAuthorizationTests.swift
+++ b/Tests/EyePostureReminderTests/Services/ScreenTimeAuthorizationTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Unit tests for the Screen Time authorization abstraction added in #204.
 ///

--- a/Tests/EyePostureReminderTests/Services/ScreenTimeShieldTests.swift
+++ b/Tests/EyePostureReminderTests/Services/ScreenTimeShieldTests.swift
@@ -1,6 +1,7 @@
+import XCTest
+
 @testable import EyePostureReminder
 @testable import ScreenTimeExtensionShared
-import XCTest
 
 /// Unit tests for the Screen Time shield abstraction layer.
 ///

--- a/Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/ScreenTimeTrackerTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import UIKit
 import XCTest
+
+@testable import EyePostureReminder
 
 // swiftlint:disable type_body_length
 

--- a/Tests/EyePostureReminderTests/Services/SelectedAppsStateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/SelectedAppsStateTests.swift
@@ -1,6 +1,7 @@
+import XCTest
+
 @testable import EyePostureReminder
 @testable import ScreenTimeExtensionShared
-import XCTest
 
 /// Unit tests for `SelectedAppsState` and shared App Group selection metadata.
 ///

--- a/Tests/EyePostureReminderTests/Services/ServiceCoverageBoostTests.swift
+++ b/Tests/EyePostureReminderTests/Services/ServiceCoverageBoostTests.swift
@@ -1,5 +1,7 @@
-@testable import EyePostureReminder
+import MetricKit
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Additional service and model tests targeting coverage gaps in partially-covered
 /// production files: PauseConditionManager, OverlayManager, MetricKitSubscriber,
@@ -658,5 +660,3 @@ final class ServiceCoverageBoostTests2: XCTestCase {
         XCTAssertEqual(mock.cancelAllCallCount, 1)
     }
 }
-
-import MetricKit

--- a/Tests/EyePostureReminderTests/Services/ServiceLifecycleTests.swift
+++ b/Tests/EyePostureReminderTests/Services/ServiceLifecycleTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for `ServiceLifecycle` protocol conformance.
 ///

--- a/Tests/EyePostureReminderTests/Services/ShieldConfigurationCopyTests.swift
+++ b/Tests/EyePostureReminderTests/Services/ShieldConfigurationCopyTests.swift
@@ -1,5 +1,6 @@
-@testable import ScreenTimeExtensionShared
 import XCTest
+
+@testable import ScreenTimeExtensionShared
 
 final class ShieldConfigurationCopyTests: XCTestCase {
 

--- a/Tests/EyePostureReminderTests/Services/WatchdogHeartbeatTests.swift
+++ b/Tests/EyePostureReminderTests/Services/WatchdogHeartbeatTests.swift
@@ -1,6 +1,7 @@
+import XCTest
+
 @testable import EyePostureReminder
 @testable import ScreenTimeExtensionShared
-import XCTest
 
 final class WatchdogHeartbeatTests: XCTestCase {
     func test_event_usesWatchdogKindAndStableDetail() {

--- a/Tests/EyePostureReminderTests/Utilities/AccessibilityAnnouncementTests.swift
+++ b/Tests/EyePostureReminderTests/Utilities/AccessibilityAnnouncementTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 // Tests for AccessibilityNotificationPosting announcement support (#287).
 //

--- a/Tests/EyePostureReminderTests/Utilities/AppStorageKeysTests.swift
+++ b/Tests/EyePostureReminderTests/Utilities/AppStorageKeysTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for `AppStorageKey` — centralised UserDefaults key constants.
 ///

--- a/Tests/EyePostureReminderTests/Utilities/LegalLinksTests.swift
+++ b/Tests/EyePostureReminderTests/Utilities/LegalLinksTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 final class LegalLinksTests: XCTestCase {
     func test_hostedPrivacyPolicyURL_pointsToPublicHostedPolicy() throws {

--- a/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelExtendedTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Additional coverage for `SettingsViewModel` — edge cases not yet covered
 /// by the existing test files: SnoozeOption computed properties, preset option

--- a/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelFormatterTests.swift
+++ b/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelFormatterTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for `SettingsViewModel` static formatting helpers.
 /// These are pure functions with branching logic used for user-visible picker labels.

--- a/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelPhase2Tests.swift
+++ b/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelPhase2Tests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Phase 2 unit tests for `SettingsViewModel`.
 ///

--- a/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelTests.swift
+++ b/Tests/EyePostureReminderTests/ViewModels/SettingsViewModelTests.swift
@@ -1,6 +1,7 @@
 import Combine
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for `SettingsViewModel`.
 ///

--- a/Tests/EyePostureReminderTests/Views/ColorTokenTests.swift
+++ b/Tests/EyePostureReminderTests/Views/ColorTokenTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import UIKit
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests that all color tokens in the `Colors.xcassets` Asset Catalog resolve correctly.
 ///

--- a/Tests/EyePostureReminderTests/Views/ComponentsExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/Views/ComponentsExtendedTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import SwiftUI
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for `SecondaryButtonStyle` and the `withMotionSafe` helper in
 /// `Components.swift`. Covers the remaining untested components.

--- a/Tests/EyePostureReminderTests/Views/ComponentsTests.swift
+++ b/Tests/EyePostureReminderTests/Views/ComponentsTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import SwiftUI
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for `Components.swift` — reusable Restful Grove SwiftUI components.
 ///

--- a/Tests/EyePostureReminderTests/Views/CoverageBoostTests.swift
+++ b/Tests/EyePostureReminderTests/Views/CoverageBoostTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Additional tests targeting coverage gaps in files that are partially testable
 /// without a host app. Pure SwiftUI `body` properties remain out of scope for

--- a/Tests/EyePostureReminderTests/Views/DarkModeTests.swift
+++ b/Tests/EyePostureReminderTests/Views/DarkModeTests.swift
@@ -1,7 +1,8 @@
-@testable import EyePostureReminder
 import SwiftUI
 import UIKit
 import XCTest
+
+@testable import EyePostureReminder
 
 // Expanded dark mode tests for the DesignSystem.
 //

--- a/Tests/EyePostureReminderTests/Views/DesignSystemExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/Views/DesignSystemExtendedTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import SwiftUI
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Additional coverage for design system tokens — fills remaining gaps in
 /// AppOpacity, AppLayout edge values, AppAnimation boundary checks, and

--- a/Tests/EyePostureReminderTests/Views/DesignSystemTests.swift
+++ b/Tests/EyePostureReminderTests/Views/DesignSystemTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import SwiftUI
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Regression tests for `DesignSystem.swift` — the single source of truth for
 /// all visual tokens (colors, fonts, spacing, animation, layout).

--- a/Tests/EyePostureReminderTests/Views/HomeViewLaunchContextResolverTests.swift
+++ b/Tests/EyePostureReminderTests/Views/HomeViewLaunchContextResolverTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import UserNotifications
 import XCTest
+
+@testable import EyePostureReminder
 
 #if DEBUG
 @MainActor

--- a/Tests/EyePostureReminderTests/Views/OnboardingViewTests.swift
+++ b/Tests/EyePostureReminderTests/Views/OnboardingViewTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import SwiftUI
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for onboarding views — `OnboardingWelcomeView`, `OnboardingPermissionView`,
 /// and `OnboardingSetupView`.

--- a/Tests/EyePostureReminderTests/Views/OverlayAccessibilityTests.swift
+++ b/Tests/EyePostureReminderTests/Views/OverlayAccessibilityTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Accessibility-focused tests for `OverlayView` — covers #310 (VoiceOver
 /// initial focus order) and related body evaluation after the sort-priority fix.

--- a/Tests/EyePostureReminderTests/Views/OverlayGestureTests.swift
+++ b/Tests/EyePostureReminderTests/Views/OverlayGestureTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 
 final class OverlayGestureTests: XCTestCase {
 

--- a/Tests/EyePostureReminderTests/Views/PreviewTests.swift
+++ b/Tests/EyePostureReminderTests/Views/PreviewTests.swift
@@ -1,7 +1,8 @@
-@testable import EyePostureReminder
 import SwiftUI
 import UIKit
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Smoke tests that instantiate every view the way its `#Preview` block does,
 /// then force body evaluation via `UIHostingController.loadViewIfNeeded()`.

--- a/Tests/EyePostureReminderTests/Views/SettingsAccessibilityTests.swift
+++ b/Tests/EyePostureReminderTests/Views/SettingsAccessibilityTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import Foundation
 import XCTest
+
+@testable import EyePostureReminder
 
 @MainActor
 final class SettingsAccessibilityTests: XCTestCase {

--- a/Tests/EyePostureReminderTests/Views/StringCatalogTests.swift
+++ b/Tests/EyePostureReminderTests/Views/StringCatalogTests.swift
@@ -1,5 +1,6 @@
-@testable import EyePostureReminder
 import XCTest
+
+@testable import EyePostureReminder
 // swiftlint:disable file_length
 
 // Tests for the String Catalog (`Localizable.xcstrings`) shipped by Linus.

--- a/Tests/EyePostureReminderTests/Views/TrueInterruptViewCoverageTests.swift
+++ b/Tests/EyePostureReminderTests/Views/TrueInterruptViewCoverageTests.swift
@@ -1,7 +1,8 @@
-@testable import EyePostureReminder
 import SwiftUI
 import UIKit
 import XCTest
+
+@testable import EyePostureReminder
 
 // swiftlint:disable type_body_length
 @MainActor

--- a/Tests/EyePostureReminderTests/Views/ViewBodyCoverageTests.swift
+++ b/Tests/EyePostureReminderTests/Views/ViewBodyCoverageTests.swift
@@ -1,7 +1,8 @@
-@testable import EyePostureReminder
 import SwiftUI
 import UIKit
 import XCTest
+
+@testable import EyePostureReminder
 
 // swiftlint:disable type_body_length
 /// Comprehensive view-body coverage tests.

--- a/Tests/EyePostureReminderTests/Views/YinYangEyeViewExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/Views/YinYangEyeViewExtendedTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import SwiftUI
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Extended tests for `YinYangEyeView` — covers RightHalf shape path geometry
 /// and animation state properties.

--- a/Tests/EyePostureReminderTests/Views/YinYangEyeViewTests.swift
+++ b/Tests/EyePostureReminderTests/Views/YinYangEyeViewTests.swift
@@ -1,6 +1,7 @@
-@testable import EyePostureReminder
 import SwiftUI
 import XCTest
+
+@testable import EyePostureReminder
 
 /// Tests for `YinYangEyeView` — the yin-yang status icon used in
 /// HomeView and OnboardingView.


### PR DESCRIPTION
## Summary

Per [docs/google_swift_coding_style.md §Import Statements](docs/google_swift_coding_style.md), imports must be:

1. Module/submodule imports (sorted lexicographically, case-insensitive)
2. Individual declaration imports (`import func ...`)
3. `@testable` imports (sorted lexicographically)

…with exactly one blank line between groups.

Audit found 88 files where `@testable import …` preceded a regular module import (e.g. `@testable import EyePostureReminder` then `import XCTest`). This PR reorders them so regular module imports come first, followed by a blank line, then `@testable` imports.

## Notable additional fix

`Tests/EyePostureReminderTests/Services/ServiceCoverageBoostTests.swift` had an orphan `import MetricKit` at the *bottom* of the file (after the closing brace of the test class). Moved it to the top of the file with the other imports — §Import Statements requires imports be the first non-comment tokens in a source file.

## Validation

- `./scripts/build.sh build` — succeeded
- `./scripts/build.sh test` — **2075 tests, 0 failures, 0 unexpected** (~99 s)
- Re-ran the audit: zero remaining ordering violations across `EyePostureReminder/`, `Tests/`, `UITests/`, `Extensions/`, `ScreenTimeExtensions/`.

## Risk

Very low. Pure reordering of import statements; no behavioural or API changes. The orphan `import MetricKit` move is the only semantic change and the test suite (which exercises that file extensively) still passes.

## Files skipped from auto-fix (already compliant)

- `EyePostureReminder/Services/OverlayManager.swift` — already case-insensitively sorted (`os`, `SwiftUI`, `UIKit`); leaves the inline doc comment between imports untouched.

Closes #647