### PR TITLE
Tighten access control on type-private symbols (#652)

### DIFF
--- a/EyePostureReminder/Services/AppCoordinator.swift
+++ b/EyePostureReminder/Services/AppCoordinator.swift
@@ -654,8 +654,8 @@ final class AppCoordinator: ObservableObject {
 
 }
 
-private extension AppCoordinator {
-    static func resolveSettings(
+extension AppCoordinator {
+    private static func resolveSettings(
         _ settings: SettingsStore?,
         makeSettings: (() -> SettingsStore)?
     ) -> SettingsStore {
@@ -668,7 +668,7 @@ private extension AppCoordinator {
         return SettingsStore()
     }
 
-    static func resolveScheduler(
+    private static func resolveScheduler(
         _ scheduler: ReminderScheduling?,
         makeScheduler: (() -> ReminderScheduling)?
     ) -> ReminderScheduling {
@@ -681,7 +681,7 @@ private extension AppCoordinator {
         return ReminderScheduler()
     }
 
-    static func resolveOverlayManager(
+    private static func resolveOverlayManager(
         _ overlayManager: OverlayPresenting?,
         makeOverlayManager: (() -> OverlayPresenting)?
     ) -> OverlayPresenting {
@@ -694,7 +694,7 @@ private extension AppCoordinator {
         return OverlayManager()
     }
 
-    static func resolveScreenTimeAuthorization(
+    private static func resolveScreenTimeAuthorization(
         _ screenTimeAuthorization: ScreenTimeAuthorizationProviding?,
         uiTestStatusStore: UserDefaults,
         processEnvironment: [String: String],
@@ -718,13 +718,13 @@ private extension AppCoordinator {
         return screenTimeAuthorization
     }
 
-    static func resolveDeviceActivityMonitor(
+    private static func resolveDeviceActivityMonitor(
         _ deviceActivityMonitor: DeviceActivityMonitorProviding?
     ) -> DeviceActivityMonitorProviding {
         deviceActivityMonitor ?? DeviceActivityMonitorNoop()
     }
 
-    static func resolveScreenTimeTracker(
+    private static func resolveScreenTimeTracker(
         _ screenTimeTracker: ScreenTimeTracking?,
         uiTestMode: Bool,
         makeScreenTimeTracker: (() -> ScreenTimeTracking)?
@@ -741,7 +741,7 @@ private extension AppCoordinator {
         return screenTimeTracker
     }
 
-    static func resolvePauseConditionManager(
+    private static func resolvePauseConditionManager(
         _ pauseConditionProvider: PauseConditionProviding?,
         settings: SettingsStore,
         uiTestMode: Bool,

--- a/EyePostureReminder/Views/AppCategoryPickerView.swift
+++ b/EyePostureReminder/Views/AppCategoryPickerView.swift
@@ -136,8 +136,17 @@ struct AppCategoryPickerView: View {
         }
     }
 
-    var primaryButtonHintKey: LocalizedStringKey {
-        switch authorizationStatus {
+    private var primaryButtonHintKey: LocalizedStringKey {
+        Self.primaryButtonHintKey(for: authorizationStatus)
+    }
+
+    /// Maps `authorizationStatus` to the localized accessibility hint key for the primary CTA.
+    ///
+    /// Exposed at type-level so unit tests can verify the mapping without instantiating the view.
+    static func primaryButtonHintKey(
+        for status: ScreenTimeAuthorizationStatus
+    ) -> LocalizedStringKey {
+        switch status {
         case .unavailable:   return "appCategoryPicker.button.pendingApproval.hint"
         case .notDetermined: return "appCategoryPicker.button.enableAccess.hint"
         case .denied:        return "appCategoryPicker.button.openSettings.hint"

--- a/Tests/EyePostureReminderTests/Views/TrueInterruptViewCoverageTests.swift
+++ b/Tests/EyePostureReminderTests/Views/TrueInterruptViewCoverageTests.swift
@@ -272,53 +272,29 @@ final class TrueInterruptViewCoverageTests: XCTestCase {
     // MARK: - Accessibility Hint Body Tests
 
     func test_appCategoryPickerView_unavailable_bodyContainsPrimaryButtonHint() {
-        let view = AppCategoryPickerView(
-            appsState: makeSelectedAppsState(),
-            authorizationStatus: .unavailable,
-            onRequestAuthorization: {},
-            onDone: {}
-        )
         XCTAssertEqual(
-            view.primaryButtonHintKey,
+            AppCategoryPickerView.primaryButtonHintKey(for: .unavailable),
             "appCategoryPicker.button.pendingApproval.hint",
             "Unavailable state must use pending-approval hint key")
     }
 
     func test_appCategoryPickerView_notDetermined_bodyContainsPrimaryButtonHint() {
-        let view = AppCategoryPickerView(
-            appsState: makeSelectedAppsState(),
-            authorizationStatus: .notDetermined,
-            onRequestAuthorization: {},
-            onDone: {}
-        )
         XCTAssertEqual(
-            view.primaryButtonHintKey,
+            AppCategoryPickerView.primaryButtonHintKey(for: .notDetermined),
             "appCategoryPicker.button.enableAccess.hint",
             "Not-determined state must use enable-access hint key")
     }
 
     func test_appCategoryPickerView_denied_bodyContainsPrimaryButtonHint() {
-        let view = AppCategoryPickerView(
-            appsState: makeSelectedAppsState(),
-            authorizationStatus: .denied,
-            onRequestAuthorization: {},
-            onDone: {}
-        )
         XCTAssertEqual(
-            view.primaryButtonHintKey,
+            AppCategoryPickerView.primaryButtonHintKey(for: .denied),
             "appCategoryPicker.button.openSettings.hint",
             "Denied state must use open-settings hint key")
     }
 
     func test_appCategoryPickerView_approved_bodyContainsPrimaryButtonHint() {
-        let view = AppCategoryPickerView(
-            appsState: makeSelectedAppsState(),
-            authorizationStatus: .approved,
-            onRequestAuthorization: {},
-            onDone: {}
-        )
         XCTAssertEqual(
-            view.primaryButtonHintKey,
+            AppCategoryPickerView.primaryButtonHintKey(for: .approved),
             "appCategoryPicker.button.selectApps.hint",
             "Approved state must use select-apps hint key")
     }


### PR DESCRIPTION
## Summary

Per [docs/google_swift_coding_style.md §Access Levels](docs/google_swift_coding_style.md) and §Extensions, this PR fixes the three access-control violations identified in audit #652:

### 1. `AppCategoryPickerView.primaryButtonHintKey` — was internal, should be private
The instance computed property leaked into the module's surface even though it is consumed only by the view's own `accessibilityHint` modifier. Tests were the sole external caller, so I extracted the pure mapping into a `static func primaryButtonHintKey(for status:)` and made the instance property `private`. Tests now exercise the static helper, which is the correct testability seam (no view instance needed).

### 2. `AppCoordinator` — file-level access on extension is forbidden
`private extension AppCoordinator { ... }` is explicitly forbidden by §Extensions: *"Specifying an explicit access level at the file level on an extension is forbidden. Each member of the extension has its access level specified if it is different than the default."* Removed the file-level modifier and added `private` to each `static func` member — same effective visibility, compliant style.

### 3. `PauseConditionManager.focusDetector` / `carPlayDetector`
Audit asked to verify no unintended exposure. Confirmed via grep: both stored properties are `private`, only accessed via `self.` inside the type, never re-exposed by extensions, protocols, or test seams. **No code change required.**

## Validation

- `./scripts/build.sh build` — succeeded
- `./scripts/build.sh test` — **2075 tests, 0 failures, 0 unexpected** (~102 s)
- `./scripts/build.sh lint` — succeeded

## Risk

Very low. Pure visibility tightening:
- The static `primaryButtonHintKey(for:)` returns identical `LocalizedStringKey` values to the deleted instance switch.
- The `AppCoordinator` extension members were already effectively `private` (file-level modifier); now they are explicitly `private` per-member.
- No behavioural or API surface change for any non-test caller.

Closes #652