### PR TITLE
Add Google-format doc comments to public Services + ReminderRowView (#649)

### DIFF
--- a/EyePostureReminder/Services/AudioInterruptionManager.swift
+++ b/EyePostureReminder/Services/AudioInterruptionManager.swift
@@ -52,6 +52,12 @@ typealias AudioSessionFactory = () -> AudioSessionControlling
 final class AudioInterruptionManager: MediaControlling {
     private let audioSession: AudioSessionControlling
 
+    /// Creates an audio-interruption manager bound to a specific audio session.
+    ///
+    /// - Parameters:
+    ///   - audioSession: Pre-built session used directly when supplied (test seam).
+    ///   - makeAudioSession: Factory invoked only when `audioSession` is `nil`;
+    ///     defaults to `AVAudioSession.sharedInstance()` for production use.
     init(
         audioSession: AudioSessionControlling? = nil,
         makeAudioSession: @escaping AudioSessionFactory = { AVAudioSession.sharedInstance() }
@@ -61,6 +67,11 @@ final class AudioInterruptionManager: MediaControlling {
 
     // MARK: - MediaControlling
 
+    /// Activates `AVAudioSession` with the `.soloAmbient` category to interrupt other apps' audio.
+    ///
+    /// Called immediately before an overlay appears. Failures are logged but
+    /// non-fatal — the overlay still presents, and `resumeExternalAudio()` remains
+    /// safe to call on dismissal because deactivating an inactive session is a no-op.
     func pauseExternalAudio() {
         do {
             try audioSession.setCategory(.soloAmbient, mode: .default, options: [])
@@ -80,6 +91,12 @@ final class AudioInterruptionManager: MediaControlling {
         }
     }
 
+    /// Deactivates `AVAudioSession` and notifies other apps to resume playback.
+    ///
+    /// Must be called from every overlay dismiss path to release the audio
+    /// interruption. Uses `.notifyOthersOnDeactivation` so apps such as
+    /// Spotify or Podcasts resume automatically. Failures are logged and
+    /// otherwise ignored.
     func resumeExternalAudio() {
         do {
             // .notifyOthersOnDeactivation lets Spotify / Podcasts / etc. resume automatically.

--- a/EyePostureReminder/Services/MetricKitSubscriber.swift
+++ b/EyePostureReminder/Services/MetricKitSubscriber.swift
@@ -47,6 +47,10 @@ protocol MetricKitSubscribing {
 /// in the Xcode Organizer log stream. No third-party crash SDK is needed for the beta.
 final class MetricKitSubscriber: NSObject, MXMetricManagerSubscriber {
 
+    /// Process-wide singleton used by `AppDelegate` to register the subscriber once at launch.
+    ///
+    /// Tests that need to inject mocks must construct their own instance via `init(...)`
+    /// rather than mutate this shared value.
     static let shared = MetricKitSubscriber()
 
     private let metricManager: MetricKitManaging

--- a/EyePostureReminder/Services/NoopServices.swift
+++ b/EyePostureReminder/Services/NoopServices.swift
@@ -8,6 +8,11 @@ import Foundation
 
 // MARK: - NoopScreenTimeTracker
 
+/// Inert `ScreenTimeTracking` used only when the app is launched in UI-test mode.
+///
+/// Replaces the live tracker so XCUITest runs do not spin up the per-second
+/// timers and lifecycle observers used by `ScreenTimeTracker`, which would
+/// otherwise prevent the accessibility tree from settling between interactions.
 @MainActor
 final class NoopScreenTimeTracker: ScreenTimeTracking {
     var onThresholdReached: (@MainActor (ReminderType) -> Void)?
@@ -27,6 +32,11 @@ final class NoopScreenTimeTracker: ScreenTimeTracking {
 
 // MARK: - NoopPauseConditionManager
 
+/// Inert `PauseConditionProviding` used only when the app is launched in UI-test mode.
+///
+/// Always reports `isPaused == false` and never invokes `onPauseStateChanged`,
+/// so UI tests observe a deterministic, never-paused state regardless of
+/// device focus modes, CarPlay, or other live pause sources.
 @MainActor
 final class NoopPauseConditionManager: PauseConditionProviding {
     var isPaused: Bool { false }

--- a/EyePostureReminder/Services/OverlayManager.swift
+++ b/EyePostureReminder/Services/OverlayManager.swift
@@ -133,6 +133,11 @@ final class OverlayManager: OverlayPresenting {
     /// Tracks whether external audio was paused by this overlay so we only resume when needed.
     private var isAudioPaused = false
 
+    /// Whether a break overlay window is currently on screen and visible to the user.
+    ///
+    /// `true` while a `UIWindow` is installed and not hidden, `false` after dismissal
+    /// or before the first overlay is shown. Read by `AppCoordinator` to decide
+    /// whether to suppress duplicate threshold-triggered presentations.
     var isOverlayVisible: Bool {
         overlayWindow != nil && overlayWindow?.isHidden == false
     }

--- a/EyePostureReminder/Views/ReminderRowView.swift
+++ b/EyePostureReminder/Views/ReminderRowView.swift
@@ -1,5 +1,13 @@
 import SwiftUI
 
+/// Settings list row that toggles a single `ReminderType` and exposes its
+/// interval and break-duration pickers when enabled.
+///
+/// Used inside `SettingsView` to render one row per reminder kind. Calls
+/// `onChanged` after every binding mutation so the parent view-model can
+/// persist updated `ReminderSettings`. VoiceOver announcements are posted
+/// via the injected `AccessibilityNotificationPosting` whenever the row
+/// expands or collapses, satisfying the accessibility requirement in #432.
 struct ReminderRowView: View {
 
     let type: ReminderType


### PR DESCRIPTION
## Summary

Per [docs/google_swift_coding_style.md §"Where to Document"](docs/google_swift_coding_style.md), every public declaration and member should carry a doc comment. This PR fills the six gaps surfaced by audit #649.

## Doc comments added

- **`MetricKitSubscriber.shared`** — explains the singleton's launch-time role and points test authors at `init(...)` for mock injection.
- **`OverlayManager.isOverlayVisible`** — defines truth conditions and the caller contract used by `AppCoordinator` to suppress duplicate presentations.
- **`NoopScreenTimeTracker` / `NoopPauseConditionManager`** — type-level docs explaining UI-test-only purpose, replacing per-second timers / pause sources for deterministic accessibility-tree settling.
- **`AudioInterruptionManager.init`** — documents the test-seam parameter and default factory.
- **`AudioInterruptionManager.pauseExternalAudio()`** — documents activation semantics and that failure is non-fatal because deactivation remains safe.
- **`AudioInterruptionManager.resumeExternalAudio()`** — documents the dismiss-path requirement and `.notifyOthersOnDeactivation` behaviour.
- **`ReminderRowView`** — type-level doc covering purpose, the `onChanged` callback contract, and the VoiceOver-announcement requirement from #432.

## Validation

- `./scripts/build.sh build` — succeeded
- `./scripts/build.sh lint` — succeeded
- `./scripts/build.sh test` — **2075 tests, 0 failures, 0 unexpected** (~80 s)

## Risk

None. Pure documentation additions; zero runtime / API-surface change.

Closes #649