### PR TITLE
Correct notification permission entry in submission tracker (#643)

### DIFF
--- a/docs/app-store-submission-status.md
+++ b/docs/app-store-submission-status.md
@@ -28,7 +28,7 @@ Legend: ✅ Done · ⚠️ In progress / partial · ❌ Not started · 🔒 Bloc
 |---|------|--------|-------|
 | E1 | `NSMotionUsageDescription` present in Info.plist | ✅ Done | Present in `EyePostureReminder/Info.plist` |
 | E2 | Focus Status capability enabled on App ID for distribution signing | ⚠️ Partial | `EyePostureReminder.Distribution.entitlements` intentionally omits Focus Status to unblock archiving; enable when regenerating App Store profile |
-| E3 | Notification permission usage description accurate | ✅ Done | Present in Info.plist |
+| E3 | Notification permission rationale accurate | ✅ Done | iOS does not require a `NS*UsageDescription` plist key for `UNUserNotificationCenter`. Authorization is requested at runtime in `OnboardingPermissionView` and `AppCoordinator.requestNotificationAuthorisation()` via `requestAuthorization(options: [.alert, .sound, .badge])`; user-facing rationale is presented on the onboarding permission screen before the system prompt. |
 
 ---
 


### PR DESCRIPTION
## Summary

Audit #643 caught a factual error in `docs/app-store-submission-status.md`: row E3 claimed the notification permission usage description was "Present in Info.plist", but iOS does not require an `NS*UsageDescription` key for `UNUserNotificationCenter`, and `EyePostureReminder/Info.plist` does not contain one (only `NSFocusStatusUsageDescription` and `NSMotionUsageDescription`).

Per the audit's remediation guidance — *"Do not add a nonfunctional iOS plist key just to satisfy the tracker"* — this PR corrects the row to describe the actual iOS notification flow.

## Change

- Row label: **"Notification permission usage description accurate" → "Notification permission rationale accurate"**
- Notes:
  - iOS does not require an `NS*UsageDescription` key for `UNUserNotificationCenter`.
  - Authorization is requested at runtime in `OnboardingPermissionView` and `AppCoordinator.requestNotificationAuthorisation()` via `requestAuthorization(options: [.alert, .sound, .badge])`.
  - User-facing rationale appears on the onboarding permission screen, presented before the system prompt.

## Validation

- Verified `EyePostureReminder/Info.plist` only contains `NSFocusStatusUsageDescription` and `NSMotionUsageDescription`.
- Verified `requestAuthorization(options:)` call sites in `OnboardingPermissionView.swift` and `AppCoordinator.swift`.

## Risk

None. Documentation-only change.

Closes #643