### PR TITLE
Audit IUO usage per Google Swift Style §Optional Types (#648)

### DIFF
--- a/EyePostureReminder/Services/OverlayManager.swift
+++ b/EyePostureReminder/Services/OverlayManager.swift
@@ -113,6 +113,16 @@ final class OverlayManager: OverlayPresenting {
     private let windowSceneProvider: WindowSceneProvider
 
     // MARK: - State
+    //
+    // All mutable references below are declared as regular `Optional` (not
+    // implicitly unwrapped optionals). Per Google Swift Style §Implicitly
+    // Unwrapped Optionals, IUOs are inherently unsafe and must be avoided
+    // outside the narrow exceptions for `@IBOutlet`-style late-bound UIKit
+    // properties and unit-test fixtures. Each value here is genuinely
+    // optional during the manager's lifetime: the overlay window only exists
+    // while a reminder is on screen, the dismiss callback is set per
+    // presentation, and the scene-activation observer is only registered
+    // while we need to react to scene resume events.
 
     private var overlayWindow: UIWindow?
     private var dismissCallback: (() -> Void)?

--- a/Tests/EyePostureReminderTests/README.md
+++ b/Tests/EyePostureReminderTests/README.md
@@ -1,0 +1,55 @@
+# EyePostureReminderTests — Conventions
+
+This document captures conventions for the unit-test suite that complement
+the Google Swift Style guide (`docs/google_swift_coding_style.md`).
+
+## Test fixture lifecycle and Implicitly Unwrapped Optionals (IUOs)
+
+Test cases routinely declare fixtures as IUOs:
+
+```swift
+final class AppCoordinatorTests: XCTestCase {
+    var settings: SettingsStore!
+    var sut: AppCoordinator!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        settings = SettingsStore(store: MockSettingsPersisting())
+        sut = AppCoordinator(settings: settings, …)
+    }
+}
+```
+
+This is **intentional and conformant** with the project style. Per
+Google Swift Style §Implicitly Unwrapped Optionals:
+
+> Implicitly unwrapped optionals are also allowed in unit tests. This is for
+> reasons similar to the UI object scenario above — the lifetime of test
+> fixtures often begins not in the test's initializer but in the `setUp()`
+> method of a test so that they can be reset before the execution of each
+> test.
+
+Production code in `EyePostureReminder/` and `Extensions/` must **not** use
+IUOs (audited in #648). When introducing new test fixtures, prefer the IUO
+pattern over `Optional<T>` + force-unwrap to keep test bodies focused on
+behaviour rather than fixture nil-checking.
+
+## Naming convention
+
+Test methods follow `test_subject_action_expectedResult`, matching the UI
+test suite (`Tests/EyePostureReminderUITests/README.md`). Group related
+tests with `// MARK: -` sections.
+
+## Mocks and fakes
+
+Place protocol-conforming mocks in `Tests/EyePostureReminderTests/Mocks/`
+and prefix the type with `Mock` (e.g. `MockOverlayPresenting`,
+`MockNotificationCenter`). Mocks should be deterministic and capture the
+inputs needed for assertions; avoid recording state the test does not read.
+
+## Async / `@MainActor`
+
+Annotate `XCTestCase` subclasses with `@MainActor` when they exercise
+`@MainActor`-isolated production types. Use `async throws` setup/tear-down
+variants (`setUp() async throws`, `tearDown() async throws`) to compose
+cleanly with the rest of the suite.


### PR DESCRIPTION
## Summary
Closes #648.

Audited implicitly unwrapped optional (IUO) usage across the codebase per Google Swift Style §Implicitly Unwrapped Optionals.

## Findings
- **Production code** (`EyePostureReminder/`, `Extensions/`) contains **zero IUOs** — all reference types use regular `Optional` or non-optional declarations.
- **Test code** uses ~126 IUOs across ~33 files, **all confined to XCTest `setUp()` fixtures**. The Google Swift Style guide explicitly permits this pattern (line 1531 of `docs/google_swift_coding_style.md`).
- `OverlayManager.swift` line 118 (`dismissCallback`), called out specifically in the issue, is already a regular `Optional` — no refactor required.

## Changes
1. **`OverlayManager.swift`** — added a doc comment to the `// MARK: - State` block documenting why each mutable reference is a regular `Optional` (not an IUO), with reference to §Implicitly Unwrapped Optionals.
2. **`Tests/EyePostureReminderTests/README.md`** (new) — captures the test-fixture IUO convention along with naming, mock, and async/`@MainActor` guidance so future contributors don't flag the pattern as a violation.

## Acceptance criteria
- [x] IUO usage reviewed and justified
- [x] Unnecessary IUOs refactored to regular Optional (n/a — none found in production)
- [x] Comments added documenting intentional Optional choices and the test-fixture IUO convention
- [x] `./scripts/build.sh lint` passes
- [x] `./scripts/build.sh build` passes
- [x] `./scripts/build.sh test` passes (2075/2075 tests passing locally)
- [x] PR opened against `main`

## Testing
- `./scripts/build.sh all` → ✓ All steps passed in 116s

## Related
- Parent audit: #646
- Standard: `docs/google_swift_coding_style.md` §Implicitly Unwrapped Optionals