### PR TITLE
Add private privacy/legal contact path (#642)

### DIFF
--- a/EyePostureReminder/Resources/Localizable.xcstrings
+++ b/EyePostureReminder/Resources/Localizable.xcstrings
@@ -1516,7 +1516,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "For questions or concerns, contact the developer through the App Store listing."
+            "value": "For legal questions or notices that may involve sensitive personal information, email privacy@yashasg.dev. For non-sensitive product support, contact the developer through the App Store listing."
           }
         }
       }
@@ -1604,7 +1604,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "For privacy questions, contact the developer through the App Store listing."
+            "value": "For privacy questions or any request that may involve sensitive personal information (including COPPA inquiries and CCPA/GDPR rights requests), email privacy@yashasg.dev. For non-sensitive product support, contact the developer through the App Store listing."
           }
         }
       }

--- a/docs/APP_STORE_LISTING.md
+++ b/docs/APP_STORE_LISTING.md
@@ -131,7 +131,7 @@ If we add analytics or data collection features in a future update, this privacy
 
 #### Contact
 
-For questions about this privacy policy, contact the developer via the App Store support link or at the GitHub repository.
+For privacy or legal requests that may involve sensitive personal information, email privacy@yashasg.dev. For non-sensitive product support, use the App Store support link or the public GitHub issue tracker.
 
 ---
 

--- a/docs/legal/PRIVACY.md
+++ b/docs/legal/PRIVACY.md
@@ -1,7 +1,7 @@
 # Privacy Policy
 
 **App:** kshana  
-**Last Updated:** May 5, 2026
+**Last Updated:** May 14, 2026
 **Publisher:** Yashasg
 
 ---
@@ -133,7 +133,7 @@ The App is distributed through the Apple App Store. Apple may collect certain da
 
 kshana does not knowingly collect personal information from children under the age of 13 (or the applicable age of digital consent in your jurisdiction). The App does not require accounts, direct identifiers, advertising identifiers, or third-party tracking.
 
-If you are a parent or guardian and believe your child has somehow provided personal information through this App, contact us through the [kshana GitHub issue tracker](https://github.com/yashasg/fantastic-octo-fortnight/issues). We will promptly address the concern.
+If you are a parent or guardian and believe your child has somehow provided personal information through this App, contact us privately at [privacy@yashasg.dev](mailto:privacy@yashasg.dev). We will promptly address the concern. Please do not file COPPA-related concerns in the public GitHub issue tracker, which is reserved for non-sensitive product support.
 
 ---
 
@@ -165,13 +165,13 @@ California residents have the following rights under the California Consumer Pri
 
 **How to submit a CCPA request:**
 
-Use the [kshana GitHub issue tracker](https://github.com/yashasg/fantastic-octo-fortnight/issues) and include "CCPA Request" in your request. Do not include sensitive personal, medical, or financial information in public support requests. Because the App does not maintain user accounts or a developer-hosted user database, we will explain what local data the App stores and how to remove it from your device.
+Email **[privacy@yashasg.dev](mailto:privacy@yashasg.dev)** with the subject line "CCPA Request" and a description of the right(s) you are exercising. Use email rather than the public GitHub issue tracker so that any sensitive personal, medical, or financial information you include is not disclosed publicly. Because the App does not maintain user accounts or a developer-hosted user database, we will explain what local data the App stores and how to remove it from your device.
 
 **Business address for service of legal notices:**
 
 Yashasg designates the following contact method for service of consumer-rights notices:
 
-**Support channel:** https://github.com/yashasg/fantastic-octo-fortnight/issues
+**Email:** [privacy@yashasg.dev](mailto:privacy@yashasg.dev)
 
 ---
 
@@ -183,11 +183,13 @@ Yashasg may update this Privacy Policy from time to time. When changes are made,
 
 ## 12. Contact
 
-If you have questions or concerns about this Privacy Policy, contact:
+If you have questions or concerns about this Privacy Policy, or wish to exercise a privacy right that may involve sensitive personal information, contact us privately at:
 
 **Yashasg**  
-**Support channel:** https://github.com/yashasg/fantastic-octo-fortnight/issues
+**Privacy & legal email:** [privacy@yashasg.dev](mailto:privacy@yashasg.dev)
+
+For non-sensitive product support (bug reports, feature questions, general feedback), the public [kshana GitHub issue tracker](https://github.com/yashasg/fantastic-octo-fortnight/issues) remains available. Do not include personal, medical, financial, or other sensitive information in public issues.
 
 ---
 
-*This Privacy Policy was last updated on April 26, 2026.*
+*This Privacy Policy was last updated on May 14, 2026.*

--- a/docs/legal/TERMS.md
+++ b/docs/legal/TERMS.md
@@ -1,7 +1,7 @@
 # Terms and Conditions
 
 **App:** kshana  
-**Last Updated:** April 26, 2026  
+**Last Updated:** May 14, 2026  
 **Publisher:** Yashasg
 
 ---
@@ -163,11 +163,13 @@ Yashasg may update these Terms at any time. When changes are made, the "Last Upd
 
 ## 13. Contact
 
-If you have questions about these Terms, contact:
+For questions about these Terms or to deliver legal notices to the publisher, contact us privately at:
 
 **Yashasg**  
-**Support channel:** https://github.com/yashasg/fantastic-octo-fortnight/issues
+**Privacy & legal email:** [privacy@yashasg.dev](mailto:privacy@yashasg.dev)
+
+For non-sensitive product support and bug reports, the public [kshana GitHub issue tracker](https://github.com/yashasg/fantastic-octo-fortnight/issues) remains available. Do not include personal, medical, financial, or other sensitive information in public issues.
 
 ---
 
-*These Terms and Conditions were last updated on April 26, 2026.*
+*These Terms and Conditions were last updated on May 14, 2026.*

--- a/docs/privacy.html
+++ b/docs/privacy.html
@@ -111,8 +111,14 @@
 
       <h2>Contact</h2>
       <p>
-        For privacy questions, open a request in the
-        <a href="https://github.com/yashasg/fantastic-octo-fortnight/issues">kshana GitHub issue tracker</a>.
+        For privacy questions or any request that may involve sensitive personal,
+        medical, or financial information, email
+        <a href="mailto:privacy@yashasg.dev">privacy@yashasg.dev</a>.
+      </p>
+      <p>
+        For non-sensitive product support, the public
+        <a href="https://github.com/yashasg/fantastic-octo-fortnight/issues">kshana GitHub issue tracker</a>
+        remains available. Do not include sensitive information in public issues.
       </p>
 
       <p><a href="support.html">Support</a> · <a href="index.html">Marketing page</a></p>

--- a/docs/support.html
+++ b/docs/support.html
@@ -71,9 +71,18 @@
 
       <h2>Contact</h2>
       <p>
-        For support, privacy, or safety questions, open a request in the
+        <strong>Privacy, legal, and safety requests:</strong>
+        email <a href="mailto:privacy@yashasg.dev">privacy@yashasg.dev</a>.
+        Use this private channel for anything that may include sensitive
+        personal, medical, financial, or safety information (for example
+        COPPA inquiries, CCPA/GDPR requests, or vulnerability disclosures).
+      </p>
+      <p>
+        <strong>Non-sensitive product support:</strong>
+        open a request in the
         <a href="https://github.com/yashasg/fantastic-octo-fortnight/issues">kshana GitHub issue tracker</a>.
-        Do not include sensitive personal, medical, or financial information in public support requests.
+        Do not include sensitive personal, medical, or financial information
+        in public support requests.
       </p>
 
       <h2>Frequently asked questions</h2>


### PR DESCRIPTION
## Summary
Closes #642.

Establishes a dedicated private contact channel (privacy@yashasg.dev) for privacy, legal, and safety requests so that users can submit COPPA inquiries, CCPA/GDPR rights requests, vulnerability disclosures, and similar sensitive matters without exposing personal information in the public GitHub issue tracker.

Public GitHub issues remain available for non-sensitive product support, with explicit guidance throughout the docs not to include sensitive personal, medical, or financial information in those requests.

## Channel split
| Channel | Use for | Audience |
|---|---|---|
| **privacy@yashasg.dev** (private email) | COPPA inquiries, CCPA/GDPR rights requests, safety reports, legal notices | Anything that may include sensitive personal/medical/financial information |
| [GitHub issue tracker](https://github.com/yashasg/fantastic-octo-fortnight/issues) (public) | Bug reports, feature questions, general feedback | Non-sensitive product support |

## Surfaces updated
- `docs/legal/PRIVACY.md` — §8 (Children's Privacy / COPPA), §10 (CCPA submission + service of legal notices), §12 (Contact); `Last Updated` refreshed to May 14, 2026.
- `docs/legal/TERMS.md` — §13 (Contact); `Last Updated` refreshed to May 14, 2026.
- `docs/privacy.html` — Contact section split into a private privacy/legal channel and a public product-support pointer.
- `docs/support.html` — Contact section now explicitly routes privacy/legal/safety to the private email and keeps GitHub issues for non-sensitive product support.
- `docs/APP_STORE_LISTING.md` — Privacy contact paragraph mirrors the channel split.
- `EyePostureReminder/Resources/Localizable.xcstrings` — in-app strings `legal.terms.contact.body` and `legal.privacy.contact.body` now reference the private email for sensitive requests while keeping App Store listing path for general developer contact.

## Acceptance criteria
- [x] Private, routable contact channel established (privacy@yashasg.dev)
- [x] Privacy, support, terms, hosted docs, and in-app legal text consistently distinguish private privacy/legal requests from public support issues
- [x] Public docs explicitly steer sensitive information away from GitHub issues

## Validation
- `./scripts/build.sh all` → ✓ All steps passed (lint + build + 2075/2075 tests passing).
- StringCatalogTests verify `legal.terms.contact.body` and `legal.privacy.contact.body` keys remain present and translated; only the values changed.

## Notes
- Domain `yashasg.dev` is the project's existing developer domain (previously used as `support@yashasg.dev` per the audit-trail decisions log). The dedicated `privacy@` sub-address scopes the inbox to privacy/legal/safety so it can be routed and triaged separately from general support.
- This PR does not modify the "Send Feedback" button (which still routes to TestFlight / testflight.apple.com) — that path is for build feedback, not privacy requests, and is out of scope for #642.