### PR TITLE
Add swift-composable-architecture 1.25.5 dependency (#664)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,20 +242,35 @@ jobs:
           ./scripts/setup-uitests.sh
 
       - name: Build UI tests for testing (once)
+        # -skipMacroValidation suppresses Xcode's interactive trust prompt for
+        # the Swift macro plugins introduced by the swift-composable-architecture
+        # 1.25.5 dependency (#664). Even though the UI test target does not
+        # import TCA, building the local SwiftPM package resolves the full
+        # macro graph (ComposableArchitectureMacros, CasePathsMacros,
+        # DependenciesMacrosPlugin, PerceptionMacros), which fails headless
+        # validation otherwise.
+        #
+        # SWIFT_TREAT_WARNINGS_AS_ERRORS / GCC_TREAT_WARNINGS_AS_ERRORS are
+        # NOT passed as xcodebuild command-line overrides because they
+        # propagate to every target — including the TCA dependency targets
+        # that pass `-suppress-warnings` in their own package configs — and
+        # the two flags conflict (`error: conflicting options
+        # '-warnings-as-errors' and '-suppress-warnings'`). The no-warning
+        # contract on first-party UI test targets is enforced per-target via
+        # SWIFT_TREAT_WARNINGS_AS_ERRORS = YES in UITests/project.yml.
         run: |
           xcodebuild build-for-testing \
             -project UITests/EyePostureReminderUITests.xcodeproj \
             -scheme EyePostureReminderUITests \
             -destination "${{ env.SIMULATOR }}" \
             -derivedDataPath "${{ env.DERIVED_DATA_PATH }}" \
+            -skipMacroValidation \
             CODE_SIGN_IDENTITY= \
             CODE_SIGNING_REQUIRED=NO \
             CODE_SIGNING_ALLOWED=NO \
             ENABLE_BITCODE=NO \
             ENABLE_APP_INTENTS_METADATA_EXTRACTION=NO \
-            ENABLE_APPINTENTS_METADATA_EXTRACTION=NO \
-            SWIFT_TREAT_WARNINGS_AS_ERRORS=YES \
-            GCC_TREAT_WARNINGS_AS_ERRORS=YES
+            ENABLE_APPINTENTS_METADATA_EXTRACTION=NO
 
       - name: Verify prebuilt xctestrun
         run: |

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,131 @@
+{
+  "pins" : [
+    {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "revision" : "206cbce3882b4de9aee19ce62ac5b7306cadd45b",
+        "version" : "1.7.3"
+      }
+    },
+    {
+      "identity" : "swift-clocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
+      "state" : {
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections",
+      "state" : {
+        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-composable-architecture",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-composable-architecture",
+      "state" : {
+        "revision" : "1eaa6fa2ee57ac42843283b9fd3457af408c858d",
+        "version" : "1.25.5"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies",
+      "state" : {
+        "revision" : "706feb7858a7f6c242879d137b8ee30926aa5b26",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-identified-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-identified-collections",
+      "state" : {
+        "revision" : "322d9ffeeba85c9f7c4984b39422ec7cc3c56597",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-navigation",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-navigation",
+      "state" : {
+        "revision" : "32f35241b8be0719c4c7f00eb27713b1cadb6248",
+        "version" : "2.8.0"
+      }
+    },
+    {
+      "identity" : "swift-perception",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-perception",
+      "state" : {
+        "revision" : "25ac73741c3436605d61eceb5207e896973918e7",
+        "version" : "2.0.10"
+      }
+    },
+    {
+      "identity" : "swift-sharing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-sharing",
+      "state" : {
+        "revision" : "bc27f8322bc30f6ce7d864d137dc77a6de8b57eb",
+        "version" : "2.8.0"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
+        "version" : "603.0.1"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/Package.swift
+++ b/Package.swift
@@ -10,6 +10,15 @@ let package = Package(
     products: [
         .executable(name: "EyePostureReminder", targets: ["EyePostureReminder"])
     ],
+    dependencies: [
+        // Pinned to exact 1.25.5 per #662 / #664 — do not bump without explicit
+        // authorisation from the migration owner. Subsequent TCA migration issues
+        // (#665+) consume `ComposableArchitecture` from this dependency.
+        .package(
+            url: "https://github.com/pointfreeco/swift-composable-architecture",
+            exact: "1.25.5"
+        )
+    ],
     targets: [
         .target(
             name: "ScreenTimeExtensionShared",
@@ -21,7 +30,8 @@ let package = Package(
         .executableTarget(
             name: "EyePostureReminder",
             dependencies: [
-                "ScreenTimeExtensionShared"
+                "ScreenTimeExtensionShared",
+                .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
             ],
             path: "EyePostureReminder",
             resources: [
@@ -34,7 +44,8 @@ let package = Package(
             name: "EyePostureReminderTests",
             dependencies: [
                 "EyePostureReminder",
-                "ScreenTimeExtensionShared"
+                "ScreenTimeExtensionShared",
+                .product(name: "ComposableArchitecture", package: "swift-composable-architecture")
             ],
             path: "Tests/EyePostureReminderTests",
             resources: [

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -58,8 +58,13 @@ XCODE_FLAGS=(
   ENABLE_BITCODE=NO
   ENABLE_APP_INTENTS_METADATA_EXTRACTION=NO
   ENABLE_APPINTENTS_METADATA_EXTRACTION=NO
-  SWIFT_TREAT_WARNINGS_AS_ERRORS=YES
-  GCC_TREAT_WARNINGS_AS_ERRORS=YES
+  # SWIFT_TREAT_WARNINGS_AS_ERRORS / GCC_TREAT_WARNINGS_AS_ERRORS are NOT set
+  # here — passing them as xcodebuild build settings would propagate to every
+  # SwiftPM dependency (e.g. swift-collections, swift-concurrency-extras), and
+  # those packages set `-suppress-warnings` themselves, which conflicts with
+  # `-warnings-as-errors`, breaking the build (#664). Both values are already
+  # enforced on every first-party target via project.yml lines 75/130/165 and
+  # UITests/project.yml lines 47/102, so app coverage is unchanged.
 )
 
 # ── Guards ───────────────────────────────────────────────────────────────────
@@ -109,6 +114,10 @@ elapsed() {
 }
 
 # ── xcodebuild runner (xcpretty fallback) ─────────────────────────────────────
+# Note: -skipMacroValidation suppresses the interactive "trust" prompt
+# Xcode otherwise requires for Swift macros (e.g. ComposableArchitecture's
+# `@Reducer`, `@DependencyClient`). Required for headless / CI builds — added
+# in #664 alongside the swift-composable-architecture 1.25.5 dependency.
 run_xcodebuild() {
   local start rc
   start=$(date +%s)
@@ -120,11 +129,11 @@ run_xcodebuild() {
     # still holds xcodebuild's real exit code.  Using `|| true` instead would
     # reset PIPESTATUS to (0) before we can read it — that was the false-green bug.
     set +o pipefail
-    xcodebuild "$@" "${XCODE_FLAGS[@]}" | xcpretty
+    xcodebuild -skipMacroValidation "$@" "${XCODE_FLAGS[@]}" | xcpretty
     rc=${PIPESTATUS[0]}
     set -o pipefail
   else
-    xcodebuild "$@" "${XCODE_FLAGS[@]}" || rc=$?
+    xcodebuild -skipMacroValidation "$@" "${XCODE_FLAGS[@]}" || rc=$?
   fi
 
   echo "  (took $(elapsed "$start"))"
@@ -511,7 +520,7 @@ cmd_clean() {
   dest=$(detect_destination)
 
   info "Cleaning DerivedData and build products…"
-  xcodebuild clean \
+  xcodebuild clean -skipMacroValidation \
     -scheme "$SCHEME" \
     -destination "$dest" \
     -derivedDataPath "$DERIVED_DATA_PATH" \

--- a/scripts/setup-screentime.sh
+++ b/scripts/setup-screentime.sh
@@ -107,9 +107,17 @@ if [[ "${1:-}" == "--build" ]]; then
   # avoid "extension CFBundleVersion must match containing app" warnings.
   # CI sets BUILD_NUMBER (= github.run_number) before calling this script;
   # locally it defaults to "1" which matches the project.yml baseline.
+  # -skipMacroValidation suppresses Xcode's interactive "trust" prompt for
+  # Swift macros (e.g. ComposableArchitecture's @Reducer, @DependencyClient).
+  # Even though the extension targets do not import TCA, the local SwiftPM
+  # package resolves the full dependency graph (including macro plugins) when
+  # generating the dependency graph for any xcodebuild invocation, so the
+  # validation gate trips here too. Required for headless / CI builds — added
+  # in #664 alongside the swift-composable-architecture 1.25.5 dependency.
   BUILD_NUMBER="${BUILD_NUMBER:-1}"
   set +e
   xcodebuild build \
+    -skipMacroValidation \
     -project "$XCODEPROJ" \
     -scheme "$SCHEME" \
     -destination "$DEST" \


### PR DESCRIPTION
## Summary

First substantive PR in the TCA migration tracked by #662. Adds The
Composable Architecture as a SwiftPM dependency at exact 1.25.5 and
links the `ComposableArchitecture` product into both:

- `EyePostureReminder` (the app target)
- `EyePostureReminderTests` (so future Phase-3 TestStore rewrites can land)

`Package.resolved` is committed so the full transitive dep graph is
pinned (CasePaths, Clocks, ConcurrencyExtras, CombineSchedulers,
CustomDump, Dependencies, IdentifiedCollections, IssueReporting,
OrderedCollections, Perception, Sharing, SwiftNavigation,
XCTestDynamicOverlay).

## Build-script changes (required to support TCA macros + SwiftPM deps)

`scripts/build.sh`:

1. **`-skipMacroValidation`** added to every `xcodebuild` invocation
   (`run_xcodebuild` xcpretty path, non-xcpretty path, and `cmd_clean`).
   Required because Xcode 16+ otherwise blocks on an interactive
   "trust this Swift macro" prompt for TCA's `@Reducer`,
   `@DependencyClient`, `@CasePathable`, and `@Perceptible` macros.

2. **`SWIFT_TREAT_WARNINGS_AS_ERRORS=YES`** and
   **`GCC_TREAT_WARNINGS_AS_ERRORS=YES`** removed from the global
   `XCODE_FLAGS` array. When passed as command-line build settings they
   propagate to every SwiftPM dependency target, but several TCA
   transitive deps pass `-suppress-warnings` in their own package
   configs — the two options conflict
   (`error: Conflicting options '-warnings-as-errors' and '-suppress-warnings'`)
   and break the build. `-Werror` is still enforced on every first-party
   target via the existing per-target settings in `project.yml`
   (lines 75/130/165) and `UITests/project.yml` (lines 47/102), so
   coverage is unchanged for our code.

## Verification

```
$ env -u GIT_CONFIG_COUNT -u GIT_CONFIG_KEY_0 -u GIT_CONFIG_VALUE_0 \
    ./scripts/build.sh all
…
✓ Build succeeded   (45s)
✓ Lint passed
✓ Tests passed       (2075/2075, 99s)
✓ All steps passed in 108s
```

Run on Xcode 26.4 / iPhone 17 simulator.

## Out of scope

No source files import `ComposableArchitecture` yet — the dep is linked
purely via `Package.swift` so subsequent Phase-0 issues (#665 dependency
clients, #666 `AppFeature` skeleton, #667 navigation scaffolding) can
start consuming it without a chicken-and-egg setup. xcodebuild's link
log confirms `ComposableArchitecture` and all transitive frameworks are
emitted into the app binary.

Closes #664