### PR TITLE
Fix line-wrapping in Views to comply with 100-char column limit (#650)

### DIFF
--- a/EyePostureReminder/Views/Components.swift
+++ b/EyePostureReminder/Views/Components.swift
@@ -55,13 +55,17 @@ struct PrimaryButtonStyle: ButtonStyle {
                 .background(AppColor.primaryRest)
                 .clipShape(RoundedRectangle(cornerRadius: AppLayout.radiusPill, style: .continuous))
                 .scaleEffect((!reduceMotion && configuration.isPressed) ? 0.98 : 1.0)
-                .animation(reduceMotion ? nil : .easeOut(duration: 0.12), value: configuration.isPressed)
+                .animation(
+                    reduceMotion ? nil : .easeOut(duration: 0.12),
+                    value: configuration.isPressed
+                )
         }
     }
 }
 
 extension ButtonStyle where Self == PrimaryButtonStyle {
-    /// Pill-shaped primary button: `primaryRest` fill, adaptive high-contrast text, subtle press scale.
+    /// Pill-shaped primary button: `primaryRest` fill, adaptive high-contrast text, subtle press
+    /// scale.
     static var primary: PrimaryButtonStyle { PrimaryButtonStyle() }
 }
 
@@ -155,7 +159,11 @@ struct SecondaryButtonStyle: ButtonStyle {
             .foregroundStyle(AppColor.textSecondary)
             .frame(minHeight: AppLayout.minTapTarget)
             .padding(.horizontal, AppSpacing.md)
-            .opacity(configuration.isPressed ? AppOpacity.pressedButton : (isEnabled ? 1 : AppOpacity.disabledButton))
+            .opacity(
+                configuration.isPressed
+                    ? AppOpacity.pressedButton
+                    : (isEnabled ? 1 : AppOpacity.disabledButton)
+            )
     }
 }
 

--- a/EyePostureReminder/Views/DesignSystem.swift
+++ b/EyePostureReminder/Views/DesignSystem.swift
@@ -90,7 +90,11 @@ enum AppTypography {
     static func registerFonts() {
         for fileName in fontFileNames {
             guard
-                let url = Bundle.module.url(forResource: fileName, withExtension: "ttf", subdirectory: "Fonts"),
+                let url = Bundle.module.url(
+                    forResource: fileName,
+                    withExtension: "ttf",
+                    subdirectory: "Fonts"
+                ),
                 let dataProvider = CGDataProvider(url: url as CFURL),
                 let font = CGFont(dataProvider)
             else {
@@ -119,7 +123,8 @@ enum AppTypography {
     /// Caption emphasized — custom font scales with Dynamic Type (base: 13pt).
     static let captionEmphasized: Font = .custom(fontFamilyName, size: 13, relativeTo: .footnote)
 
-    /// Secondary action buttons (onboarding, secondary CTAs) — custom font scales with Dynamic Type (base: 15pt regular).
+    /// Secondary action buttons (onboarding, secondary CTAs) — custom font scales with Dynamic
+    /// Type (base: 15pt regular).
     static let secondaryAction: Font = .custom(fontFamilyName, size: 15, relativeTo: .subheadline)
 
     /// Overlay dismiss button — custom font scales with Dynamic Type (base: 28pt).
@@ -129,10 +134,12 @@ enum AppTypography {
     /// VoiceOver exposes a labelled accessibility element instead of reading this text directly.
     static let countdown: Font = .system(size: 64, weight: .bold, design: .monospaced)
 
-    /// Settings row icon — SF Symbol inside a 32 pt tinted circle (decorative, accessibility-hidden).
+    /// Settings row icon — SF Symbol inside a 32 pt tinted circle (decorative,
+    /// accessibility-hidden).
     static let settingsRowIcon: Font = .system(size: 15, weight: .semibold)
 
-    /// Warning icon — SF Symbol inside a 36 pt warning banner circle (decorative, accessibility-hidden).
+    /// Warning icon — SF Symbol inside a 36 pt warning banner circle (decorative,
+    /// accessibility-hidden).
     static let warningIcon: Font = .system(size: 16, weight: .semibold)
 
     /// Reminder card icon — SF Symbol in an onboarding reminder card; scales with Dynamic Type.
@@ -213,7 +220,8 @@ enum AppAnimation {
     /// Onboarding transition used in ContentView (hasSeenOnboarding toggle)
     static let onboardingTransition: Animation = .easeInOut(duration: onboardingFadeIn)
     /// Onboarding screen fade-in entrance animation (easeOut + delay)
-    static let onboardingFadeInCurve: Animation = .easeOut(duration: onboardingFadeIn).delay(onboardingFadeInDelay)
+    static let onboardingFadeInCurve: Animation =
+        .easeOut(duration: onboardingFadeIn).delay(onboardingFadeInDelay)
     /// Calming entrance — slower ease-out for fade + gentle slide. No bounce.
     /// Adopt in OverlayView for a softer, less utilitarian entrance.
     static let calmingEntranceCurve: Animation = .easeOut(duration: calmingEntranceDuration)
@@ -346,11 +354,15 @@ extension AppTypography {
     /// Overlay / home-screen status icon — SF Symbol sized to `overlayIconSize` (decorative).
     static let overlayIcon: Font = .system(size: AppLayout.overlayIconSize)
     /// Home yin-yang logo symbol — sized relative to the home hero icon frame.
-    static let homeLogoIcon: Font = .system(size: AppLayout.overlayIconSize * 0.42, weight: .semibold)
-    /// Onboarding hero illustration icon — SF Symbol sized to `onboardingIllustrationSize` (decorative).
-    static let illustrationIcon: Font = .system(size: AppLayout.onboardingIllustrationSize, weight: .semibold)
+    static let homeLogoIcon: Font =
+        .system(size: AppLayout.overlayIconSize * 0.42, weight: .semibold)
+    /// Onboarding hero illustration icon — SF Symbol sized to `onboardingIllustrationSize`
+    /// (decorative).
+    static let illustrationIcon: Font =
+        .system(size: AppLayout.onboardingIllustrationSize, weight: .semibold)
     /// True Interrupt Mode shield icon — SF Symbol sized for onboarding/configuration hero cards.
-    static let trueInterruptIcon: Font = .system(size: AppLayout.onboardingIllustrationSize * 0.55, weight: .semibold)
+    static let trueInterruptIcon: Font =
+        .system(size: AppLayout.onboardingIllustrationSize * 0.55, weight: .semibold)
 }
 
 extension AppFont {

--- a/EyePostureReminder/Views/HomeView.swift
+++ b/EyePostureReminder/Views/HomeView.swift
@@ -11,7 +11,8 @@ struct HomeView: View {
 
     @State private var showSettings = false
     @AppStorage(AppStorageKey.openSettingsOnLaunch) private var openSettingsOnLaunch = false
-    @AppStorage(AppStorageKey.trueInterruptSkippedBannerDismissed) private var trueInterruptBannerDismissed = false
+    @AppStorage(AppStorageKey.trueInterruptSkippedBannerDismissed)
+    private var trueInterruptBannerDismissed = false
 #if DEBUG
     @AppStorage(AppStorageKey.uiTestScreenTimeStatus) private var uiTestScreenTimeStatusRaw = ""
 #endif
@@ -24,11 +25,13 @@ struct HomeView: View {
     private let processEnvironmentProvider: ProcessEnvironmentProvider
 
     init(
-        accessibilityNotificationPoster: AccessibilityNotificationPosting = LiveAccessibilityNotificationPoster(),
+        accessibilityNotificationPoster: AccessibilityNotificationPosting
+            = LiveAccessibilityNotificationPoster(),
         launchArguments: [String]? = nil,
         launchArgumentsProvider: @escaping LaunchArgumentsProvider = { CommandLine.arguments },
         processEnvironment: [String: String]? = nil,
-        processEnvironmentProvider: @escaping ProcessEnvironmentProvider = { ProcessInfo.processInfo.environment }
+        processEnvironmentProvider: @escaping ProcessEnvironmentProvider
+            = { ProcessInfo.processInfo.environment }
     ) {
         self.accessibilityNotificationPoster = accessibilityNotificationPoster
         self.launchArguments = launchArguments
@@ -139,7 +142,8 @@ struct HomeView: View {
         launchArguments: [String]? = nil,
         launchArgumentsProvider: LaunchArgumentsProvider = { CommandLine.arguments },
         processEnvironment: [String: String]? = nil,
-        processEnvironmentProvider: ProcessEnvironmentProvider = { ProcessInfo.processInfo.environment }
+        processEnvironmentProvider: ProcessEnvironmentProvider
+            = { ProcessInfo.processInfo.environment }
     ) -> Bool? {
         let resolvedLaunchArguments = launchArguments ?? launchArgumentsProvider()
         if resolvedLaunchArguments.contains("--show-true-interrupt-banner") {
@@ -164,7 +168,8 @@ struct HomeView: View {
         launchArguments: [String]? = nil,
         launchArgumentsProvider: LaunchArgumentsProvider = { CommandLine.arguments },
         processEnvironment: [String: String]? = nil,
-        processEnvironmentProvider: ProcessEnvironmentProvider = { ProcessInfo.processInfo.environment }
+        processEnvironmentProvider: ProcessEnvironmentProvider
+            = { ProcessInfo.processInfo.environment }
     ) -> Bool {
         let resolvedLaunchArguments = launchArguments ?? launchArgumentsProvider()
         if resolvedLaunchArguments.contains("--simulate-screen-time-not-determined") {
@@ -200,7 +205,10 @@ struct HomeView: View {
                     .id(settings.globalEnabled)
                     .transition(.opacity)
                 }
-                .animation(reduceMotion ? nil : AppAnimation.statusCrossfadeCurve, value: settings.globalEnabled)
+                .animation(
+                    reduceMotion ? nil : AppAnimation.statusCrossfadeCurve,
+                    value: settings.globalEnabled
+                )
             }
 
             Spacer()
@@ -406,7 +414,9 @@ struct TrueInterruptSetupPill: View {
             .padding(.horizontal, AppSpacing.sm)
             .padding(.vertical, AppSpacing.xs)
             .background(AppColor.surface, in: Capsule())
-            .overlay(Capsule().strokeBorder(AppColor.separatorSoft, lineWidth: AppLayout.borderHair))
+            .overlay(
+                Capsule().strokeBorder(AppColor.separatorSoft, lineWidth: AppLayout.borderHair)
+            )
         }
         .frame(minHeight: AppLayout.minTapTarget)
         .contentShape(Rectangle())
@@ -453,7 +463,9 @@ struct TrueInterruptSkippedBanner: View {
                     .frame(minHeight: AppLayout.minTapTarget)
                     .contentShape(Rectangle())
                     .foregroundStyle(AppColor.primaryRest)
-                    .accessibilityHint(Text("home.trueInterrupt.skippedBanner.setUp.hint", bundle: .module))
+                    .accessibilityHint(
+                        Text("home.trueInterrupt.skippedBanner.setUp.hint", bundle: .module)
+                    )
                     .accessibilityIdentifier("home.trueInterrupt.skippedBanner.setUp")
 
                     Button(action: onDismiss) {
@@ -463,7 +475,9 @@ struct TrueInterruptSkippedBanner: View {
                     .frame(minHeight: AppLayout.minTapTarget)
                     .contentShape(Rectangle())
                     .foregroundStyle(AppColor.textSecondary)
-                    .accessibilityHint(Text("home.trueInterrupt.skippedBanner.dismiss.hint", bundle: .module))
+                    .accessibilityHint(
+                        Text("home.trueInterrupt.skippedBanner.dismiss.hint", bundle: .module)
+                    )
                     .accessibilityIdentifier("home.trueInterrupt.skippedBanner.dismiss")
                 }
             }

--- a/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift
@@ -17,14 +17,17 @@ struct OnboardingPermissionView: View {
 
     init(onNext: @escaping () -> Void,
          notificationCenter: NotificationScheduling? = nil,
-         makeNotificationCenter: @escaping () -> NotificationScheduling = { UNUserNotificationCenter.current() },
+         makeNotificationCenter: @escaping () -> NotificationScheduling
+            = { UNUserNotificationCenter.current() },
          requestPermission: (() async -> Void)? = nil,
          accessibilityEnabledOverride: Bool? = nil) {
         self.onNext = onNext
         let resolvedNotificationCenter = notificationCenter ?? makeNotificationCenter()
         self.requestPermission = requestPermission ?? {
             do {
-                _ = try await resolvedNotificationCenter.requestAuthorization(options: [.alert, .sound, .badge])
+                _ = try await resolvedNotificationCenter.requestAuthorization(
+                    options: [.alert, .sound, .badge]
+                )
             } catch {
                 Logger.scheduling.error("Notification permission request failed: \(error)")
             }
@@ -70,7 +73,9 @@ struct OnboardingPermissionView: View {
                     .buttonStyle(.primary)
                     .padding(.horizontal, AppSpacing.xl)
                     .accessibilityLabel(Text("onboarding.permission.enableButton", bundle: .module))
-                    .accessibilityHint(Text("onboarding.permission.enableButton.hint", bundle: .module))
+                    .accessibilityHint(
+                        Text("onboarding.permission.enableButton.hint", bundle: .module)
+                    )
                     .accessibilityIdentifier("onboarding.enableNotifications")
 
                     // Secondary option — no system prompt, just advance
@@ -78,8 +83,12 @@ struct OnboardingPermissionView: View {
                         Text("onboarding.permission.skipButton", bundle: .module)
                     }
                         .buttonStyle(.secondary)
-                        .accessibilityLabel(Text("onboarding.permission.skipButton", bundle: .module))
-                        .accessibilityHint(Text("onboarding.permission.skipButton.hint", bundle: .module))
+                        .accessibilityLabel(
+                            Text("onboarding.permission.skipButton", bundle: .module)
+                        )
+                        .accessibilityHint(
+                            Text("onboarding.permission.skipButton.hint", bundle: .module)
+                        )
                         .accessibilityIdentifier("onboarding.permission.nextButton")
                 }
                 .padding(AppSpacing.md)
@@ -120,7 +129,10 @@ private struct NotificationPreviewCard: View {
                     .symbolRenderingMode(.hierarchical)
                     .font(AppFont.caption)
                     .foregroundStyle(AppColor.primaryRest)
-                    .frame(width: AppLayout.decorativeIconFrame, height: AppLayout.decorativeIconFrame)
+                    .frame(
+                        width: AppLayout.decorativeIconFrame,
+                        height: AppLayout.decorativeIconFrame
+                    )
                     .background(
                         RoundedRectangle(cornerRadius: AppLayout.radiusSmall, style: .continuous)
                             .fill(AppColor.surfaceTint)

--- a/EyePostureReminder/Views/Onboarding/OnboardingSetupView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingSetupView.swift
@@ -34,7 +34,10 @@ struct OnboardingSetupView: View {
                     OnboardingReminderPickerCard(
                         icon: AppSymbol.eyeBreak,
                         color: AppColor.primaryRest,
-                        title: String(localized: "onboarding.setup.eyeBreaks.title", bundle: .module),
+                        title: String(
+                            localized: "onboarding.setup.eyeBreaks.title",
+                            bundle: .module
+                        ),
                         typeID: "eyes",
                         intervalKey: .eyesInterval,
                         durationKey: .eyesBreakDuration,
@@ -44,7 +47,10 @@ struct OnboardingSetupView: View {
                     OnboardingReminderPickerCard(
                         icon: AppSymbol.postureCheck,
                         color: AppColor.secondaryCalm,
-                        title: String(localized: "onboarding.setup.postureChecks.title", bundle: .module),
+                        title: String(
+                            localized: "onboarding.setup.postureChecks.title",
+                            bundle: .module
+                        ),
                         typeID: "posture",
                         intervalKey: .postureInterval,
                         durationKey: .postureBreakDuration,
@@ -92,7 +98,8 @@ private struct OnboardingReminderPickerCard: View {
     let icon: String
     let color: Color
     let title: String
-    /// Stable, localisation-safe identifier used for accessibility identifiers (e.g. "eyes", "posture").
+    /// Stable, localisation-safe identifier used for accessibility identifiers (e.g. "eyes",
+    /// "posture").
     let typeID: String
     let intervalKey: AnalyticsEvent.SettingKey
     let durationKey: AnalyticsEvent.SettingKey
@@ -110,7 +117,10 @@ private struct OnboardingReminderPickerCard: View {
                     .symbolRenderingMode(.hierarchical)
                     .font(AppFont.reminderCardIcon)
                     .foregroundStyle(color)
-                    .frame(width: AppLayout.decorativeIconFrame, height: AppLayout.decorativeIconFrame)
+                    .frame(
+                        width: AppLayout.decorativeIconFrame,
+                        height: AppLayout.decorativeIconFrame
+                    )
                     .background(
                         RoundedRectangle(cornerRadius: AppLayout.radiusSmall, style: .continuous)
                             .fill(AppColor.surfaceTint)
@@ -125,7 +135,10 @@ private struct OnboardingReminderPickerCard: View {
             Divider()
 
             // Interval picker — how often the reminder fires
-            Picker(String(localized: "onboarding.setup.picker.every", bundle: .module), selection: $interval) {
+            Picker(
+                String(localized: "onboarding.setup.picker.every", bundle: .module),
+                selection: $interval
+            ) {
                 ForEach(SettingsViewModel.intervalOptions, id: \.self) { seconds in
                     Text(SettingsViewModel.labelForInterval(seconds)).tag(seconds)
                 }
@@ -133,7 +146,10 @@ private struct OnboardingReminderPickerCard: View {
             .accessibilityIdentifier("onboarding.\(typeID).intervalPicker")
             .accessibilityHint(
                 String(
-                    format: String(localized: "settings.reminder.intervalPicker.hint", bundle: .module),
+                    format: String(
+                        localized: "settings.reminder.intervalPicker.hint",
+                        bundle: .module
+                    ),
                     title
                 )
             )
@@ -147,7 +163,10 @@ private struct OnboardingReminderPickerCard: View {
             }
 
             // Break duration picker — how long each break lasts
-            Picker(String(localized: "onboarding.setup.picker.breakFor", bundle: .module), selection: $breakDuration) {
+            Picker(
+                String(localized: "onboarding.setup.picker.breakFor", bundle: .module),
+                selection: $breakDuration
+            ) {
                 ForEach(SettingsViewModel.breakDurationOptions, id: \.self) { seconds in
                     Text(SettingsViewModel.labelForBreakDuration(seconds)).tag(seconds)
                 }
@@ -155,7 +174,10 @@ private struct OnboardingReminderPickerCard: View {
             .accessibilityIdentifier("onboarding.\(typeID).durationPicker")
             .accessibilityHint(
                 String(
-                    format: String(localized: "settings.reminder.durationPicker.hint", bundle: .module),
+                    format: String(
+                        localized: "settings.reminder.durationPicker.hint",
+                        bundle: .module
+                    ),
                     title
                 )
             )

--- a/EyePostureReminder/Views/Onboarding/OnboardingView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingView.swift
@@ -23,7 +23,8 @@ struct OnboardingView: View {
             LiveAccessibilityNotificationPoster()
         }
     ) {
-        self.accessibilityNotificationPoster = accessibilityNotificationPoster ?? makeAccessibilityNotificationPoster()
+        self.accessibilityNotificationPoster =
+            accessibilityNotificationPoster ?? makeAccessibilityNotificationPoster()
     }
 
     private static let configurePageControl: Void = {

--- a/EyePostureReminder/Views/Onboarding/OnboardingWelcomeView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingWelcomeView.swift
@@ -15,7 +15,9 @@ struct OnboardingWelcomeView: View {
 
                     YinYangEyeView()
                         .accessibilityElement(children: .ignore)
-                        .accessibilityLabel(Text("onboarding.welcome.illustrationLabel", bundle: .module))
+                        .accessibilityLabel(
+                            Text("onboarding.welcome.illustrationLabel", bundle: .module)
+                        )
 
                     // Headline + Subheadline
                     VStack(spacing: AppSpacing.sm) {
@@ -46,7 +48,10 @@ struct OnboardingWelcomeView: View {
                         .padding(.vertical, AppSpacing.sm)
                         .background(
                             AppColor.surfaceTint,
-                            in: RoundedRectangle(cornerRadius: AppLayout.radiusCard, style: .continuous)
+                            in: RoundedRectangle(
+                                cornerRadius: AppLayout.radiusCard,
+                                style: .continuous
+                            )
                         )
                         .accessibilityIdentifier("onboarding.welcome.disclaimer")
 

--- a/EyePostureReminder/Views/OverlayView.swift
+++ b/EyePostureReminder/Views/OverlayView.swift
@@ -107,7 +107,8 @@ struct OverlayView: View {
         .accessibilityIdentifier("overlay.dismissButton")
     }
 
-    /// Vertically-centered content stack containing the icon, headline, countdown, and action buttons.
+    /// Vertically-centered content stack containing the icon, headline, countdown, and action
+    /// buttons.
     private var centerContent: some View {
         VStack(spacing: AppSpacing.lg) {
             Spacer()
@@ -314,7 +315,8 @@ struct OverlayView: View {
         reduceMotionOverride ?? reduceMotion
     }
 
-    /// Starts a one-second repeating timer that decrements `secondsRemaining` and triggers auto-dismiss at zero.
+    /// Starts a one-second repeating timer that decrements `secondsRemaining` and triggers
+    /// auto-dismiss at zero.
     private func startTimer() {
         guard timer == nil else { return }
         let newTimer = Timer(timeInterval: 1, repeats: true) { _ in

--- a/EyePostureReminder/Views/ReminderRowView.swift
+++ b/EyePostureReminder/Views/ReminderRowView.swift
@@ -27,7 +27,8 @@ struct ReminderRowView: View {
         breakDuration: Binding<TimeInterval>,
         onChanged: @escaping () -> Void,
         reduceMotionOverride: Bool? = nil,
-        accessibilityNotificationPoster: AccessibilityNotificationPosting = LiveAccessibilityNotificationPoster()
+        accessibilityNotificationPoster: AccessibilityNotificationPosting
+            = LiveAccessibilityNotificationPoster()
     ) {
         self.type = type
         _isEnabled = isEnabled
@@ -47,10 +48,16 @@ struct ReminderRowView: View {
                 accessibilityHint: Text(
                     isEnabled
                         ? String(
-                            format: String(localized: "settings.reminder.toggle.enabled.hint", bundle: .module),
+                            format: String(
+                                localized: "settings.reminder.toggle.enabled.hint",
+                                bundle: .module
+                            ),
                             type.title)
                         : String(
-                            format: String(localized: "settings.reminder.toggle.disabled.hint", bundle: .module),
+                            format: String(
+                                localized: "settings.reminder.toggle.disabled.hint",
+                                bundle: .module
+                            ),
                             type.title)
                 ),
                 onChange: { _ in onChanged() },
@@ -60,7 +67,10 @@ struct ReminderRowView: View {
             )
 
             if isEnabled {
-                Picker(String(localized: "settings.reminder.intervalPicker", bundle: .module), selection: $interval) {
+                Picker(
+                    String(localized: "settings.reminder.intervalPicker", bundle: .module),
+                    selection: $interval
+                ) {
                     ForEach(SettingsViewModel.intervalOptions, id: \.self) { seconds in
                         Text(formatInterval(seconds)).tag(seconds)
                     }
@@ -68,7 +78,10 @@ struct ReminderRowView: View {
                 .onChangeCompat(of: interval) { _ in onChanged() }
                 .accessibilityHint(
                     String(
-                        format: String(localized: "settings.reminder.intervalPicker.hint", bundle: .module),
+                        format: String(
+                            localized: "settings.reminder.intervalPicker.hint",
+                            bundle: .module
+                        ),
                         type.title
                     )
                 )
@@ -85,7 +98,10 @@ struct ReminderRowView: View {
                 .onChangeCompat(of: breakDuration) { _ in onChanged() }
                 .accessibilityHint(
                     String(
-                        format: String(localized: "settings.reminder.durationPicker.hint", bundle: .module),
+                        format: String(
+                            localized: "settings.reminder.durationPicker.hint",
+                            bundle: .module
+                        ),
                         type.title
                     )
                 )
@@ -96,8 +112,14 @@ struct ReminderRowView: View {
         // Announce picker visibility change to VoiceOver when the reminder is toggled (#432).
         .onChangeCompat(of: isEnabled) { newValue in
             let message = newValue
-                ? String(localized: "settings.reminder.pickers.visible.announcement", bundle: .module)
-                : String(localized: "settings.reminder.pickers.hidden.announcement", bundle: .module)
+                ? String(
+                    localized: "settings.reminder.pickers.visible.announcement",
+                    bundle: .module
+                )
+                : String(
+                    localized: "settings.reminder.pickers.hidden.announcement",
+                    bundle: .module
+                )
             accessibilityNotificationPoster.postAnnouncement(message: message)
         }
     }


### PR DESCRIPTION
## Summary

Apply Google Swift Style §Column Limit and §Line-Wrapping to Views + ViewModels. All previously-flagged lines now fit within the 100-character column limit. Edits are formatting-only — no behavioural or API changes.

## Files updated

- `EyePostureReminder/Views/Components.swift` — wrap `.animation` modifier args; extract complex `.opacity` ternary; wrap doc comment.
- `EyePostureReminder/Views/DesignSystem.swift` — break long `Bundle.module.url(...)` call across args; wrap doc comments at column 100; break long static font declarations after `=`.
- `EyePostureReminder/Views/HomeView.swift` — wrap `@AppStorage` attribute, init parameter defaults, `.animation`, `.overlay`, and `.accessibilityHint(Text(...))` modifier args.
- `EyePostureReminder/Views/OverlayView.swift` — wrap two long doc comments using `///` continuation.
- `EyePostureReminder/Views/ReminderRowView.swift` — wrap inline `String(localized:bundle:)` inside `format` args; wrap `Picker(label:selection:)` args; wrap announcement message expressions.
- `EyePostureReminder/Views/Onboarding/OnboardingPermissionView.swift` — wrap notificationCenter factory default, `requestAuthorization` options, `accessibilityHint/Label` Text args, and `Image.frame(width:height:)`.
- `EyePostureReminder/Views/Onboarding/OnboardingSetupView.swift` — wrap `String(localized:bundle:)` inside `OnboardingReminderPickerCard` inits, `Picker` args, `Image.frame`, and doc comment.
- `EyePostureReminder/Views/Onboarding/OnboardingView.swift` — break long `??` assignment after `=`.
- `EyePostureReminder/Views/Onboarding/OnboardingWelcomeView.swift` — wrap `accessibilityLabel(Text(...))` and `RoundedRectangle(cornerRadius:style:)` args.

## Verification

- `./scripts/build.sh all` → ✅ all 2075 tests pass, no warnings, no failures (105 s).
- `awk 'length>100' …` over the 9 touched files → ✅ no remaining violations.

## References

- Parent audit: #646
- Standard: [docs/google_swift_coding_style.md](https://github.com/yashasg/fantastic-octo-fortnight/blob/main/docs/google_swift_coding_style.md) — §Column Limit, §Line-Wrapping

Closes #650