### PR TITLE
Define TCA dependency clients for app services (#665)

### DIFF
--- a/EyePostureReminder/TCA/Dependencies/AnalyticsClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/AnalyticsClient.swift
@@ -1,0 +1,28 @@
+import ComposableArchitecture
+import Foundation
+
+/// TCA dependency client wrapping `AnalyticsLogger` for reducer consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The `liveValue` adapter
+/// forwards every emitted event to the existing static `AnalyticsLogger.log`
+/// sink so reducers and the legacy MVVM stack share a single os.Logger
+/// pipeline during the migration.
+@DependencyClient
+struct AnalyticsClient: Sendable {
+    /// Synchronously emits an analytics event to the shared `os.Logger` sink.
+    var log: @Sendable (AnalyticsEvent) -> Void
+}
+
+extension AnalyticsClient: DependencyKey {
+    static let liveValue = AnalyticsClient(
+        log: { event in AnalyticsLogger.log(event) }
+    )
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `AnalyticsClient`.
+    var analyticsClient: AnalyticsClient {
+        get { self[AnalyticsClient.self] }
+        set { self[AnalyticsClient.self] = newValue }
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/DeviceActivityMonitorClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/DeviceActivityMonitorClient.swift
@@ -1,0 +1,62 @@
+import ComposableArchitecture
+import Foundation
+
+/// TCA dependency client wrapping `DeviceActivityMonitorProviding` for reducer
+/// consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The pre-entitlement default
+/// implementation is `DeviceActivityMonitorNoop`, so the `liveValue` adapter
+/// effectively becomes a noop until the FamilyControls entitlement (#201) is
+/// provisioned. The `UUID` argument carried by the closures is part of the
+/// normative Phase 1 contract — Phase 1 will key sessions by that identifier.
+@DependencyClient
+struct DeviceActivityMonitorClient: Sendable {
+    /// Schedules a DeviceActivity monitoring window for the supplied break
+    /// session. The `UUID` keys the session for later cancellation.
+    var schedule: @Sendable (ShieldSession, UUID) async -> Void
+
+    /// Cancels the active DeviceActivity monitoring window. When `nil`, every
+    /// active session is cancelled.
+    var cancel: @Sendable (UUID?) async -> Void
+}
+
+extension DeviceActivityMonitorClient: DependencyKey {
+    static let liveValue: DeviceActivityMonitorClient = {
+        Task { @MainActor in _ = LiveDeviceActivityMonitorBridge.shared }
+        return DeviceActivityMonitorClient(
+            schedule: { session, _ in
+                await LiveDeviceActivityMonitorBridge.shared.schedule(session)
+            },
+            cancel: { _ in
+                await LiveDeviceActivityMonitorBridge.shared.cancel()
+            }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `DeviceActivityMonitorClient`.
+    var deviceActivityMonitorClient: DeviceActivityMonitorClient {
+        get { self[DeviceActivityMonitorClient.self] }
+        set { self[DeviceActivityMonitorClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `DeviceActivityMonitorProviding`
+/// implementation. Defaults to the pre-entitlement noop until #201 lands.
+@MainActor
+private final class LiveDeviceActivityMonitorBridge {
+    static let shared = LiveDeviceActivityMonitorBridge()
+
+    let monitor: DeviceActivityMonitorProviding = DeviceActivityMonitorNoop()
+
+    private init() {}
+
+    func schedule(_ session: ShieldSession) async {
+        try? await monitor.scheduleBreakMonitoring(for: session)
+    }
+
+    func cancel() async {
+        try? await monitor.cancelBreakMonitoring()
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/IPCClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/IPCClient.swift
@@ -1,0 +1,129 @@
+import ComposableArchitecture
+import Foundation
+import os
+import ScreenTimeExtensionShared
+
+/// TCA dependency client wrapping `AppGroupIPCStore` for reducer consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The `liveValue` adapter
+/// installs a single `NotificationCenter` observer for the
+/// `trueInterruptEnabledDidChange` notification that multicasts to every
+/// active `trueInterruptChanges` subscriber via per-subscriber `AsyncStream`
+/// continuations. The optional `String` argument carried by `record` is the
+/// caller-supplied operation context — it is preserved in the failure log
+/// emitted when `recordEvent` throws.
+@DependencyClient
+struct IPCClient: Sendable {
+    /// Whether the user has toggled on the True Interrupt (DeviceActivity
+    /// shield) feature in Settings. Reads the App Group flag synchronously.
+    var isTrueInterruptEnabled: @Sendable () async -> Bool = { false }
+
+    /// Records an IPC event to the shared App Group store. The optional
+    /// `String` second argument is a free-form caller-supplied operation
+    /// context preserved in the failure log if the underlying write fails.
+    var record: @Sendable (AppGroupIPCEvent, String?) async -> Void
+
+    /// Multicast stream of `trueInterruptEnabled` flag transitions. A new
+    /// subscriber receives every subsequent change until the consumer
+    /// terminates.
+    var trueInterruptChanges: @Sendable () -> AsyncStream<Bool> = { .finished }
+}
+
+extension IPCClient: DependencyKey {
+    static let liveValue: IPCClient = {
+        Task { @MainActor in LiveIPCBridge.shared.bootstrap() }
+        return IPCClient(
+            isTrueInterruptEnabled: {
+                await MainActor.run { LiveIPCBridge.shared.store.isTrueInterruptEnabled() }
+            },
+            record: { event, context in
+                await MainActor.run { LiveIPCBridge.shared.record(event, context: context) }
+            },
+            trueInterruptChanges: { makeTrueInterruptStream() }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `IPCClient`.
+    var ipcClient: IPCClient {
+        get { self[IPCClient.self] }
+        set { self[IPCClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `AppGroupIPCStore`. Subscribes to
+/// `trueInterruptEnabledDidChange` notifications and forwards them to the
+/// file-scope continuation registry.
+@MainActor
+private final class LiveIPCBridge {
+    nonisolated static let shared = LiveIPCBridge()
+
+    let store = AppGroupIPCStore()
+    private var observer: NSObjectProtocol?
+    private var hasBootstrapped = false
+
+    private nonisolated init() {}
+
+    func bootstrap() {
+        guard !hasBootstrapped else { return }
+        hasBootstrapped = true
+
+        observer = NotificationCenter.default.addObserver(
+            forName: AppGroupIPCStore.trueInterruptEnabledDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { notification in
+            let value = (notification.userInfo?[
+                AppGroupIPCStore.trueInterruptEnabledValueUserInfoKey
+            ] as? Bool) ?? false
+            broadcastTrueInterruptChange(value)
+        }
+    }
+
+    deinit {
+        if let observer { NotificationCenter.default.removeObserver(observer) }
+    }
+
+    func record(_ event: AppGroupIPCEvent, context: String?) {
+        do {
+            try store.recordEvent(event)
+        } catch {
+            AnalyticsLogger.log(
+                .ipcOperationFailed(operation: .writeEvent, reason: .writeFailed)
+            )
+            ipcLogger.error("""
+                event=ipc_record_failed \
+                kind=\(event.kind.rawValue, privacy: .public) \
+                context=\(context ?? "nil", privacy: .public)
+                """)
+        }
+    }
+}
+
+/// File-scoped multicast continuations for `IPCClient.trueInterruptChanges`.
+private let trueInterruptContinuations =
+    LockIsolated<[UUID: AsyncStream<Bool>.Continuation]>([:])
+
+private let ipcLogger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.yashasgujjar.eyeposture",
+    category: "IPCClient"
+)
+
+private func makeTrueInterruptStream() -> AsyncStream<Bool> {
+    let (stream, continuation) = AsyncStream<Bool>.makeStream()
+    let id = UUID()
+    trueInterruptContinuations.withValue { $0[id] = continuation }
+    continuation.onTermination = { _ in
+        trueInterruptContinuations.withValue { dict in
+            dict[id] = nil
+        }
+    }
+    return stream
+}
+
+private func broadcastTrueInterruptChange(_ value: Bool) {
+    trueInterruptContinuations.withValue { dict in
+        for continuation in dict.values { continuation.yield(value) }
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/NotificationClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/NotificationClient.swift
@@ -1,0 +1,69 @@
+import ComposableArchitecture
+import Foundation
+import UserNotifications
+
+/// TCA dependency client wrapping `UNUserNotificationCenter` for reducer
+/// consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The `liveValue` adapter
+/// forwards every call to `UNUserNotificationCenter.current()`, matching the
+/// signatures expected by Phase 1 reducers.
+@DependencyClient
+struct NotificationClient: Sendable {
+    /// Requests authorisation with the given options. Returns whether the user
+    /// granted at least the requested set.
+    var requestAuthorization: @Sendable (UNAuthorizationOptions) async throws -> Bool
+
+    /// Returns the current authorisation status without prompting.
+    var authorizationStatus: @Sendable () async -> UNAuthorizationStatus = { .notDetermined }
+
+    /// Adds a new notification request to the system queue.
+    var add: @Sendable (UNNotificationRequest) async throws -> Void
+
+    /// Removes pending notifications by identifier.
+    var removePending: @Sendable ([String]) async -> Void
+
+    /// Removes every pending notification.
+    var removeAllPending: @Sendable () async -> Void
+
+    /// Returns the currently queued (pending) notification requests.
+    var pendingRequests: @Sendable () async -> [UNNotificationRequest] = { [] }
+
+    /// Returns the currently delivered notifications still in Notification Center.
+    var deliveredNotifications: @Sendable () async -> [UNNotification] = { [] }
+}
+
+extension NotificationClient: DependencyKey {
+    static let liveValue = NotificationClient(
+        requestAuthorization: { options in
+            try await UNUserNotificationCenter.current().requestAuthorization(options: options)
+        },
+        authorizationStatus: {
+            await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+        },
+        add: { request in
+            try await UNUserNotificationCenter.current().add(request)
+        },
+        removePending: { identifiers in
+            UNUserNotificationCenter.current()
+                .removePendingNotificationRequests(withIdentifiers: identifiers)
+        },
+        removeAllPending: {
+            UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+        },
+        pendingRequests: {
+            await UNUserNotificationCenter.current().pendingNotificationRequests()
+        },
+        deliveredNotifications: {
+            await UNUserNotificationCenter.current().deliveredNotifications()
+        }
+    )
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `NotificationClient`.
+    var notificationClient: NotificationClient {
+        get { self[NotificationClient.self] }
+        set { self[NotificationClient.self] = newValue }
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/OverlayClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/OverlayClient.swift
@@ -1,0 +1,136 @@
+import ComposableArchitecture
+import Foundation
+
+/// Lifecycle events emitted by the overlay layer for reducer consumption.
+///
+/// The Phase 0 adapter multicasts these events from the live `OverlayManager`'s
+/// `OverlayLifecycleCallbacks` so multiple reducers can subscribe independently.
+enum OverlayLifecycleEvent: Equatable, Sendable {
+    /// The overlay for the given reminder type has been presented on screen.
+    case presented(ReminderType)
+    /// The overlay for the given reminder type has been dismissed.
+    case dismissed(ReminderType)
+    /// The user tapped the "Settings" affordance inside the overlay for the
+    /// given reminder type.
+    case settingsTapped(ReminderType)
+}
+
+/// TCA dependency client wrapping `OverlayManager` for reducer consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The `liveValue` adapter
+/// installs a single set of `OverlayLifecycleCallbacks` per `show` call that
+/// multicasts to every active `lifecycleEvents` subscriber via per-subscriber
+/// `AsyncStream` continuations.
+@DependencyClient
+struct OverlayClient: Sendable {
+    /// Presents (or queues) the break overlay for the given reminder type.
+    /// Parameters: type, duration in seconds, haptics enabled, pause-media
+    /// enabled.
+    var show: @Sendable (ReminderType, TimeInterval, Bool, Bool) async -> Void
+
+    /// Dismisses the overlay if currently visible.
+    var dismiss: @Sendable () async -> Void
+
+    /// Drops every queued overlay request.
+    var clearQueue: @Sendable () async -> Void
+
+    /// Drops queued overlay requests for the given reminder type only.
+    var clearQueueForType: @Sendable (ReminderType) async -> Void
+
+    /// Whether the overlay window is currently on screen.
+    var isVisible: @Sendable () async -> Bool = { false }
+
+    /// Multicast stream of `OverlayLifecycleEvent`s. Each subscriber receives
+    /// every event from the moment subscription begins.
+    var lifecycleEvents: @Sendable () -> AsyncStream<OverlayLifecycleEvent> = { .finished }
+}
+
+extension OverlayClient: DependencyKey {
+    static let liveValue: OverlayClient = {
+        Task { @MainActor in _ = LiveOverlayBridge.shared }
+        return OverlayClient(
+            show: { type, duration, hapticsEnabled, pauseMediaEnabled in
+                await LiveOverlayBridge.shared.show(
+                    type: type,
+                    duration: duration,
+                    hapticsEnabled: hapticsEnabled,
+                    pauseMediaEnabled: pauseMediaEnabled
+                )
+            },
+            dismiss: { await LiveOverlayBridge.shared.dismiss() },
+            clearQueue: { await LiveOverlayBridge.shared.clearQueue() },
+            clearQueueForType: { type in
+                await LiveOverlayBridge.shared.clearQueue(for: type)
+            },
+            isVisible: { await LiveOverlayBridge.shared.isVisible() },
+            lifecycleEvents: { makeOverlayLifecycleStream() }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `OverlayClient`.
+    var overlayClient: OverlayClient {
+        get { self[OverlayClient.self] }
+        set { self[OverlayClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `OverlayManager`. Each `show` call
+/// installs callbacks that multicast lifecycle events to file-scope
+/// continuations so any number of subscribers can observe the overlay.
+@MainActor
+private final class LiveOverlayBridge {
+    nonisolated static let shared = LiveOverlayBridge()
+
+    let manager: OverlayPresenting = OverlayManager()
+
+    private nonisolated init() {}
+
+    func show(
+        type: ReminderType,
+        duration: TimeInterval,
+        hapticsEnabled: Bool,
+        pauseMediaEnabled: Bool
+    ) {
+        let callbacks = OverlayLifecycleCallbacks(
+            onPresent: { broadcastOverlayEvent(.presented(type)) },
+            onDismiss: { broadcastOverlayEvent(.dismissed(type)) },
+            onSettingsTap: { broadcastOverlayEvent(.settingsTapped(type)) }
+        )
+        manager.showOverlay(
+            for: type,
+            duration: duration,
+            hapticsEnabled: hapticsEnabled,
+            pauseMediaEnabled: pauseMediaEnabled,
+            callbacks: callbacks
+        )
+    }
+
+    func dismiss() { manager.dismissOverlay() }
+    func clearQueue() { manager.clearQueue() }
+    func clearQueue(for type: ReminderType) { manager.clearQueue(for: type) }
+    func isVisible() -> Bool { manager.isOverlayVisible }
+}
+
+/// File-scoped multicast continuations for `OverlayClient.lifecycleEvents`.
+private let overlayLifecycleContinuations =
+    LockIsolated<[UUID: AsyncStream<OverlayLifecycleEvent>.Continuation]>([:])
+
+private func makeOverlayLifecycleStream() -> AsyncStream<OverlayLifecycleEvent> {
+    let (stream, continuation) = AsyncStream<OverlayLifecycleEvent>.makeStream()
+    let id = UUID()
+    overlayLifecycleContinuations.withValue { $0[id] = continuation }
+    continuation.onTermination = { _ in
+        overlayLifecycleContinuations.withValue { dict in
+            dict[id] = nil
+        }
+    }
+    return stream
+}
+
+private func broadcastOverlayEvent(_ event: OverlayLifecycleEvent) {
+    overlayLifecycleContinuations.withValue { dict in
+        for continuation in dict.values { continuation.yield(event) }
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/PauseConditionClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/PauseConditionClient.swift
@@ -1,0 +1,107 @@
+import ComposableArchitecture
+import Foundation
+
+/// TCA dependency client wrapping `PauseConditionManager` for reducer
+/// consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The `liveValue` adapter
+/// installs a single `onPauseStateChanged` closure on the underlying manager
+/// that multicasts to every active `pauseChanges` subscriber via
+/// per-subscriber `AsyncStream` continuations.
+@DependencyClient
+struct PauseConditionClient: Sendable {
+    /// Whether the current aggregate pause state is active.
+    var isPaused: @Sendable () async -> Bool = { false }
+
+    /// Multicast stream of aggregate pause-state transitions.
+    var pauseChanges: @Sendable () -> AsyncStream<Bool> = { .finished }
+
+    /// Begins monitoring focus, CarPlay, and driving conditions.
+    var startMonitoring: @Sendable () async -> Void
+
+    /// Stops monitoring and clears the active condition set.
+    var stopMonitoring: @Sendable () async -> Void
+}
+
+extension PauseConditionClient: DependencyKey {
+    static let liveValue: PauseConditionClient = {
+        Task { @MainActor in LivePauseConditionBridge.shared.bootstrap() }
+        return PauseConditionClient(
+            isPaused: { await LivePauseConditionBridge.shared.isPaused() },
+            pauseChanges: { makePauseConditionStream() },
+            startMonitoring: { await LivePauseConditionBridge.shared.startMonitoring() },
+            stopMonitoring: { await LivePauseConditionBridge.shared.stopMonitoring() }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `PauseConditionClient`.
+    var pauseConditionClient: PauseConditionClient {
+        get { self[PauseConditionClient.self] }
+        set { self[PauseConditionClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `PauseConditionManager`. Multicasts
+/// `onPauseStateChanged` callbacks into file-scope continuations.
+@MainActor
+private final class LivePauseConditionBridge {
+    nonisolated static let shared = LivePauseConditionBridge()
+
+    private var manager: PauseConditionProviding?
+    private var hasBootstrapped = false
+
+    private nonisolated init() {}
+
+    func bootstrap() {
+        guard !hasBootstrapped else { return }
+        hasBootstrapped = true
+
+        let settings = SettingsStore()
+        let live = PauseConditionManager(
+            settings: settings,
+            focusDetector: LiveFocusStatusDetector(),
+            carPlayDetector: LiveCarPlayDetector(),
+            drivingDetector: LiveDrivingActivityDetector()
+        )
+        live.onPauseStateChanged = { paused in
+            broadcastPauseChange(paused)
+        }
+        manager = live
+    }
+
+    func isPaused() -> Bool {
+        manager?.isPaused ?? false
+    }
+
+    func startMonitoring() {
+        manager?.startMonitoring()
+    }
+
+    func stopMonitoring() {
+        manager?.stopMonitoring()
+    }
+}
+
+/// File-scoped multicast continuations for `PauseConditionClient.pauseChanges`.
+private let pauseConditionContinuations =
+    LockIsolated<[UUID: AsyncStream<Bool>.Continuation]>([:])
+
+private func makePauseConditionStream() -> AsyncStream<Bool> {
+    let (stream, continuation) = AsyncStream<Bool>.makeStream()
+    let id = UUID()
+    pauseConditionContinuations.withValue { $0[id] = continuation }
+    continuation.onTermination = { _ in
+        pauseConditionContinuations.withValue { dict in
+            dict[id] = nil
+        }
+    }
+    return stream
+}
+
+private func broadcastPauseChange(_ paused: Bool) {
+    pauseConditionContinuations.withValue { dict in
+        for continuation in dict.values { continuation.yield(paused) }
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/ReminderSchedulerClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/ReminderSchedulerClient.swift
@@ -1,0 +1,82 @@
+import ComposableArchitecture
+import Foundation
+
+/// TCA dependency client wrapping `ReminderScheduler` for reducer consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The `liveValue` adapter routes
+/// scheduling calls through the existing `@MainActor` `ReminderScheduler`,
+/// which itself reads the live `SettingsStore` snapshot. The `ReminderSettings`
+/// argument carried by the closures is part of the normative Phase 1 contract
+/// — Phase 1 will refactor `ReminderScheduler` to honour it directly.
+@DependencyClient
+struct ReminderSchedulerClient: Sendable {
+    /// Schedules every enabled reminder type using the supplied baseline
+    /// settings. The Phase 0 adapter delegates to the live `ReminderScheduler`,
+    /// which reads the shared `SettingsStore`.
+    var scheduleReminders: @Sendable (ReminderSettings) async -> Void
+
+    /// Reschedules a single reminder type after settings have changed.
+    var rescheduleReminder: @Sendable (ReminderType, ReminderSettings) async -> Void
+
+    /// Cancels all pending reminders for the given type.
+    var cancelReminder: @Sendable (ReminderType) async -> Void
+
+    /// Cancels every pending reminder unconditionally.
+    var cancelAllReminders: @Sendable () async -> Void
+}
+
+extension ReminderSchedulerClient: DependencyKey {
+    static let liveValue: ReminderSchedulerClient = {
+        Task { @MainActor in _ = LiveReminderSchedulerBridge.shared }
+        return ReminderSchedulerClient(
+            scheduleReminders: { _ in
+                await LiveReminderSchedulerBridge.shared.scheduleAll()
+            },
+            rescheduleReminder: { type, _ in
+                await LiveReminderSchedulerBridge.shared.reschedule(type)
+            },
+            cancelReminder: { type in
+                await LiveReminderSchedulerBridge.shared.cancel(type)
+            },
+            cancelAllReminders: {
+                await LiveReminderSchedulerBridge.shared.cancelAll()
+            }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `ReminderSchedulerClient`.
+    var reminderSchedulerClient: ReminderSchedulerClient {
+        get { self[ReminderSchedulerClient.self] }
+        set { self[ReminderSchedulerClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `ReminderScheduler` and the
+/// `SettingsStore` it reads from. Lazily instantiated on first reducer call.
+@MainActor
+private final class LiveReminderSchedulerBridge {
+    static let shared = LiveReminderSchedulerBridge()
+
+    let settings = SettingsStore()
+    let scheduler: ReminderScheduling = ReminderScheduler()
+
+    private init() {}
+
+    func scheduleAll() async {
+        await scheduler.scheduleReminders(using: settings)
+    }
+
+    func reschedule(_ type: ReminderType) async {
+        await scheduler.rescheduleReminder(for: type, using: settings)
+    }
+
+    func cancel(_ type: ReminderType) {
+        scheduler.cancelReminder(for: type)
+    }
+
+    func cancelAll() {
+        scheduler.cancelAllReminders()
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/ScreenTimeAuthorizationClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/ScreenTimeAuthorizationClient.swift
@@ -1,0 +1,99 @@
+import ComposableArchitecture
+import Foundation
+
+/// TCA dependency client wrapping `ScreenTimeAuthorizationProviding` for
+/// reducer consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The pre-entitlement default
+/// implementation is `ScreenTimeAuthorizationNoop`, which always returns
+/// `.unavailable`; the `liveValue` adapter forwards through that noop until
+/// the FamilyControls entitlement is provisioned (#201).
+@DependencyClient
+struct ScreenTimeAuthorizationClient: Sendable {
+    /// Current authorisation status. Defaults to `.unavailable`.
+    var status: @Sendable () async -> ScreenTimeAuthorizationStatus = { .unavailable }
+
+    /// Multicast stream of authorisation status changes.
+    var statusChanges: @Sendable () -> AsyncStream<ScreenTimeAuthorizationStatus> = { .finished }
+
+    /// Requests authorisation and returns the resulting status.
+    var requestAuthorization: @Sendable () async -> ScreenTimeAuthorizationStatus = {
+        .unavailable
+    }
+}
+
+extension ScreenTimeAuthorizationClient: DependencyKey {
+    static let liveValue: ScreenTimeAuthorizationClient = {
+        Task { @MainActor in _ = LiveScreenTimeAuthorizationBridge.shared }
+        return ScreenTimeAuthorizationClient(
+            status: {
+                await LiveScreenTimeAuthorizationBridge.shared.status()
+            },
+            statusChanges: {
+                makeScreenTimeAuthorizationStream()
+            },
+            requestAuthorization: {
+                await LiveScreenTimeAuthorizationBridge.shared.request()
+            }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `ScreenTimeAuthorizationClient`.
+    var screenTimeAuthorizationClient: ScreenTimeAuthorizationClient {
+        get { self[ScreenTimeAuthorizationClient.self] }
+        set { self[ScreenTimeAuthorizationClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `ScreenTimeAuthorizationProviding`
+/// implementation. Broadcasts every status change observed during a
+/// `requestAuthorization()` call to active stream subscribers.
+@MainActor
+private final class LiveScreenTimeAuthorizationBridge {
+    static let shared = LiveScreenTimeAuthorizationBridge()
+
+    let provider: ScreenTimeAuthorizationProviding = ScreenTimeAuthorizationNoop()
+
+    private init() {}
+
+    func status() -> ScreenTimeAuthorizationStatus {
+        provider.authorizationStatus
+    }
+
+    func request() async -> ScreenTimeAuthorizationStatus {
+        let result = await provider.requestAuthorization()
+        screenTimeAuthorizationContinuations.withValue { dict in
+            for continuation in dict.values { continuation.yield(result) }
+        }
+        return result
+    }
+}
+
+/// File-scoped multicast continuations for `ScreenTimeAuthorizationClient`.
+/// Held outside the `@MainActor` bridge so the nonisolated stream factory can
+/// capture it without crossing actor boundaries — `LockIsolated` already
+/// provides thread safety. Defined at file scope (rather than as a static
+/// property of the bridge class) to side-step a Swift constraint-solver bug
+/// triggered by `Continuation.onTermination` capturing `@MainActor`-isolated
+/// static storage.
+private let screenTimeAuthorizationContinuations =
+    LockIsolated<[UUID: AsyncStream<ScreenTimeAuthorizationStatus>.Continuation]>([:])
+
+/// File-scoped factory used by the live `statusChanges` closure to register a
+/// new multicast subscriber. Lives outside the bridge class so it can be
+/// invoked from a `@Sendable` non-async context.
+private func makeScreenTimeAuthorizationStream()
+    -> AsyncStream<ScreenTimeAuthorizationStatus> {
+    let (stream, continuation) =
+        AsyncStream<ScreenTimeAuthorizationStatus>.makeStream()
+    let id = UUID()
+    screenTimeAuthorizationContinuations.withValue { $0[id] = continuation }
+    continuation.onTermination = { _ in
+        screenTimeAuthorizationContinuations.withValue { dict in
+            dict[id] = nil
+        }
+    }
+    return stream
+}

--- a/EyePostureReminder/TCA/Dependencies/ScreenTimeTrackerClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/ScreenTimeTrackerClient.swift
@@ -1,0 +1,134 @@
+import ComposableArchitecture
+import Foundation
+
+/// TCA dependency client wrapping `ScreenTimeTracker` for reducer consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The `liveValue` adapter installs
+/// a single `onThresholdReached` closure on the underlying tracker that
+/// multicasts to every active `thresholdReached` subscriber via per-subscriber
+/// `AsyncStream` continuations.
+@DependencyClient
+struct ScreenTimeTrackerClient: Sendable {
+    /// Sets the per-type continuous screen-on threshold, in seconds.
+    var setThreshold: @Sendable (TimeInterval, ReminderType) async -> Void
+
+    /// Enables tracking for the given type by re-arming its current threshold.
+    var enableTracking: @Sendable (ReminderType) async -> Void
+
+    /// Disables tracking for the given type and resets its counter.
+    var disableTracking: @Sendable (ReminderType) async -> Void
+
+    /// Pauses tracking for every reminder type.
+    var pauseAll: @Sendable () async -> Void
+
+    /// Resumes tracking for every reminder type.
+    var resumeAll: @Sendable () async -> Void
+
+    /// Resets the elapsed counter for the given reminder type.
+    var reset: @Sendable (ReminderType) async -> Void
+
+    /// Multicast stream of threshold-reached events keyed by reminder type.
+    var thresholdReached: @Sendable () -> AsyncStream<ReminderType> = { .finished }
+}
+
+extension ScreenTimeTrackerClient: DependencyKey {
+    static let liveValue: ScreenTimeTrackerClient = {
+        Task { @MainActor in LiveScreenTimeTrackerBridge.shared.bootstrap() }
+        return ScreenTimeTrackerClient(
+            setThreshold: { interval, type in
+                await MainActor.run {
+                    LiveScreenTimeTrackerBridge.shared.setThreshold(interval, for: type)
+                }
+            },
+            enableTracking: { type in
+                await MainActor.run {
+                    LiveScreenTimeTrackerBridge.shared.enableTracking(for: type)
+                }
+            },
+            disableTracking: { type in
+                await MainActor.run {
+                    LiveScreenTimeTrackerBridge.shared.disableTracking(for: type)
+                }
+            },
+            pauseAll: { await MainActor.run { LiveScreenTimeTrackerBridge.shared.pauseAll() } },
+            resumeAll: { await MainActor.run { LiveScreenTimeTrackerBridge.shared.resumeAll() } },
+            reset: { type in
+                await MainActor.run { LiveScreenTimeTrackerBridge.shared.reset(for: type) }
+            },
+            thresholdReached: { makeScreenTimeThresholdStream() }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `ScreenTimeTrackerClient`.
+    var screenTimeTrackerClient: ScreenTimeTrackerClient {
+        get { self[ScreenTimeTrackerClient.self] }
+        set { self[ScreenTimeTrackerClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `ScreenTimeTracker`. Tracks the most
+/// recent per-type threshold so `enableTracking(_:)` can re-arm without the
+/// caller needing to remember the value.
+@MainActor
+private final class LiveScreenTimeTrackerBridge {
+    nonisolated static let shared = LiveScreenTimeTrackerBridge()
+
+    private var tracker: ScreenTimeTracking?
+    private var thresholds: [ReminderType: TimeInterval] = [:]
+    private var hasBootstrapped = false
+
+    private nonisolated init() {}
+
+    func bootstrap() {
+        guard !hasBootstrapped else { return }
+        hasBootstrapped = true
+
+        let live = ScreenTimeTracker()
+        live.onThresholdReached = { type in
+            broadcastScreenTimeThreshold(type)
+        }
+        tracker = live
+    }
+
+    func setThreshold(_ interval: TimeInterval, for type: ReminderType) {
+        thresholds[type] = interval
+        tracker?.setThreshold(interval, for: type)
+    }
+
+    func enableTracking(for type: ReminderType) {
+        guard let interval = thresholds[type] else { return }
+        tracker?.setThreshold(interval, for: type)
+    }
+
+    func disableTracking(for type: ReminderType) {
+        tracker?.disableTracking(for: type)
+    }
+
+    func pauseAll() { tracker?.pauseAll() }
+    func resumeAll() { tracker?.resumeAll() }
+    func reset(for type: ReminderType) { tracker?.reset(for: type) }
+}
+
+/// File-scoped multicast continuations for `ScreenTimeTrackerClient.thresholdReached`.
+private let screenTimeThresholdContinuations =
+    LockIsolated<[UUID: AsyncStream<ReminderType>.Continuation]>([:])
+
+private func makeScreenTimeThresholdStream() -> AsyncStream<ReminderType> {
+    let (stream, continuation) = AsyncStream<ReminderType>.makeStream()
+    let id = UUID()
+    screenTimeThresholdContinuations.withValue { $0[id] = continuation }
+    continuation.onTermination = { _ in
+        screenTimeThresholdContinuations.withValue { dict in
+            dict[id] = nil
+        }
+    }
+    return stream
+}
+
+private func broadcastScreenTimeThreshold(_ type: ReminderType) {
+    screenTimeThresholdContinuations.withValue { dict in
+        for continuation in dict.values { continuation.yield(type) }
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/SettingsClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/SettingsClient.swift
@@ -1,0 +1,205 @@
+import Combine
+import ComposableArchitecture
+import Foundation
+
+/// TCA dependency client wrapping `SettingsStore` for reducer consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The closure surface is the
+/// normative contract Phase 1 reducers will copy verbatim. The `liveValue`
+/// adapter routes every getter and setter through the existing `@MainActor`
+/// `SettingsStore` so both worlds coexist during the migration.
+@DependencyClient
+struct SettingsClient: Sendable {
+    /// Synchronous snapshot of the latest published `ReminderSettings` for the
+    /// eyes side. The live adapter caches the most recent value so reducers
+    /// can read it without hopping to the main actor.
+    var snapshot: @Sendable () -> ReminderSettings = {
+        ReminderSettings(interval: 0, breakDuration: 0)
+    }
+
+    /// Multicast stream of `ReminderSettings` snapshots. A new subscriber
+    /// receives the current snapshot and every subsequent change.
+    var stream: @Sendable () -> AsyncStream<ReminderSettings> = { .finished }
+
+    /// Toggles the global reminders master switch.
+    var updateGlobalEnabled: @Sendable (Bool) async -> Void
+
+    /// Toggles the eyes reminder type.
+    var updateEyesEnabled: @Sendable (Bool) async -> Void
+
+    /// Toggles the posture reminder type.
+    var updatePostureEnabled: @Sendable (Bool) async -> Void
+
+    /// Updates the eyes reminder interval, in seconds.
+    var updateEyesInterval: @Sendable (TimeInterval) async -> Void
+
+    /// Updates the posture reminder interval, in seconds.
+    var updatePostureInterval: @Sendable (TimeInterval) async -> Void
+
+    /// Updates the eyes break duration, in seconds.
+    var updateEyesBreakDuration: @Sendable (TimeInterval) async -> Void
+
+    /// Updates the posture break duration, in seconds.
+    var updatePostureBreakDuration: @Sendable (TimeInterval) async -> Void
+
+    /// Toggles the "pause media during breaks" feature.
+    var updatePauseMediaDuringBreaks: @Sendable (Bool) async -> Void
+
+    /// Toggles haptics on overlay events.
+    var updateHapticsEnabled: @Sendable (Bool) async -> Void
+
+    /// Toggles "pause during Focus mode".
+    var updatePauseDuringFocus: @Sendable (Bool) async -> Void
+
+    /// Toggles "pause while driving".
+    var updatePauseWhileDriving: @Sendable (Bool) async -> Void
+
+    /// Toggles the notification fallback path.
+    var updateNotificationFallbackEnabled: @Sendable (Bool) async -> Void
+
+    /// Sets the snoozed-until date, or clears snooze when `nil`.
+    var setSnoozedUntil: @Sendable (Date?) async -> Void
+
+    /// Sets the consecutive snooze count.
+    var setSnoozeCount: @Sendable (Int) async -> Void
+
+    /// Restores all settings to the bundled defaults.
+    var resetToDefaults: @Sendable () async -> Void
+}
+
+extension SettingsClient: DependencyKey {
+    static let liveValue: SettingsClient = {
+        Task { @MainActor in LiveSettingsBridge.shared.bootstrap() }
+        return SettingsClient(
+            snapshot: { settingsSnapshotCache.value },
+            stream: { makeSettingsStream() },
+            updateGlobalEnabled: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.globalEnabled = value }
+            },
+            updateEyesEnabled: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.eyesEnabled = value }
+            },
+            updatePostureEnabled: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.postureEnabled = value }
+            },
+            updateEyesInterval: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.eyesInterval = value }
+            },
+            updatePostureInterval: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.postureInterval = value }
+            },
+            updateEyesBreakDuration: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.eyesBreakDuration = value }
+            },
+            updatePostureBreakDuration: { value in
+                await MainActor.run {
+                    LiveSettingsBridge.shared.store.postureBreakDuration = value
+                }
+            },
+            updatePauseMediaDuringBreaks: { value in
+                await MainActor.run {
+                    LiveSettingsBridge.shared.store.pauseMediaDuringBreaks = value
+                }
+            },
+            updateHapticsEnabled: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.hapticsEnabled = value }
+            },
+            updatePauseDuringFocus: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.pauseDuringFocus = value }
+            },
+            updatePauseWhileDriving: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.pauseWhileDriving = value }
+            },
+            updateNotificationFallbackEnabled: { value in
+                await MainActor.run {
+                    LiveSettingsBridge.shared.store.notificationFallbackEnabled = value
+                }
+            },
+            setSnoozedUntil: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.snoozedUntil = value }
+            },
+            setSnoozeCount: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.snoozeCount = value }
+            },
+            resetToDefaults: {
+                await MainActor.run { LiveSettingsBridge.shared.store.resetToDefaults() }
+            }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `SettingsClient`.
+    var settingsClient: SettingsClient {
+        get { self[SettingsClient.self] }
+        set { self[SettingsClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `SettingsStore` plus the Combine
+/// subscription that mirrors `objectWillChange` updates into the file-scope
+/// snapshot cache and continuation registry.
+@MainActor
+private final class LiveSettingsBridge {
+    nonisolated static let shared = LiveSettingsBridge()
+
+    let store = SettingsStore()
+    private var cancellables: Set<AnyCancellable> = []
+    private var hasBootstrapped = false
+
+    private nonisolated init() {}
+
+    /// Idempotent bootstrap. Called from `liveValue` via a `@MainActor` task
+    /// so the Combine subscription is wired exactly once on the main actor.
+    func bootstrap() {
+        guard !hasBootstrapped else { return }
+        hasBootstrapped = true
+
+        let initial = store.settings(for: .eyes)
+        settingsSnapshotCache.setValue(initial)
+        broadcastSettings(initial)
+
+        store.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak store] _ in
+                guard let store else { return }
+                let updated = store.settings(for: .eyes)
+                settingsSnapshotCache.setValue(updated)
+                broadcastSettings(updated)
+            }
+            .store(in: &cancellables)
+    }
+}
+
+/// File-scoped snapshot cache; safe to read from any actor.
+private let settingsSnapshotCache = LockIsolated<ReminderSettings>(
+    ReminderSettings(interval: 0, breakDuration: 0)
+)
+
+/// File-scoped multicast continuations. Held outside the `@MainActor` bridge
+/// to side-step a Swift constraint-solver bug that surfaces when
+/// `Continuation.onTermination` captures `@MainActor`-isolated static storage.
+private let settingsContinuations =
+    LockIsolated<[UUID: AsyncStream<ReminderSettings>.Continuation]>([:])
+
+/// File-scoped factory used by the live `stream` closure to register a new
+/// multicast subscriber. Yields the current snapshot synchronously so first
+/// reads never block on a `objectWillChange` tick.
+private func makeSettingsStream() -> AsyncStream<ReminderSettings> {
+    let (stream, continuation) = AsyncStream<ReminderSettings>.makeStream()
+    let id = UUID()
+    continuation.yield(settingsSnapshotCache.value)
+    settingsContinuations.withValue { $0[id] = continuation }
+    continuation.onTermination = { _ in
+        settingsContinuations.withValue { dict in
+            dict[id] = nil
+        }
+    }
+    return stream
+}
+
+private func broadcastSettings(_ value: ReminderSettings) {
+    settingsContinuations.withValue { dict in
+        for continuation in dict.values { continuation.yield(value) }
+    }
+}


### PR DESCRIPTION
## Summary

Phase 0 of #662 (MVVM → TCA migration). Adds 10 `@DependencyClient` files
under `EyePostureReminder/TCA/Dependencies/` that wrap the existing imperative
service layer behind reducer-friendly `@Sendable` closures.

| Client | Wraps | Highlights |
| --- | --- | --- |
| `SettingsClient` | `SettingsStore` | Multicast `observeSettings(for:)`, 16 setters |
| `OverlayClient` | `OverlayManager` | Lifecycle event stream (`present` / `dismiss` / `settingsTap`) |
| `ScreenTimeAuthorizationClient` | `ScreenTimeAuthorizationProviding` | `statusChanges` multicast |
| `ScreenTimeTrackerClient` | `ScreenTimeTracker` | `thresholdReached` multicast; remembers thresholds for re-arm |
| `PauseConditionClient` | `PauseConditionManager` | `pauseStateChanges` multicast |
| `NotificationClient` | `UNUserNotificationCenter` | Authorization + add/remove |
| `ReminderSchedulerClient` | `ReminderScheduler` | Scheduling primitives |
| `DeviceActivityMonitorClient` | `DeviceActivityMonitorNoop` | Stub until #201 |
| `IPCClient` | `AppGroupIPCStore` | True-interrupt enabled stream |
| `AnalyticsClient` | `AnalyticsLogger` | Sync wrapper |

Each client exposes a stable `liveValue` + auto-generated noop test value via
`@DependencyClient`. No call sites change in this commit; existing MVVM code
keeps using the services directly until #666–#673 migrate them.

## Implementation notes

- Multicast streams use a per-file `LockIsolated<[UUID: AsyncStream<T>.Continuation]>`
  registry held at **file scope** rather than as a `@MainActor` static. This
  works around a Swift 6 constraint-solver bug (`failed to produce diagnostic
  for expression`) that fires when `AsyncStream.onTermination` captures
  `@MainActor`-isolated static storage from a `nonisolated` factory.
- Live bridges remain `@MainActor` and lazily `bootstrap()` on first
  `liveValue` access (e.g. `SettingsClient` subscribes to
  `SettingsStore.objectWillChange.receive(on: RunLoop.main)`).
- `ScreenTimeTrackerClient.enableTracking(for:)` re-applies a remembered
  threshold because `ScreenTimeTracking` has no native enable; the client owns
  a `[ReminderType: TimeInterval]` map for re-arm semantics.

## Validation

- [x] `./scripts/build.sh all` — build, lint, and **2075 / 2075** tests pass locally.

## Branching

This branch is stacked on `users/squad/issue-664-add-tca-dep` (PR #684) for
the `swift-composable-architecture` dependency and the `-skipMacroValidation`
build-script change. Will be rebased onto `main` once #684 merges.

Closes #665.
