### PR TITLE
Add AppFeature root reducer skeleton and Phase-1 stubs (#666)

### DIFF
--- a/EyePostureReminder/TCA/AppFeature.swift
+++ b/EyePostureReminder/TCA/AppFeature.swift
@@ -1,0 +1,78 @@
+import ComposableArchitecture
+import Foundation
+import SwiftUI
+
+/// Root reducer composing every feature in the TCA migration of the Eye &
+/// Posture Reminder app.
+///
+/// Phase 0 (`p0-tca-3` / #666) deliberately leaves the body almost empty:
+/// the goal is to nail down the *surface* — state shape, action vocabulary,
+/// scopes, and presentation wiring — so that Phase 1 issues can fill in each
+/// individual feature reducer in any order, without merge collisions on this
+/// root file.
+///
+/// Wiring into `EyePostureReminderApp.swift` is intentionally deferred to
+/// Phase 2 issue `p0-tca-11` (#674) — the legacy MVVM app-coordinator stack
+/// remains the production runtime until then.
+@Reducer
+struct AppFeature {
+    /// Re-exposes `AppDelegate.NotificationRoute` at the AppFeature scope so
+    /// the action vocabulary can refer to it without a leading
+    /// `AppDelegate.` qualifier and without modifying `AppDelegate.swift`.
+    typealias NotificationRoute = AppDelegate.NotificationRoute
+
+    @ObservableState
+    struct State: Equatable {
+        var hasSeenOnboarding: Bool = false
+        var home: HomeFeature.State = .init()
+        var settings: SettingsFeature.State = .init()
+        var onboarding: OnboardingFeature.State = .init()
+        var scheduling: SchedulingFeature.State = .init()
+        @Presents var overlay: OverlayFeature.State?
+        @Presents var destination: Destination.State?
+    }
+
+    enum Action {
+        case onAppear
+        case scenePhaseChanged(ScenePhase)
+        case home(HomeFeature.Action)
+        case settings(SettingsFeature.Action)
+        case onboarding(OnboardingFeature.Action)
+        case scheduling(SchedulingFeature.Action)
+        case overlay(PresentationAction<OverlayFeature.Action>)
+        case destination(PresentationAction<Destination.Action>)
+        case notificationRouted(NotificationRoute)
+    }
+
+    @Reducer
+    enum Destination {
+        case settingsSheet(SettingsFeature)
+        case appCategoryPicker(AppCategoryPickerFeature)
+    }
+
+    var body: some ReducerOf<Self> {
+        Scope(state: \.home, action: \.home) { HomeFeature() }
+        Scope(state: \.settings, action: \.settings) { SettingsFeature() }
+        Scope(state: \.onboarding, action: \.onboarding) { OnboardingFeature() }
+        Scope(state: \.scheduling, action: \.scheduling) { SchedulingFeature() }
+
+        Reduce { _, action in
+            switch action {
+            case .onAppear:
+                return .send(.scheduling(.start))
+            case .scenePhaseChanged:
+                // Phase-2 issue p0-tca-13 (#676) fills this in.
+                return .none
+            case .notificationRouted:
+                // Phase-2 issue p0-tca-12 (#675) fills this in.
+                return .none
+            case .home, .settings, .onboarding, .scheduling, .overlay, .destination:
+                return .none
+            }
+        }
+        .ifLet(\.$overlay, action: \.overlay) { OverlayFeature() }
+        .ifLet(\.$destination, action: \.destination)
+    }
+}
+
+extension AppFeature.Destination.State: Equatable {}

--- a/EyePostureReminder/TCA/Dependencies/AnalyticsClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/AnalyticsClient.swift
@@ -1,0 +1,28 @@
+import ComposableArchitecture
+import Foundation
+
+/// TCA dependency client wrapping `AnalyticsLogger` for reducer consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The `liveValue` adapter
+/// forwards every emitted event to the existing static `AnalyticsLogger.log`
+/// sink so reducers and the legacy MVVM stack share a single os.Logger
+/// pipeline during the migration.
+@DependencyClient
+struct AnalyticsClient: Sendable {
+    /// Synchronously emits an analytics event to the shared `os.Logger` sink.
+    var log: @Sendable (AnalyticsEvent) -> Void
+}
+
+extension AnalyticsClient: DependencyKey {
+    static let liveValue = AnalyticsClient(
+        log: { event in AnalyticsLogger.log(event) }
+    )
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `AnalyticsClient`.
+    var analyticsClient: AnalyticsClient {
+        get { self[AnalyticsClient.self] }
+        set { self[AnalyticsClient.self] = newValue }
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/DeviceActivityMonitorClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/DeviceActivityMonitorClient.swift
@@ -1,0 +1,62 @@
+import ComposableArchitecture
+import Foundation
+
+/// TCA dependency client wrapping `DeviceActivityMonitorProviding` for reducer
+/// consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The pre-entitlement default
+/// implementation is `DeviceActivityMonitorNoop`, so the `liveValue` adapter
+/// effectively becomes a noop until the FamilyControls entitlement (#201) is
+/// provisioned. The `UUID` argument carried by the closures is part of the
+/// normative Phase 1 contract — Phase 1 will key sessions by that identifier.
+@DependencyClient
+struct DeviceActivityMonitorClient: Sendable {
+    /// Schedules a DeviceActivity monitoring window for the supplied break
+    /// session. The `UUID` keys the session for later cancellation.
+    var schedule: @Sendable (ShieldSession, UUID) async -> Void
+
+    /// Cancels the active DeviceActivity monitoring window. When `nil`, every
+    /// active session is cancelled.
+    var cancel: @Sendable (UUID?) async -> Void
+}
+
+extension DeviceActivityMonitorClient: DependencyKey {
+    static let liveValue: DeviceActivityMonitorClient = {
+        Task { @MainActor in _ = LiveDeviceActivityMonitorBridge.shared }
+        return DeviceActivityMonitorClient(
+            schedule: { session, _ in
+                await LiveDeviceActivityMonitorBridge.shared.schedule(session)
+            },
+            cancel: { _ in
+                await LiveDeviceActivityMonitorBridge.shared.cancel()
+            }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `DeviceActivityMonitorClient`.
+    var deviceActivityMonitorClient: DeviceActivityMonitorClient {
+        get { self[DeviceActivityMonitorClient.self] }
+        set { self[DeviceActivityMonitorClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `DeviceActivityMonitorProviding`
+/// implementation. Defaults to the pre-entitlement noop until #201 lands.
+@MainActor
+private final class LiveDeviceActivityMonitorBridge {
+    static let shared = LiveDeviceActivityMonitorBridge()
+
+    let monitor: DeviceActivityMonitorProviding = DeviceActivityMonitorNoop()
+
+    private init() {}
+
+    func schedule(_ session: ShieldSession) async {
+        try? await monitor.scheduleBreakMonitoring(for: session)
+    }
+
+    func cancel() async {
+        try? await monitor.cancelBreakMonitoring()
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/IPCClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/IPCClient.swift
@@ -1,0 +1,129 @@
+import ComposableArchitecture
+import Foundation
+import os
+import ScreenTimeExtensionShared
+
+/// TCA dependency client wrapping `AppGroupIPCStore` for reducer consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The `liveValue` adapter
+/// installs a single `NotificationCenter` observer for the
+/// `trueInterruptEnabledDidChange` notification that multicasts to every
+/// active `trueInterruptChanges` subscriber via per-subscriber `AsyncStream`
+/// continuations. The optional `String` argument carried by `record` is the
+/// caller-supplied operation context — it is preserved in the failure log
+/// emitted when `recordEvent` throws.
+@DependencyClient
+struct IPCClient: Sendable {
+    /// Whether the user has toggled on the True Interrupt (DeviceActivity
+    /// shield) feature in Settings. Reads the App Group flag synchronously.
+    var isTrueInterruptEnabled: @Sendable () async -> Bool = { false }
+
+    /// Records an IPC event to the shared App Group store. The optional
+    /// `String` second argument is a free-form caller-supplied operation
+    /// context preserved in the failure log if the underlying write fails.
+    var record: @Sendable (AppGroupIPCEvent, String?) async -> Void
+
+    /// Multicast stream of `trueInterruptEnabled` flag transitions. A new
+    /// subscriber receives every subsequent change until the consumer
+    /// terminates.
+    var trueInterruptChanges: @Sendable () -> AsyncStream<Bool> = { .finished }
+}
+
+extension IPCClient: DependencyKey {
+    static let liveValue: IPCClient = {
+        Task { @MainActor in LiveIPCBridge.shared.bootstrap() }
+        return IPCClient(
+            isTrueInterruptEnabled: {
+                await MainActor.run { LiveIPCBridge.shared.store.isTrueInterruptEnabled() }
+            },
+            record: { event, context in
+                await MainActor.run { LiveIPCBridge.shared.record(event, context: context) }
+            },
+            trueInterruptChanges: { makeTrueInterruptStream() }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `IPCClient`.
+    var ipcClient: IPCClient {
+        get { self[IPCClient.self] }
+        set { self[IPCClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `AppGroupIPCStore`. Subscribes to
+/// `trueInterruptEnabledDidChange` notifications and forwards them to the
+/// file-scope continuation registry.
+@MainActor
+private final class LiveIPCBridge {
+    nonisolated static let shared = LiveIPCBridge()
+
+    let store = AppGroupIPCStore()
+    private var observer: NSObjectProtocol?
+    private var hasBootstrapped = false
+
+    private nonisolated init() {}
+
+    func bootstrap() {
+        guard !hasBootstrapped else { return }
+        hasBootstrapped = true
+
+        observer = NotificationCenter.default.addObserver(
+            forName: AppGroupIPCStore.trueInterruptEnabledDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { notification in
+            let value = (notification.userInfo?[
+                AppGroupIPCStore.trueInterruptEnabledValueUserInfoKey
+            ] as? Bool) ?? false
+            broadcastTrueInterruptChange(value)
+        }
+    }
+
+    deinit {
+        if let observer { NotificationCenter.default.removeObserver(observer) }
+    }
+
+    func record(_ event: AppGroupIPCEvent, context: String?) {
+        do {
+            try store.recordEvent(event)
+        } catch {
+            AnalyticsLogger.log(
+                .ipcOperationFailed(operation: .writeEvent, reason: .writeFailed)
+            )
+            ipcLogger.error("""
+                event=ipc_record_failed \
+                kind=\(event.kind.rawValue, privacy: .public) \
+                context=\(context ?? "nil", privacy: .public)
+                """)
+        }
+    }
+}
+
+/// File-scoped multicast continuations for `IPCClient.trueInterruptChanges`.
+private let trueInterruptContinuations =
+    LockIsolated<[UUID: AsyncStream<Bool>.Continuation]>([:])
+
+private let ipcLogger = Logger(
+    subsystem: Bundle.main.bundleIdentifier ?? "com.yashasgujjar.eyeposture",
+    category: "IPCClient"
+)
+
+private func makeTrueInterruptStream() -> AsyncStream<Bool> {
+    let (stream, continuation) = AsyncStream<Bool>.makeStream()
+    let id = UUID()
+    trueInterruptContinuations.withValue { $0[id] = continuation }
+    continuation.onTermination = { _ in
+        trueInterruptContinuations.withValue { dict in
+            dict[id] = nil
+        }
+    }
+    return stream
+}
+
+private func broadcastTrueInterruptChange(_ value: Bool) {
+    trueInterruptContinuations.withValue { dict in
+        for continuation in dict.values { continuation.yield(value) }
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/NotificationClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/NotificationClient.swift
@@ -1,0 +1,69 @@
+import ComposableArchitecture
+import Foundation
+import UserNotifications
+
+/// TCA dependency client wrapping `UNUserNotificationCenter` for reducer
+/// consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The `liveValue` adapter
+/// forwards every call to `UNUserNotificationCenter.current()`, matching the
+/// signatures expected by Phase 1 reducers.
+@DependencyClient
+struct NotificationClient: Sendable {
+    /// Requests authorisation with the given options. Returns whether the user
+    /// granted at least the requested set.
+    var requestAuthorization: @Sendable (UNAuthorizationOptions) async throws -> Bool
+
+    /// Returns the current authorisation status without prompting.
+    var authorizationStatus: @Sendable () async -> UNAuthorizationStatus = { .notDetermined }
+
+    /// Adds a new notification request to the system queue.
+    var add: @Sendable (UNNotificationRequest) async throws -> Void
+
+    /// Removes pending notifications by identifier.
+    var removePending: @Sendable ([String]) async -> Void
+
+    /// Removes every pending notification.
+    var removeAllPending: @Sendable () async -> Void
+
+    /// Returns the currently queued (pending) notification requests.
+    var pendingRequests: @Sendable () async -> [UNNotificationRequest] = { [] }
+
+    /// Returns the currently delivered notifications still in Notification Center.
+    var deliveredNotifications: @Sendable () async -> [UNNotification] = { [] }
+}
+
+extension NotificationClient: DependencyKey {
+    static let liveValue = NotificationClient(
+        requestAuthorization: { options in
+            try await UNUserNotificationCenter.current().requestAuthorization(options: options)
+        },
+        authorizationStatus: {
+            await UNUserNotificationCenter.current().notificationSettings().authorizationStatus
+        },
+        add: { request in
+            try await UNUserNotificationCenter.current().add(request)
+        },
+        removePending: { identifiers in
+            UNUserNotificationCenter.current()
+                .removePendingNotificationRequests(withIdentifiers: identifiers)
+        },
+        removeAllPending: {
+            UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+        },
+        pendingRequests: {
+            await UNUserNotificationCenter.current().pendingNotificationRequests()
+        },
+        deliveredNotifications: {
+            await UNUserNotificationCenter.current().deliveredNotifications()
+        }
+    )
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `NotificationClient`.
+    var notificationClient: NotificationClient {
+        get { self[NotificationClient.self] }
+        set { self[NotificationClient.self] = newValue }
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/OverlayClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/OverlayClient.swift
@@ -1,0 +1,136 @@
+import ComposableArchitecture
+import Foundation
+
+/// Lifecycle events emitted by the overlay layer for reducer consumption.
+///
+/// The Phase 0 adapter multicasts these events from the live `OverlayManager`'s
+/// `OverlayLifecycleCallbacks` so multiple reducers can subscribe independently.
+enum OverlayLifecycleEvent: Equatable, Sendable {
+    /// The overlay for the given reminder type has been presented on screen.
+    case presented(ReminderType)
+    /// The overlay for the given reminder type has been dismissed.
+    case dismissed(ReminderType)
+    /// The user tapped the "Settings" affordance inside the overlay for the
+    /// given reminder type.
+    case settingsTapped(ReminderType)
+}
+
+/// TCA dependency client wrapping `OverlayManager` for reducer consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The `liveValue` adapter
+/// installs a single set of `OverlayLifecycleCallbacks` per `show` call that
+/// multicasts to every active `lifecycleEvents` subscriber via per-subscriber
+/// `AsyncStream` continuations.
+@DependencyClient
+struct OverlayClient: Sendable {
+    /// Presents (or queues) the break overlay for the given reminder type.
+    /// Parameters: type, duration in seconds, haptics enabled, pause-media
+    /// enabled.
+    var show: @Sendable (ReminderType, TimeInterval, Bool, Bool) async -> Void
+
+    /// Dismisses the overlay if currently visible.
+    var dismiss: @Sendable () async -> Void
+
+    /// Drops every queued overlay request.
+    var clearQueue: @Sendable () async -> Void
+
+    /// Drops queued overlay requests for the given reminder type only.
+    var clearQueueForType: @Sendable (ReminderType) async -> Void
+
+    /// Whether the overlay window is currently on screen.
+    var isVisible: @Sendable () async -> Bool = { false }
+
+    /// Multicast stream of `OverlayLifecycleEvent`s. Each subscriber receives
+    /// every event from the moment subscription begins.
+    var lifecycleEvents: @Sendable () -> AsyncStream<OverlayLifecycleEvent> = { .finished }
+}
+
+extension OverlayClient: DependencyKey {
+    static let liveValue: OverlayClient = {
+        Task { @MainActor in _ = LiveOverlayBridge.shared }
+        return OverlayClient(
+            show: { type, duration, hapticsEnabled, pauseMediaEnabled in
+                await LiveOverlayBridge.shared.show(
+                    type: type,
+                    duration: duration,
+                    hapticsEnabled: hapticsEnabled,
+                    pauseMediaEnabled: pauseMediaEnabled
+                )
+            },
+            dismiss: { await LiveOverlayBridge.shared.dismiss() },
+            clearQueue: { await LiveOverlayBridge.shared.clearQueue() },
+            clearQueueForType: { type in
+                await LiveOverlayBridge.shared.clearQueue(for: type)
+            },
+            isVisible: { await LiveOverlayBridge.shared.isVisible() },
+            lifecycleEvents: { makeOverlayLifecycleStream() }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `OverlayClient`.
+    var overlayClient: OverlayClient {
+        get { self[OverlayClient.self] }
+        set { self[OverlayClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `OverlayManager`. Each `show` call
+/// installs callbacks that multicast lifecycle events to file-scope
+/// continuations so any number of subscribers can observe the overlay.
+@MainActor
+private final class LiveOverlayBridge {
+    nonisolated static let shared = LiveOverlayBridge()
+
+    let manager: OverlayPresenting = OverlayManager()
+
+    private nonisolated init() {}
+
+    func show(
+        type: ReminderType,
+        duration: TimeInterval,
+        hapticsEnabled: Bool,
+        pauseMediaEnabled: Bool
+    ) {
+        let callbacks = OverlayLifecycleCallbacks(
+            onPresent: { broadcastOverlayEvent(.presented(type)) },
+            onDismiss: { broadcastOverlayEvent(.dismissed(type)) },
+            onSettingsTap: { broadcastOverlayEvent(.settingsTapped(type)) }
+        )
+        manager.showOverlay(
+            for: type,
+            duration: duration,
+            hapticsEnabled: hapticsEnabled,
+            pauseMediaEnabled: pauseMediaEnabled,
+            callbacks: callbacks
+        )
+    }
+
+    func dismiss() { manager.dismissOverlay() }
+    func clearQueue() { manager.clearQueue() }
+    func clearQueue(for type: ReminderType) { manager.clearQueue(for: type) }
+    func isVisible() -> Bool { manager.isOverlayVisible }
+}
+
+/// File-scoped multicast continuations for `OverlayClient.lifecycleEvents`.
+private let overlayLifecycleContinuations =
+    LockIsolated<[UUID: AsyncStream<OverlayLifecycleEvent>.Continuation]>([:])
+
+private func makeOverlayLifecycleStream() -> AsyncStream<OverlayLifecycleEvent> {
+    let (stream, continuation) = AsyncStream<OverlayLifecycleEvent>.makeStream()
+    let id = UUID()
+    overlayLifecycleContinuations.withValue { $0[id] = continuation }
+    continuation.onTermination = { _ in
+        overlayLifecycleContinuations.withValue { dict in
+            dict[id] = nil
+        }
+    }
+    return stream
+}
+
+private func broadcastOverlayEvent(_ event: OverlayLifecycleEvent) {
+    overlayLifecycleContinuations.withValue { dict in
+        for continuation in dict.values { continuation.yield(event) }
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/PauseConditionClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/PauseConditionClient.swift
@@ -1,0 +1,107 @@
+import ComposableArchitecture
+import Foundation
+
+/// TCA dependency client wrapping `PauseConditionManager` for reducer
+/// consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The `liveValue` adapter
+/// installs a single `onPauseStateChanged` closure on the underlying manager
+/// that multicasts to every active `pauseChanges` subscriber via
+/// per-subscriber `AsyncStream` continuations.
+@DependencyClient
+struct PauseConditionClient: Sendable {
+    /// Whether the current aggregate pause state is active.
+    var isPaused: @Sendable () async -> Bool = { false }
+
+    /// Multicast stream of aggregate pause-state transitions.
+    var pauseChanges: @Sendable () -> AsyncStream<Bool> = { .finished }
+
+    /// Begins monitoring focus, CarPlay, and driving conditions.
+    var startMonitoring: @Sendable () async -> Void
+
+    /// Stops monitoring and clears the active condition set.
+    var stopMonitoring: @Sendable () async -> Void
+}
+
+extension PauseConditionClient: DependencyKey {
+    static let liveValue: PauseConditionClient = {
+        Task { @MainActor in LivePauseConditionBridge.shared.bootstrap() }
+        return PauseConditionClient(
+            isPaused: { await LivePauseConditionBridge.shared.isPaused() },
+            pauseChanges: { makePauseConditionStream() },
+            startMonitoring: { await LivePauseConditionBridge.shared.startMonitoring() },
+            stopMonitoring: { await LivePauseConditionBridge.shared.stopMonitoring() }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `PauseConditionClient`.
+    var pauseConditionClient: PauseConditionClient {
+        get { self[PauseConditionClient.self] }
+        set { self[PauseConditionClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `PauseConditionManager`. Multicasts
+/// `onPauseStateChanged` callbacks into file-scope continuations.
+@MainActor
+private final class LivePauseConditionBridge {
+    nonisolated static let shared = LivePauseConditionBridge()
+
+    private var manager: PauseConditionProviding?
+    private var hasBootstrapped = false
+
+    private nonisolated init() {}
+
+    func bootstrap() {
+        guard !hasBootstrapped else { return }
+        hasBootstrapped = true
+
+        let settings = SettingsStore()
+        let live = PauseConditionManager(
+            settings: settings,
+            focusDetector: LiveFocusStatusDetector(),
+            carPlayDetector: LiveCarPlayDetector(),
+            drivingDetector: LiveDrivingActivityDetector()
+        )
+        live.onPauseStateChanged = { paused in
+            broadcastPauseChange(paused)
+        }
+        manager = live
+    }
+
+    func isPaused() -> Bool {
+        manager?.isPaused ?? false
+    }
+
+    func startMonitoring() {
+        manager?.startMonitoring()
+    }
+
+    func stopMonitoring() {
+        manager?.stopMonitoring()
+    }
+}
+
+/// File-scoped multicast continuations for `PauseConditionClient.pauseChanges`.
+private let pauseConditionContinuations =
+    LockIsolated<[UUID: AsyncStream<Bool>.Continuation]>([:])
+
+private func makePauseConditionStream() -> AsyncStream<Bool> {
+    let (stream, continuation) = AsyncStream<Bool>.makeStream()
+    let id = UUID()
+    pauseConditionContinuations.withValue { $0[id] = continuation }
+    continuation.onTermination = { _ in
+        pauseConditionContinuations.withValue { dict in
+            dict[id] = nil
+        }
+    }
+    return stream
+}
+
+private func broadcastPauseChange(_ paused: Bool) {
+    pauseConditionContinuations.withValue { dict in
+        for continuation in dict.values { continuation.yield(paused) }
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/ReminderSchedulerClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/ReminderSchedulerClient.swift
@@ -1,0 +1,82 @@
+import ComposableArchitecture
+import Foundation
+
+/// TCA dependency client wrapping `ReminderScheduler` for reducer consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The `liveValue` adapter routes
+/// scheduling calls through the existing `@MainActor` `ReminderScheduler`,
+/// which itself reads the live `SettingsStore` snapshot. The `ReminderSettings`
+/// argument carried by the closures is part of the normative Phase 1 contract
+/// — Phase 1 will refactor `ReminderScheduler` to honour it directly.
+@DependencyClient
+struct ReminderSchedulerClient: Sendable {
+    /// Schedules every enabled reminder type using the supplied baseline
+    /// settings. The Phase 0 adapter delegates to the live `ReminderScheduler`,
+    /// which reads the shared `SettingsStore`.
+    var scheduleReminders: @Sendable (ReminderSettings) async -> Void
+
+    /// Reschedules a single reminder type after settings have changed.
+    var rescheduleReminder: @Sendable (ReminderType, ReminderSettings) async -> Void
+
+    /// Cancels all pending reminders for the given type.
+    var cancelReminder: @Sendable (ReminderType) async -> Void
+
+    /// Cancels every pending reminder unconditionally.
+    var cancelAllReminders: @Sendable () async -> Void
+}
+
+extension ReminderSchedulerClient: DependencyKey {
+    static let liveValue: ReminderSchedulerClient = {
+        Task { @MainActor in _ = LiveReminderSchedulerBridge.shared }
+        return ReminderSchedulerClient(
+            scheduleReminders: { _ in
+                await LiveReminderSchedulerBridge.shared.scheduleAll()
+            },
+            rescheduleReminder: { type, _ in
+                await LiveReminderSchedulerBridge.shared.reschedule(type)
+            },
+            cancelReminder: { type in
+                await LiveReminderSchedulerBridge.shared.cancel(type)
+            },
+            cancelAllReminders: {
+                await LiveReminderSchedulerBridge.shared.cancelAll()
+            }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `ReminderSchedulerClient`.
+    var reminderSchedulerClient: ReminderSchedulerClient {
+        get { self[ReminderSchedulerClient.self] }
+        set { self[ReminderSchedulerClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `ReminderScheduler` and the
+/// `SettingsStore` it reads from. Lazily instantiated on first reducer call.
+@MainActor
+private final class LiveReminderSchedulerBridge {
+    static let shared = LiveReminderSchedulerBridge()
+
+    let settings = SettingsStore()
+    let scheduler: ReminderScheduling = ReminderScheduler()
+
+    private init() {}
+
+    func scheduleAll() async {
+        await scheduler.scheduleReminders(using: settings)
+    }
+
+    func reschedule(_ type: ReminderType) async {
+        await scheduler.rescheduleReminder(for: type, using: settings)
+    }
+
+    func cancel(_ type: ReminderType) {
+        scheduler.cancelReminder(for: type)
+    }
+
+    func cancelAll() {
+        scheduler.cancelAllReminders()
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/ScreenTimeAuthorizationClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/ScreenTimeAuthorizationClient.swift
@@ -1,0 +1,99 @@
+import ComposableArchitecture
+import Foundation
+
+/// TCA dependency client wrapping `ScreenTimeAuthorizationProviding` for
+/// reducer consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The pre-entitlement default
+/// implementation is `ScreenTimeAuthorizationNoop`, which always returns
+/// `.unavailable`; the `liveValue` adapter forwards through that noop until
+/// the FamilyControls entitlement is provisioned (#201).
+@DependencyClient
+struct ScreenTimeAuthorizationClient: Sendable {
+    /// Current authorisation status. Defaults to `.unavailable`.
+    var status: @Sendable () async -> ScreenTimeAuthorizationStatus = { .unavailable }
+
+    /// Multicast stream of authorisation status changes.
+    var statusChanges: @Sendable () -> AsyncStream<ScreenTimeAuthorizationStatus> = { .finished }
+
+    /// Requests authorisation and returns the resulting status.
+    var requestAuthorization: @Sendable () async -> ScreenTimeAuthorizationStatus = {
+        .unavailable
+    }
+}
+
+extension ScreenTimeAuthorizationClient: DependencyKey {
+    static let liveValue: ScreenTimeAuthorizationClient = {
+        Task { @MainActor in _ = LiveScreenTimeAuthorizationBridge.shared }
+        return ScreenTimeAuthorizationClient(
+            status: {
+                await LiveScreenTimeAuthorizationBridge.shared.status()
+            },
+            statusChanges: {
+                makeScreenTimeAuthorizationStream()
+            },
+            requestAuthorization: {
+                await LiveScreenTimeAuthorizationBridge.shared.request()
+            }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `ScreenTimeAuthorizationClient`.
+    var screenTimeAuthorizationClient: ScreenTimeAuthorizationClient {
+        get { self[ScreenTimeAuthorizationClient.self] }
+        set { self[ScreenTimeAuthorizationClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `ScreenTimeAuthorizationProviding`
+/// implementation. Broadcasts every status change observed during a
+/// `requestAuthorization()` call to active stream subscribers.
+@MainActor
+private final class LiveScreenTimeAuthorizationBridge {
+    static let shared = LiveScreenTimeAuthorizationBridge()
+
+    let provider: ScreenTimeAuthorizationProviding = ScreenTimeAuthorizationNoop()
+
+    private init() {}
+
+    func status() -> ScreenTimeAuthorizationStatus {
+        provider.authorizationStatus
+    }
+
+    func request() async -> ScreenTimeAuthorizationStatus {
+        let result = await provider.requestAuthorization()
+        screenTimeAuthorizationContinuations.withValue { dict in
+            for continuation in dict.values { continuation.yield(result) }
+        }
+        return result
+    }
+}
+
+/// File-scoped multicast continuations for `ScreenTimeAuthorizationClient`.
+/// Held outside the `@MainActor` bridge so the nonisolated stream factory can
+/// capture it without crossing actor boundaries — `LockIsolated` already
+/// provides thread safety. Defined at file scope (rather than as a static
+/// property of the bridge class) to side-step a Swift constraint-solver bug
+/// triggered by `Continuation.onTermination` capturing `@MainActor`-isolated
+/// static storage.
+private let screenTimeAuthorizationContinuations =
+    LockIsolated<[UUID: AsyncStream<ScreenTimeAuthorizationStatus>.Continuation]>([:])
+
+/// File-scoped factory used by the live `statusChanges` closure to register a
+/// new multicast subscriber. Lives outside the bridge class so it can be
+/// invoked from a `@Sendable` non-async context.
+private func makeScreenTimeAuthorizationStream()
+    -> AsyncStream<ScreenTimeAuthorizationStatus> {
+    let (stream, continuation) =
+        AsyncStream<ScreenTimeAuthorizationStatus>.makeStream()
+    let id = UUID()
+    screenTimeAuthorizationContinuations.withValue { $0[id] = continuation }
+    continuation.onTermination = { _ in
+        screenTimeAuthorizationContinuations.withValue { dict in
+            dict[id] = nil
+        }
+    }
+    return stream
+}

--- a/EyePostureReminder/TCA/Dependencies/ScreenTimeTrackerClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/ScreenTimeTrackerClient.swift
@@ -1,0 +1,134 @@
+import ComposableArchitecture
+import Foundation
+
+/// TCA dependency client wrapping `ScreenTimeTracker` for reducer consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The `liveValue` adapter installs
+/// a single `onThresholdReached` closure on the underlying tracker that
+/// multicasts to every active `thresholdReached` subscriber via per-subscriber
+/// `AsyncStream` continuations.
+@DependencyClient
+struct ScreenTimeTrackerClient: Sendable {
+    /// Sets the per-type continuous screen-on threshold, in seconds.
+    var setThreshold: @Sendable (TimeInterval, ReminderType) async -> Void
+
+    /// Enables tracking for the given type by re-arming its current threshold.
+    var enableTracking: @Sendable (ReminderType) async -> Void
+
+    /// Disables tracking for the given type and resets its counter.
+    var disableTracking: @Sendable (ReminderType) async -> Void
+
+    /// Pauses tracking for every reminder type.
+    var pauseAll: @Sendable () async -> Void
+
+    /// Resumes tracking for every reminder type.
+    var resumeAll: @Sendable () async -> Void
+
+    /// Resets the elapsed counter for the given reminder type.
+    var reset: @Sendable (ReminderType) async -> Void
+
+    /// Multicast stream of threshold-reached events keyed by reminder type.
+    var thresholdReached: @Sendable () -> AsyncStream<ReminderType> = { .finished }
+}
+
+extension ScreenTimeTrackerClient: DependencyKey {
+    static let liveValue: ScreenTimeTrackerClient = {
+        Task { @MainActor in LiveScreenTimeTrackerBridge.shared.bootstrap() }
+        return ScreenTimeTrackerClient(
+            setThreshold: { interval, type in
+                await MainActor.run {
+                    LiveScreenTimeTrackerBridge.shared.setThreshold(interval, for: type)
+                }
+            },
+            enableTracking: { type in
+                await MainActor.run {
+                    LiveScreenTimeTrackerBridge.shared.enableTracking(for: type)
+                }
+            },
+            disableTracking: { type in
+                await MainActor.run {
+                    LiveScreenTimeTrackerBridge.shared.disableTracking(for: type)
+                }
+            },
+            pauseAll: { await MainActor.run { LiveScreenTimeTrackerBridge.shared.pauseAll() } },
+            resumeAll: { await MainActor.run { LiveScreenTimeTrackerBridge.shared.resumeAll() } },
+            reset: { type in
+                await MainActor.run { LiveScreenTimeTrackerBridge.shared.reset(for: type) }
+            },
+            thresholdReached: { makeScreenTimeThresholdStream() }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `ScreenTimeTrackerClient`.
+    var screenTimeTrackerClient: ScreenTimeTrackerClient {
+        get { self[ScreenTimeTrackerClient.self] }
+        set { self[ScreenTimeTrackerClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `ScreenTimeTracker`. Tracks the most
+/// recent per-type threshold so `enableTracking(_:)` can re-arm without the
+/// caller needing to remember the value.
+@MainActor
+private final class LiveScreenTimeTrackerBridge {
+    nonisolated static let shared = LiveScreenTimeTrackerBridge()
+
+    private var tracker: ScreenTimeTracking?
+    private var thresholds: [ReminderType: TimeInterval] = [:]
+    private var hasBootstrapped = false
+
+    private nonisolated init() {}
+
+    func bootstrap() {
+        guard !hasBootstrapped else { return }
+        hasBootstrapped = true
+
+        let live = ScreenTimeTracker()
+        live.onThresholdReached = { type in
+            broadcastScreenTimeThreshold(type)
+        }
+        tracker = live
+    }
+
+    func setThreshold(_ interval: TimeInterval, for type: ReminderType) {
+        thresholds[type] = interval
+        tracker?.setThreshold(interval, for: type)
+    }
+
+    func enableTracking(for type: ReminderType) {
+        guard let interval = thresholds[type] else { return }
+        tracker?.setThreshold(interval, for: type)
+    }
+
+    func disableTracking(for type: ReminderType) {
+        tracker?.disableTracking(for: type)
+    }
+
+    func pauseAll() { tracker?.pauseAll() }
+    func resumeAll() { tracker?.resumeAll() }
+    func reset(for type: ReminderType) { tracker?.reset(for: type) }
+}
+
+/// File-scoped multicast continuations for `ScreenTimeTrackerClient.thresholdReached`.
+private let screenTimeThresholdContinuations =
+    LockIsolated<[UUID: AsyncStream<ReminderType>.Continuation]>([:])
+
+private func makeScreenTimeThresholdStream() -> AsyncStream<ReminderType> {
+    let (stream, continuation) = AsyncStream<ReminderType>.makeStream()
+    let id = UUID()
+    screenTimeThresholdContinuations.withValue { $0[id] = continuation }
+    continuation.onTermination = { _ in
+        screenTimeThresholdContinuations.withValue { dict in
+            dict[id] = nil
+        }
+    }
+    return stream
+}
+
+private func broadcastScreenTimeThreshold(_ type: ReminderType) {
+    screenTimeThresholdContinuations.withValue { dict in
+        for continuation in dict.values { continuation.yield(type) }
+    }
+}

--- a/EyePostureReminder/TCA/Dependencies/SettingsClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/SettingsClient.swift
@@ -1,0 +1,205 @@
+import Combine
+import ComposableArchitecture
+import Foundation
+
+/// TCA dependency client wrapping `SettingsStore` for reducer consumption.
+///
+/// Phase 0 of the MVVM → TCA migration (#665). The closure surface is the
+/// normative contract Phase 1 reducers will copy verbatim. The `liveValue`
+/// adapter routes every getter and setter through the existing `@MainActor`
+/// `SettingsStore` so both worlds coexist during the migration.
+@DependencyClient
+struct SettingsClient: Sendable {
+    /// Synchronous snapshot of the latest published `ReminderSettings` for the
+    /// eyes side. The live adapter caches the most recent value so reducers
+    /// can read it without hopping to the main actor.
+    var snapshot: @Sendable () -> ReminderSettings = {
+        ReminderSettings(interval: 0, breakDuration: 0)
+    }
+
+    /// Multicast stream of `ReminderSettings` snapshots. A new subscriber
+    /// receives the current snapshot and every subsequent change.
+    var stream: @Sendable () -> AsyncStream<ReminderSettings> = { .finished }
+
+    /// Toggles the global reminders master switch.
+    var updateGlobalEnabled: @Sendable (Bool) async -> Void
+
+    /// Toggles the eyes reminder type.
+    var updateEyesEnabled: @Sendable (Bool) async -> Void
+
+    /// Toggles the posture reminder type.
+    var updatePostureEnabled: @Sendable (Bool) async -> Void
+
+    /// Updates the eyes reminder interval, in seconds.
+    var updateEyesInterval: @Sendable (TimeInterval) async -> Void
+
+    /// Updates the posture reminder interval, in seconds.
+    var updatePostureInterval: @Sendable (TimeInterval) async -> Void
+
+    /// Updates the eyes break duration, in seconds.
+    var updateEyesBreakDuration: @Sendable (TimeInterval) async -> Void
+
+    /// Updates the posture break duration, in seconds.
+    var updatePostureBreakDuration: @Sendable (TimeInterval) async -> Void
+
+    /// Toggles the "pause media during breaks" feature.
+    var updatePauseMediaDuringBreaks: @Sendable (Bool) async -> Void
+
+    /// Toggles haptics on overlay events.
+    var updateHapticsEnabled: @Sendable (Bool) async -> Void
+
+    /// Toggles "pause during Focus mode".
+    var updatePauseDuringFocus: @Sendable (Bool) async -> Void
+
+    /// Toggles "pause while driving".
+    var updatePauseWhileDriving: @Sendable (Bool) async -> Void
+
+    /// Toggles the notification fallback path.
+    var updateNotificationFallbackEnabled: @Sendable (Bool) async -> Void
+
+    /// Sets the snoozed-until date, or clears snooze when `nil`.
+    var setSnoozedUntil: @Sendable (Date?) async -> Void
+
+    /// Sets the consecutive snooze count.
+    var setSnoozeCount: @Sendable (Int) async -> Void
+
+    /// Restores all settings to the bundled defaults.
+    var resetToDefaults: @Sendable () async -> Void
+}
+
+extension SettingsClient: DependencyKey {
+    static let liveValue: SettingsClient = {
+        Task { @MainActor in LiveSettingsBridge.shared.bootstrap() }
+        return SettingsClient(
+            snapshot: { settingsSnapshotCache.value },
+            stream: { makeSettingsStream() },
+            updateGlobalEnabled: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.globalEnabled = value }
+            },
+            updateEyesEnabled: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.eyesEnabled = value }
+            },
+            updatePostureEnabled: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.postureEnabled = value }
+            },
+            updateEyesInterval: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.eyesInterval = value }
+            },
+            updatePostureInterval: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.postureInterval = value }
+            },
+            updateEyesBreakDuration: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.eyesBreakDuration = value }
+            },
+            updatePostureBreakDuration: { value in
+                await MainActor.run {
+                    LiveSettingsBridge.shared.store.postureBreakDuration = value
+                }
+            },
+            updatePauseMediaDuringBreaks: { value in
+                await MainActor.run {
+                    LiveSettingsBridge.shared.store.pauseMediaDuringBreaks = value
+                }
+            },
+            updateHapticsEnabled: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.hapticsEnabled = value }
+            },
+            updatePauseDuringFocus: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.pauseDuringFocus = value }
+            },
+            updatePauseWhileDriving: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.pauseWhileDriving = value }
+            },
+            updateNotificationFallbackEnabled: { value in
+                await MainActor.run {
+                    LiveSettingsBridge.shared.store.notificationFallbackEnabled = value
+                }
+            },
+            setSnoozedUntil: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.snoozedUntil = value }
+            },
+            setSnoozeCount: { value in
+                await MainActor.run { LiveSettingsBridge.shared.store.snoozeCount = value }
+            },
+            resetToDefaults: {
+                await MainActor.run { LiveSettingsBridge.shared.store.resetToDefaults() }
+            }
+        )
+    }()
+}
+
+extension DependencyValues {
+    /// TCA accessor for the shared `SettingsClient`.
+    var settingsClient: SettingsClient {
+        get { self[SettingsClient.self] }
+        set { self[SettingsClient.self] = newValue }
+    }
+}
+
+/// Main-actor-isolated owner of the live `SettingsStore` plus the Combine
+/// subscription that mirrors `objectWillChange` updates into the file-scope
+/// snapshot cache and continuation registry.
+@MainActor
+private final class LiveSettingsBridge {
+    nonisolated static let shared = LiveSettingsBridge()
+
+    let store = SettingsStore()
+    private var cancellables: Set<AnyCancellable> = []
+    private var hasBootstrapped = false
+
+    private nonisolated init() {}
+
+    /// Idempotent bootstrap. Called from `liveValue` via a `@MainActor` task
+    /// so the Combine subscription is wired exactly once on the main actor.
+    func bootstrap() {
+        guard !hasBootstrapped else { return }
+        hasBootstrapped = true
+
+        let initial = store.settings(for: .eyes)
+        settingsSnapshotCache.setValue(initial)
+        broadcastSettings(initial)
+
+        store.objectWillChange
+            .receive(on: RunLoop.main)
+            .sink { [weak store] _ in
+                guard let store else { return }
+                let updated = store.settings(for: .eyes)
+                settingsSnapshotCache.setValue(updated)
+                broadcastSettings(updated)
+            }
+            .store(in: &cancellables)
+    }
+}
+
+/// File-scoped snapshot cache; safe to read from any actor.
+private let settingsSnapshotCache = LockIsolated<ReminderSettings>(
+    ReminderSettings(interval: 0, breakDuration: 0)
+)
+
+/// File-scoped multicast continuations. Held outside the `@MainActor` bridge
+/// to side-step a Swift constraint-solver bug that surfaces when
+/// `Continuation.onTermination` captures `@MainActor`-isolated static storage.
+private let settingsContinuations =
+    LockIsolated<[UUID: AsyncStream<ReminderSettings>.Continuation]>([:])
+
+/// File-scoped factory used by the live `stream` closure to register a new
+/// multicast subscriber. Yields the current snapshot synchronously so first
+/// reads never block on a `objectWillChange` tick.
+private func makeSettingsStream() -> AsyncStream<ReminderSettings> {
+    let (stream, continuation) = AsyncStream<ReminderSettings>.makeStream()
+    let id = UUID()
+    continuation.yield(settingsSnapshotCache.value)
+    settingsContinuations.withValue { $0[id] = continuation }
+    continuation.onTermination = { _ in
+        settingsContinuations.withValue { dict in
+            dict[id] = nil
+        }
+    }
+    return stream
+}
+
+private func broadcastSettings(_ value: ReminderSettings) {
+    settingsContinuations.withValue { dict in
+        for continuation in dict.values { continuation.yield(value) }
+    }
+}

--- a/EyePostureReminder/TCA/Features/AppCategoryPickerFeature.swift
+++ b/EyePostureReminder/TCA/Features/AppCategoryPickerFeature.swift
@@ -1,0 +1,17 @@
+import ComposableArchitecture
+import Foundation
+
+/// Phase-0 stub for the App-Category-Picker feature reducer.
+///
+/// Follows the empty-stub contract defined by `p0-tca-3` (#666) so Phase 1
+/// issue `p0-tca-9` (#672) can replace this file in isolation without merge
+/// conflicts against the root `AppFeature` skeleton.
+@Reducer
+struct AppCategoryPickerFeature {
+    @ObservableState
+    struct State: Equatable {}
+
+    enum Action: Equatable {}
+
+    var body: some ReducerOf<Self> { EmptyReducer() }
+}

--- a/EyePostureReminder/TCA/Features/HomeFeature.swift
+++ b/EyePostureReminder/TCA/Features/HomeFeature.swift
@@ -1,0 +1,17 @@
+import ComposableArchitecture
+import Foundation
+
+/// Phase-0 stub for the Home feature reducer.
+///
+/// Follows the empty-stub contract defined by `p0-tca-3` (#666) so Phase 1
+/// issue `p0-tca-5` (#668) can replace this file in isolation without merge
+/// conflicts against the root `AppFeature` skeleton.
+@Reducer
+struct HomeFeature {
+    @ObservableState
+    struct State: Equatable {}
+
+    enum Action: Equatable {}
+
+    var body: some ReducerOf<Self> { EmptyReducer() }
+}

--- a/EyePostureReminder/TCA/Features/OnboardingFeature.swift
+++ b/EyePostureReminder/TCA/Features/OnboardingFeature.swift
@@ -1,0 +1,17 @@
+import ComposableArchitecture
+import Foundation
+
+/// Phase-0 stub for the Onboarding feature reducer.
+///
+/// Follows the empty-stub contract defined by `p0-tca-3` (#666) so Phase 1
+/// issue `p0-tca-7` (#670) can replace this file in isolation without merge
+/// conflicts against the root `AppFeature` skeleton.
+@Reducer
+struct OnboardingFeature {
+    @ObservableState
+    struct State: Equatable {}
+
+    enum Action: Equatable {}
+
+    var body: some ReducerOf<Self> { EmptyReducer() }
+}

--- a/EyePostureReminder/TCA/Features/OverlayFeature.swift
+++ b/EyePostureReminder/TCA/Features/OverlayFeature.swift
@@ -1,0 +1,17 @@
+import ComposableArchitecture
+import Foundation
+
+/// Phase-0 stub for the Overlay feature reducer.
+///
+/// Follows the empty-stub contract defined by `p0-tca-3` (#666) so Phase 1
+/// issue `p0-tca-8` (#671) can replace this file in isolation without merge
+/// conflicts against the root `AppFeature` skeleton.
+@Reducer
+struct OverlayFeature {
+    @ObservableState
+    struct State: Equatable {}
+
+    enum Action: Equatable {}
+
+    var body: some ReducerOf<Self> { EmptyReducer() }
+}

--- a/EyePostureReminder/TCA/Features/SchedulingFeature.swift
+++ b/EyePostureReminder/TCA/Features/SchedulingFeature.swift
@@ -1,0 +1,20 @@
+import ComposableArchitecture
+import Foundation
+
+/// Phase-0 stub for the Scheduling feature reducer.
+///
+/// Follows the stub contract defined by `p0-tca-3` (#666). The lone `start`
+/// action is required by `AppFeature.onAppear` (which sends
+/// `.scheduling(.start)`) and will be filled in by Phase 1 issue `p0-tca-10`
+/// (#673), which adds the long-running scheduling effects.
+@Reducer
+struct SchedulingFeature {
+    @ObservableState
+    struct State: Equatable {}
+
+    enum Action: Equatable {
+        case start
+    }
+
+    var body: some ReducerOf<Self> { EmptyReducer() }
+}

--- a/EyePostureReminder/TCA/Features/SettingsFeature.swift
+++ b/EyePostureReminder/TCA/Features/SettingsFeature.swift
@@ -1,0 +1,17 @@
+import ComposableArchitecture
+import Foundation
+
+/// Phase-0 stub for the Settings feature reducer.
+///
+/// Follows the empty-stub contract defined by `p0-tca-3` (#666) so Phase 1
+/// issue `p0-tca-6` (#669) can replace this file in isolation without merge
+/// conflicts against the root `AppFeature` skeleton.
+@Reducer
+struct SettingsFeature {
+    @ObservableState
+    struct State: Equatable {}
+
+    enum Action: Equatable {}
+
+    var body: some ReducerOf<Self> { EmptyReducer() }
+}


### PR DESCRIPTION
Closes #666.

Phase 0 of #662 (MVVM → TCA migration). Lays the parallel TCA surface so each Phase 1 issue can drop in a feature reducer without merge conflicts on the root file.

## Files

- **`EyePostureReminder/TCA/AppFeature.swift`** — root `@Reducer` composing `HomeFeature`, `SettingsFeature`, `OnboardingFeature`, `SchedulingFeature` plus presentation wiring for `OverlayFeature` and a `Destination` enum (settings sheet + app-category picker). `onAppear` sends `.scheduling(.start)`; `scenePhaseChanged` and `notificationRouted` are reserved for Phase-2 (#675, #676).
- **`EyePostureReminder/TCA/Features/{Home,Settings,Onboarding,Scheduling,Overlay,AppCategoryPicker}Feature.swift`** — empty stubs so each Phase 1 PR (#668–#673) can replace exactly one file. `SchedulingFeature` carries the lone `.start` action because the root reducer references it.

## Stack note

This branch also picks up the **#665 dependency-clients commit (#687)** that was orphaned by a merge-order race: PR #687 was set up to merge into PR #684's branch (its base) instead of `main`, so when #684 squash-merged first the dependency-client files never reached `main`. The cherry-pick recovers all 10 `TCA/Dependencies/*Client.swift` files exactly as authored in #687.

## Acceptance

- [x] `./scripts/build.sh build` — `** BUILD SUCCEEDED **`
- [x] `./scripts/build.sh test` — `Executed 2075 tests, with 0 failures`
- [x] `./scripts/build.sh lint` — `Lint passed` + `Privacy sync check passed`
- [x] No existing app code modified; TCA is a parallel surface.

## Out of scope

- Filling out reducer bodies (Phase 1: #668–#673).
- Wiring root `Store` into `EyePostureReminderApp.swift` (Phase 2: #674).
- Navigation scaffolding `RootView` (#667 — next Phase-0 issue once this lands).