### PR TITLE
Add TCA navigation scaffolding (#667)

### DIFF
--- a/EyePostureReminder/TCA/Bindings/StoreScopes.swift
+++ b/EyePostureReminder/TCA/Bindings/StoreScopes.swift
@@ -1,0 +1,12 @@
+import ComposableArchitecture
+
+/// Shared `Store.scope(...)` helpers used by more than one Phase-1 feature
+/// view.
+///
+/// Phase 0 (`p0-tca-4` / #667) deliberately leaves this file empty: its
+/// presence gives Phase 1 issues (#668–#673) a single agreed-upon location
+/// for shared scopes so they do not invent new files that collide. As Phase
+/// 1 lands, helpers belonging to multiple features (e.g. presentation
+/// scopes, derived view-state projections) should be added here rather than
+/// in any individual feature view file.
+enum StoreScopes {}

--- a/EyePostureReminder/TCA/RootView.swift
+++ b/EyePostureReminder/TCA/RootView.swift
@@ -1,0 +1,59 @@
+import ComposableArchitecture
+import SwiftUI
+
+/// Phase-0 root SwiftUI surface for the TCA migration of the Eye & Posture
+/// Reminder app.
+///
+/// This view exists solely to give Phase 1 issues a concrete attachment
+/// point for sheet, picker, and overlay presentations. Every destination
+/// body deliberately renders `EmptyView()` for now — Phase 1 issues
+/// (#668–#673) will replace each placeholder with the real SwiftUI body
+/// when the corresponding feature reducer is filled in.
+///
+/// `RootView` is **not** wired into `EyePostureReminderApp.swift` yet.
+/// Phase 2 issue `p0-tca-11` (#674) takes ownership of swapping it in for
+/// the legacy MVVM `AppCoordinator` stack.
+struct RootView: View {
+    @Perception.Bindable var store: StoreOf<AppFeature>
+
+    var body: some View {
+        WithPerceptionTracking {
+            Group {
+                if store.hasSeenOnboarding {
+                    EmptyView()
+                } else {
+                    EmptyView()
+                }
+            }
+            .sheet(
+                item: $store.scope(
+                    state: \.destination?.settingsSheet,
+                    action: \.destination.settingsSheet
+                )
+            ) { _ in
+                EmptyView()
+            }
+            .fullScreenCover(
+                item: $store.scope(
+                    state: \.destination?.appCategoryPicker,
+                    action: \.destination.appCategoryPicker
+                )
+            ) { _ in
+                EmptyView()
+            }
+            .fullScreenCover(
+                item: $store.scope(state: \.$overlay, action: \.overlay)
+            ) { _ in
+                EmptyView()
+            }
+        }
+    }
+}
+
+#Preview {
+    RootView(
+        store: Store(initialState: AppFeature.State()) {
+            AppFeature()
+        }
+    )
+}


### PR DESCRIPTION
Closes #667.

Phase 0 of #662 (MVVM → TCA migration). Lays the SwiftUI navigation primitives the migrated UI will use so Phase 1 issues can attach sheet/picker/overlay modifiers without inventing new navigation infra in each PR.

## Files

- **`EyePostureReminder/TCA/RootView.swift`** — SwiftUI view bound to a `StoreOf<AppFeature>`. Switches on `state.hasSeenOnboarding` (both branches render `EmptyView()` in Phase 0) and attaches three presentation modifiers:
  - `.sheet` for `destination.settingsSheet`
  - `.fullScreenCover` for `destination.appCategoryPicker`
  - `.fullScreenCover` for the overlay scope
  Every destination body renders `EmptyView()` — Phase 1 issues (#668–#673) replace each placeholder with the real SwiftUI body. Includes a `#Preview` that instantiates a live `AppFeature` store.
- **`EyePostureReminder/TCA/Bindings/StoreScopes.swift`** — Empty caseless `enum StoreScopes {}` reserved as the agreed location for shared `Store.scope` helpers used by more than one Phase 1 feature view.

## iOS-16 note

Uses `@Perception.Bindable` + `WithPerceptionTracking` because the deployment target is iOS 16; the SwiftUI `@Bindable` macro is iOS 17+ and the Perception backport is required for `ObservableState` observation on iOS 16.

## Acceptance

- [x] `./scripts/build.sh build` — `** BUILD SUCCEEDED **`
- [x] `./scripts/build.sh test` — `Executed 2075 tests, with 0 failures`
- [x] `./scripts/build.sh lint` — `Lint passed` + `Privacy sync check passed`
- [x] No existing app code modified.

## Out of scope

- Wiring `RootView` into `EyePostureReminderApp.swift` (Phase 2: #674).
- Filling in real destination bodies (Phase 1: #668–#673).