### PR TITLE
Implement HomeFeature reducer (Phase 1)

### DIFF
--- a/EyePostureReminder/TCA/Features/HomeFeature.swift
+++ b/EyePostureReminder/TCA/Features/HomeFeature.swift
@@ -1,17 +1,159 @@
 import ComposableArchitecture
 import Foundation
+import UserNotifications
 
-/// Phase-0 stub for the Home feature reducer.
+/// Phase 1 reducer (`p0-tca-5` / #668) backing the Home screen.
 ///
-/// Follows the empty-stub contract defined by `p0-tca-3` (#666) so Phase 1
-/// issue `p0-tca-5` (#668) can replace this file in isolation without merge
-/// conflicts against the root `AppFeature` skeleton.
+/// Mirrors the read-only behaviour of the existing MVVM `HomeView` so a
+/// later Phase 2 issue (`p0-tca-14`) can swap the view body to read from
+/// this store without altering observable behaviour.
+///
+/// Inputs come from the shared dependency clients defined by `p0-tca-2`:
+/// `SettingsClient` exposes the eyes-side `ReminderSettings` snapshot/stream,
+/// and `NotificationClient` exposes the system authorisation status. Per-type
+/// enable flags (`globalEnabled` / `eyesEnabled` / `postureEnabled`) are held
+/// directly on `State` because the Phase 0 `SettingsClient` snapshot only
+/// vends the eyes `ReminderSettings`. Those flags will be wired into the
+/// store as part of Phase 2 (`p0-tca-15`) when bindings are introduced.
 @Reducer
 struct HomeFeature {
     @ObservableState
-    struct State: Equatable {}
+    struct State: Equatable {
+        var settings = ReminderSettings(interval: 0, breakDuration: 0)
+        var globalEnabled: Bool = true
+        var eyesEnabled: Bool = true
+        var postureEnabled: Bool = true
+        var notificationAuthStatus: UNAuthorizationStatus = .notDetermined
+        var trueInterruptBannerDismissed: Bool = false
+        var openSettingsOnLaunch: Bool = false
 
-    enum Action: Equatable {}
+        var statusLocalizationKey: String {
+            HomeFeature.statusLocalizationKey(
+                globalEnabled: globalEnabled,
+                eyesEnabled: eyesEnabled,
+                postureEnabled: postureEnabled,
+                notificationAuthStatus: notificationAuthStatus
+            )
+        }
 
-    var body: some ReducerOf<Self> { EmptyReducer() }
+        var shouldShowNotificationRecovery: Bool {
+            HomeFeature.shouldShowNotificationRecovery(
+                globalEnabled: globalEnabled,
+                notificationAuthStatus: notificationAuthStatus
+            )
+        }
+
+        var shouldShowNoRemindersConfigured: Bool {
+            HomeFeature.shouldShowNoRemindersConfigured(
+                globalEnabled: globalEnabled,
+                eyesEnabled: eyesEnabled,
+                postureEnabled: postureEnabled
+            )
+        }
+    }
+
+    enum Action: Equatable {
+        case onAppear
+        case task
+        case settingsTapped
+        case dismissTrueInterruptBanner
+        case settingsChanged(ReminderSettings)
+        case notificationAuthStatusChanged(UNAuthorizationStatus)
+    }
+
+    @Dependency(\.settingsClient) var settingsClient: SettingsClient
+    @Dependency(\.notificationClient) var notificationClient: NotificationClient
+    @Dependency(\.continuousClock) var clock
+
+    private enum CancelID: Hashable {
+        case settingsStream
+        case authStatusPoll
+    }
+
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .onAppear:
+                state.settings = settingsClient.snapshot()
+                return .run { send in
+                    let status = await notificationClient.authorizationStatus()
+                    await send(.notificationAuthStatusChanged(status))
+                }
+
+            case .task:
+                return .merge(
+                    .run { send in
+                        for await snapshot in settingsClient.stream() {
+                            await send(.settingsChanged(snapshot))
+                        }
+                    }
+                    .cancellable(id: CancelID.settingsStream, cancelInFlight: true),
+                    .run { [clock, notificationClient] send in
+                        for await _ in clock.timer(interval: .seconds(1)) {
+                            let status = await notificationClient.authorizationStatus()
+                            await send(.notificationAuthStatusChanged(status))
+                        }
+                    }
+                    .cancellable(id: CancelID.authStatusPoll, cancelInFlight: true)
+                )
+
+            case .settingsTapped:
+                // Parent (`AppFeature`) intercepts to present the settings sheet
+                // (Phase 2, `p0-tca-11`); the reducer itself has no local effect.
+                return .none
+
+            case .dismissTrueInterruptBanner:
+                state.trueInterruptBannerDismissed = true
+                return .none
+
+            case let .settingsChanged(snapshot):
+                state.settings = snapshot
+                return .none
+
+            case let .notificationAuthStatusChanged(status):
+                state.notificationAuthStatus = status
+                return .none
+            }
+        }
+    }
+
+    static func statusLocalizationKey(
+        globalEnabled: Bool,
+        eyesEnabled: Bool,
+        postureEnabled: Bool,
+        notificationAuthStatus: UNAuthorizationStatus
+    ) -> String {
+        if !globalEnabled {
+            return "home.status.paused"
+        }
+        if shouldShowNoRemindersConfigured(
+            globalEnabled: globalEnabled,
+            eyesEnabled: eyesEnabled,
+            postureEnabled: postureEnabled
+        ) {
+            return "home.status.noReminders"
+        }
+        if shouldShowNotificationRecovery(
+            globalEnabled: globalEnabled,
+            notificationAuthStatus: notificationAuthStatus
+        ) {
+            return "home.status.notificationsOff"
+        }
+        return "home.status.active"
+    }
+
+    static func shouldShowNotificationRecovery(
+        globalEnabled: Bool,
+        notificationAuthStatus: UNAuthorizationStatus
+    ) -> Bool {
+        globalEnabled && notificationAuthStatus == .denied
+    }
+
+    static func shouldShowNoRemindersConfigured(
+        globalEnabled: Bool,
+        eyesEnabled: Bool,
+        postureEnabled: Bool
+    ) -> Bool {
+        globalEnabled && !eyesEnabled && !postureEnabled
+    }
 }


### PR DESCRIPTION
Phase 1 implementation for `p0-tca-5` (#668).

## Summary

Replaces the empty Phase-0 stub at `EyePostureReminder/TCA/Features/HomeFeature.swift` with the full reducer surface required by the Phase 1 spec.

## What's in the reducer

- **State** holds the eyes-side `ReminderSettings`, master/per-type enable flags (`globalEnabled`, `eyesEnabled`, `postureEnabled`), `notificationAuthStatus`, `trueInterruptBannerDismissed`, and `openSettingsOnLaunch`. Three computed properties (`statusLocalizationKey`, `shouldShowNotificationRecovery`, `shouldShowNoRemindersConfigured`) are derived from these and call the matching static helpers ported verbatim from `HomeView`'s existing static methods.
- **Action vocabulary** matches the issue spec exactly: `onAppear`, `task`, `settingsTapped`, `dismissTrueInterruptBanner`, `settingsChanged(ReminderSettings)`, `notificationAuthStatusChanged(UNAuthorizationStatus)`.
- **Effects**:
  - `.onAppear` primes `state.settings` from `settingsClient.snapshot()` and fires an effect that fetches the current `notificationClient.authorizationStatus()`.
  - `.task` merges two cancellable, long-running effects: a `for await` over `settingsClient.stream()` and a `continuousClock.timer(interval: .seconds(1))` poll of the auth status. Each is keyed by its own `CancelID` and cancels in flight on re-entry.
  - `.settingsTapped` is a no-op locally; the parent (`AppFeature`) intercepts to present the settings sheet (Phase 2 wiring lives in `p0-tca-11`).
  - `.dismissTrueInterruptBanner` flips the in-memory flag (persistence is tracked separately, per the issue's "acceptable for Phase 1" allowance).
- **Status helpers** preserve all four existing localization keys (`home.status.paused`, `home.status.noReminders`, `home.status.notificationsOff`, `home.status.active`).

## Why per-type flags live on `State`

The Phase-0 `SettingsClient.snapshot` returns a `ReminderSettings` containing only `interval` + `breakDuration` for the eyes side. The status helpers in the issue spec require `globalEnabled` / `eyesEnabled` / `postureEnabled`, but exposing those on `SettingsClient` is owned by `p0-tca-15` (#678). To honour this issue's "own this file only" constraint, the flags are held directly on `State` with sensible defaults; the bindings layer added in Phase 2 will populate them.

## Verification

- `./scripts/build.sh all` passes locally — build, lint (SwiftLint), and the full 2,075-test suite (104s).
- No file outside `EyePostureReminder/TCA/Features/HomeFeature.swift` was modified.
- Branch matches the spec: `users/squad/issue--home-feature-reducer`.

## Out of scope (per spec)

- `HomeView.swift` is **not** modified — Phase 2 issue `p0-tca-14` (#677) swaps the view body to read from this store.
- `AppFeature.swift` is **not** modified — Phase 2 wiring for `Destination.settingsSheet`, scene phase, and notification routes are owned by `p0-tca-11`/`p0-tca-12`/`p0-tca-13`.

Closes #668
