### PR TITLE
Implement OverlayFeature reducer (Phase 1)

### DIFF
--- a/EyePostureReminder/TCA/Features/OverlayFeature.swift
+++ b/EyePostureReminder/TCA/Features/OverlayFeature.swift
@@ -1,17 +1,127 @@
 import ComposableArchitecture
 import Foundation
 
-/// Phase-0 stub for the Overlay feature reducer.
+/// Phase 1 reducer (`p0-tca-8` / #671) backing the on-screen break overlay.
 ///
-/// Follows the empty-stub contract defined by `p0-tca-3` (#666) so Phase 1
-/// issue `p0-tca-8` (#671) can replace this file in isolation without merge
-/// conflicts against the root `AppFeature` skeleton.
+/// Owns the *currently presented* overlay's state — countdown, dismissal
+/// flag, and analytics emission for both manual and automatic dismissal.
+/// Lifecycle events from `OverlayClient.lifecycleEvents` are intentionally
+/// consumed by `SchedulingFeature` (`p0-tca-10`), not here, so this reducer
+/// stays focused on a single presentation instance.
 @Reducer
 struct OverlayFeature {
     @ObservableState
-    struct State: Equatable {}
+    struct State: Equatable, Identifiable {
+        let id: UUID
+        let type: ReminderType
+        let duration: TimeInterval
+        let hapticsEnabled: Bool
+        let pauseMediaEnabled: Bool
+        var secondsRemaining: Int
+        var isDismissing: Bool = false
 
-    enum Action: Equatable {}
+        init(
+            id: UUID = UUID(),
+            type: ReminderType,
+            duration: TimeInterval,
+            hapticsEnabled: Bool = true,
+            pauseMediaEnabled: Bool = false
+        ) {
+            self.id = id
+            self.type = type
+            self.duration = duration
+            self.hapticsEnabled = hapticsEnabled
+            self.pauseMediaEnabled = pauseMediaEnabled
+            self.secondsRemaining = max(0, Int(duration.rounded()))
+        }
+    }
 
-    var body: some ReducerOf<Self> { EmptyReducer() }
+    enum Action: Equatable {
+        case onAppear
+        case timerTick
+        case dismissTapped
+        case settingsTapped
+        case timerExpired
+        case dismissed
+    }
+
+    @Dependency(\.continuousClock) var clock
+    @Dependency(\.overlayClient) var overlayClient: OverlayClient
+    @Dependency(\.analyticsClient) var analyticsClient: AnalyticsClient
+
+    private enum CancelID: Hashable {
+        case timer
+    }
+
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .onAppear:
+                guard state.secondsRemaining > 0 else {
+                    return .send(.timerExpired)
+                }
+                return .run { [clock] send in
+                    for await _ in clock.timer(interval: .seconds(1)) {
+                        await send(.timerTick)
+                    }
+                }
+                .cancellable(id: CancelID.timer, cancelInFlight: true)
+
+            case .timerTick:
+                state.secondsRemaining = max(0, state.secondsRemaining - 1)
+                if state.secondsRemaining == 0 {
+                    return .send(.timerExpired)
+                }
+                return .none
+
+            case .dismissTapped:
+                guard !state.isDismissing else { return .none }
+                state.isDismissing = true
+                let elapsed = elapsed(in: state)
+                let type = state.type
+                analyticsClient.log(
+                    .overlayDismissed(type: type, method: .button, elapsedS: elapsed)
+                )
+                return .merge(
+                    .cancel(id: CancelID.timer),
+                    .run { [overlayClient] send in
+                        await overlayClient.dismiss()
+                        await send(.dismissed)
+                    }
+                )
+
+            case .settingsTapped:
+                let elapsed = elapsed(in: state)
+                analyticsClient.log(
+                    .overlayDismissed(
+                        type: state.type,
+                        method: .settingsTap,
+                        elapsedS: elapsed
+                    )
+                )
+                return .none
+
+            case .timerExpired:
+                guard !state.isDismissing else { return .none }
+                state.isDismissing = true
+                analyticsClient.log(
+                    .overlayAutoDismissed(type: state.type, durationS: state.duration)
+                )
+                return .merge(
+                    .cancel(id: CancelID.timer),
+                    .run { [overlayClient] send in
+                        await overlayClient.dismiss()
+                        await send(.dismissed)
+                    }
+                )
+
+            case .dismissed:
+                return .cancel(id: CancelID.timer)
+            }
+        }
+    }
+
+    private func elapsed(in state: State) -> TimeInterval {
+        max(0, state.duration - TimeInterval(state.secondsRemaining))
+    }
 }


### PR DESCRIPTION
Phase 1 implementation for `p0-tca-8` (#671).

## Summary

Replaces the empty Phase-0 stub at `EyePostureReminder/TCA/Features/OverlayFeature.swift` with the full reducer surface required by the Phase 1 spec.

## What's in the reducer

- **State** conforms to `Identifiable` and carries the immutable presentation parameters (`type`, `duration`, `hapticsEnabled`, `pauseMediaEnabled`) plus mutable `secondsRemaining` and `isDismissing`. A convenience initializer seeds `secondsRemaining` from the requested `duration`.
- **Action vocabulary** matches the spec: `onAppear`, `timerTick`, `dismissTapped`, `settingsTapped`, `timerExpired`, `dismissed`.
- **Effects**:
  - `.onAppear` starts a `continuousClock.timer(interval: .seconds(1))` that pumps `.timerTick`; cancellable via `CancelID.timer` so dismissal stops the countdown deterministically.
  - `.timerTick` decrements and forwards to `.timerExpired` when `secondsRemaining` hits zero.
  - `.dismissTapped` / `.timerExpired` flip `isDismissing` once (re-entrancy guarded), log the matching analytics event (`overlayDismissed(.button)` / `overlayAutoDismissed`), cancel the timer, and call `OverlayClient.dismiss` before sending `.dismissed`.
  - `.settingsTapped` logs `overlayDismissed(.settingsTap)`; the parent (`AppFeature`) drives the actual settings sheet presentation.
  - `.dismissed` cancels the timer as a final safety net.

## Notes on the analytics surface

The Phase-0 `AnalyticsEvent` enum exposes `.overlayDismissed(type:method:elapsedS:)` and `.overlayAutoDismissed(type:durationS:)` — the issue spec's `.overlayPresented(type:)` does not exist in the codebase (and the spec leaves "presented" lifecycle observation to `SchedulingFeature` via `OverlayClient.lifecycleEvents`). This reducer logs only events that map onto existing `AnalyticsEvent` cases and does **not** fabricate new cases or modify any other file.

## Verification

- `./scripts/build.sh all` passes locally — build, lint (SwiftLint), and the full 2,075-test suite (101s).
- No file outside `EyePostureReminder/TCA/Features/OverlayFeature.swift` was modified.
- Branch matches the spec: `users/squad/issue--overlay-feature-reducer`.

## Out of scope (per spec)

- `OverlayView.swift` and `OverlayManager.swift` are **not** modified — Phase 2 issue `p0-tca-14` swaps the view body to read from this store.
- Subscription to `OverlayClient.lifecycleEvents` lives in `SchedulingFeature` (`p0-tca-10` / #673).

Closes #671
