### PR TITLE
Implement SettingsFeature reducer (Phase 1)

### DIFF
--- a/EyePostureReminder/TCA/Features/SettingsFeature.swift
+++ b/EyePostureReminder/TCA/Features/SettingsFeature.swift
@@ -1,17 +1,222 @@
 import ComposableArchitecture
 import Foundation
 
-/// Phase-0 stub for the Settings feature reducer.
+/// Phase 1 reducer (`p0-tca-6` / #669) replacing the legacy
+/// `SettingsViewModel` for the Settings screen.
 ///
-/// Follows the empty-stub contract defined by `p0-tca-3` (#666) so Phase 1
-/// issue `p0-tca-6` (#669) can replace this file in isolation without merge
-/// conflicts against the root `AppFeature` skeleton.
+/// Mirrors the observable behaviour of `SettingsViewModel` so a later
+/// Phase 2 issue (`p0-tca-14` / #677) can swap `SettingsView` to read from
+/// this store and the legacy view-model can be deleted.
+///
+/// ## Phase 0 dependency surface
+///
+/// `SettingsClient.snapshot` (defined in `p0-tca-2` / #663) only returns
+/// the eyes-side `ReminderSettings`. The posture-side `prev*` capture
+/// fields live on `State` per the issue spec but are populated only once
+/// Phase 2 extends the snapshot surface (`p0-tca-15` / #678). They default
+/// to `.zero` and are not exercised by this reducer.
+///
+/// ## Why `settings` is computed
+///
+/// `ReminderSettings.interval` and `ReminderSettings.breakDuration` are
+/// declared `let`, which makes `\State.settings.interval` only a read-only
+/// `KeyPath`. `BindableAction` requires `WritableKeyPath`, so the bindable
+/// surface uses the top-level `eyesInterval` / `eyesBreakDuration` mirrors
+/// and `settings` is derived from them. This keeps the spec's
+/// `state.settings` accessor intact for downstream callers
+/// (`scheduler.rescheduleReminder(_:_:)`).
 @Reducer
 struct SettingsFeature {
     @ObservableState
-    struct State: Equatable {}
+    struct State: Equatable {
+        /// Eyes-side reminder interval, in seconds. Bindable from the View.
+        var eyesInterval: TimeInterval = 0
 
-    enum Action: Equatable {}
+        /// Eyes-side break duration, in seconds. Bindable from the View.
+        var eyesBreakDuration: TimeInterval = 0
 
-    var body: some ReducerOf<Self> { EmptyReducer() }
+        /// Last-committed eyes interval; used to compute analytics deltas.
+        var prevEyesInterval: TimeInterval = .zero
+
+        /// Last-committed eyes break duration; used to compute analytics
+        /// deltas.
+        var prevEyesBreakDuration: TimeInterval = .zero
+
+        /// Last-committed posture interval. Populated once Phase 2 extends
+        /// `SettingsClient` to vend posture-side snapshots (`p0-tca-15`).
+        var prevPostureInterval: TimeInterval = .zero
+
+        /// Last-committed posture break duration. Populated once Phase 2
+        /// extends `SettingsClient` to vend posture-side snapshots
+        /// (`p0-tca-15`).
+        var prevPostureBreakDuration: TimeInterval = .zero
+
+        /// Drives presentation of the reset-to-defaults confirmation alert.
+        var showResetConfirm: Bool = false
+
+        /// Drives presentation of the transient "Saved" banner.
+        var showSavedBanner: Bool = false
+
+        /// Aggregated eyes-side `ReminderSettings` view used by the
+        /// scheduler client. Computed because `ReminderSettings` exposes
+        /// `let` fields and so cannot be mutated through a bindable key
+        /// path.
+        var settings: ReminderSettings {
+            ReminderSettings(
+                interval: eyesInterval,
+                breakDuration: eyesBreakDuration
+            )
+        }
+    }
+
+    enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
+        case onAppear
+        case settingsChanged(ReminderSettings)
+        case snoozeTapped(SnoozeOption)
+        case resetConfirmed
+        case savedBannerExpired
+    }
+
+    /// Snooze durations exposed to the Settings UI. Mirrors
+    /// `SettingsViewModel.SnoozeOption` so analytics codes are stable
+    /// across the MVVM → TCA migration. Localised labels stay in the View
+    /// layer per the Phase 1 "own this file only" constraint.
+    enum SnoozeOption: String, CaseIterable, Equatable, Sendable {
+        case fiveMinutes
+        case oneHour
+        case restOfDay
+
+        /// Stable, non-localised analytics code emitted with
+        /// `.snoozeActivated`. Never changes between app versions or
+        /// locales.
+        var analyticsCode: String {
+            switch self {
+            case .fiveMinutes: return "5m"
+            case .oneHour:     return "1h"
+            case .restOfDay:   return "rest_of_day"
+            }
+        }
+    }
+
+    @Dependency(\.settingsClient) var settingsClient: SettingsClient
+    @Dependency(\.reminderSchedulerClient) var scheduler: ReminderSchedulerClient
+    @Dependency(\.analyticsClient) var analytics: AnalyticsClient
+    @Dependency(\.continuousClock) var clock
+    @Dependency(\.date) var now
+    @Dependency(\.calendar) var calendar
+
+    private enum CancelID: Hashable {
+        case eyesIntervalDebounce
+        case eyesBreakDurationDebounce
+        case snoozeBanner
+    }
+
+    var body: some ReducerOf<Self> {
+        BindingReducer()
+        Reduce { state, action in
+            switch action {
+            case .binding(\.eyesInterval):
+                let oldValue = state.prevEyesInterval
+                let newValue = state.eyesInterval
+                let nextSettings = state.settings
+                state.showSavedBanner = true
+                return .run { send in
+                    try await clock.sleep(for: .milliseconds(300))
+                    await settingsClient.updateEyesInterval(newValue)
+                    await scheduler.rescheduleReminder(.eyes, nextSettings)
+                    analytics.log(.settingChanged(
+                        setting: .eyesInterval,
+                        oldValue: String(oldValue),
+                        newValue: String(newValue)
+                    ))
+                    try await clock.sleep(for: .seconds(2))
+                    await send(.savedBannerExpired)
+                }
+                .cancellable(id: CancelID.eyesIntervalDebounce, cancelInFlight: true)
+
+            case .binding(\.eyesBreakDuration):
+                let oldValue = state.prevEyesBreakDuration
+                let newValue = state.eyesBreakDuration
+                let nextSettings = state.settings
+                state.showSavedBanner = true
+                return .run { send in
+                    try await clock.sleep(for: .milliseconds(300))
+                    await settingsClient.updateEyesBreakDuration(newValue)
+                    await scheduler.rescheduleReminder(.eyes, nextSettings)
+                    analytics.log(.settingChanged(
+                        setting: .eyesBreakDuration,
+                        oldValue: String(oldValue),
+                        newValue: String(newValue)
+                    ))
+                    try await clock.sleep(for: .seconds(2))
+                    await send(.savedBannerExpired)
+                }
+                .cancellable(id: CancelID.eyesBreakDurationDebounce, cancelInFlight: true)
+
+            case .binding:
+                return .none
+
+            case .onAppear:
+                let snapshot = settingsClient.snapshot()
+                state.eyesInterval = snapshot.interval
+                state.eyesBreakDuration = snapshot.breakDuration
+                state.prevEyesInterval = snapshot.interval
+                state.prevEyesBreakDuration = snapshot.breakDuration
+                return .none
+
+            case let .settingsChanged(snapshot):
+                state.eyesInterval = snapshot.interval
+                state.eyesBreakDuration = snapshot.breakDuration
+                state.prevEyesInterval = snapshot.interval
+                state.prevEyesBreakDuration = snapshot.breakDuration
+                return .none
+
+            case let .snoozeTapped(option):
+                let endDate = option.endDate(referenceDate: now(), calendar: calendar)
+                state.showSavedBanner = true
+                return .run { send in
+                    await settingsClient.setSnoozedUntil(endDate)
+                    await settingsClient.setSnoozeCount(0)
+                    analytics.log(.snoozeActivated(durationOption: option.analyticsCode))
+                    try await clock.sleep(for: .seconds(2))
+                    await send(.savedBannerExpired)
+                }
+                .cancellable(id: CancelID.snoozeBanner, cancelInFlight: true)
+
+            case .resetConfirmed:
+                state.showResetConfirm = false
+                return .run { _ in
+                    await settingsClient.resetToDefaults()
+                }
+
+            case .savedBannerExpired:
+                state.showSavedBanner = false
+                return .none
+            }
+        }
+    }
+}
+
+extension SettingsFeature.SnoozeOption {
+    /// Computes the absolute snooze expiry date from an injected reference
+    /// date and calendar. Copied verbatim from
+    /// `SettingsViewModel.SnoozeOption.endDate(referenceDate:calendar:)`
+    /// so behaviour — including the rest-of-day midnight calculation that
+    /// honours DST transitions — matches the legacy implementation
+    /// exactly.
+    func endDate(referenceDate: Date, calendar: Calendar) -> Date {
+        switch self {
+        case .fiveMinutes:
+            return referenceDate.addingTimeInterval(5 * 60)
+        case .oneHour:
+            return referenceDate.addingTimeInterval(60 * 60)
+        case .restOfDay:
+            return calendar.date(
+                byAdding: .day,
+                value: 1,
+                to: calendar.startOfDay(for: referenceDate)
+            ) ?? referenceDate.addingTimeInterval(24 * 60 * 60)
+        }
+    }
 }


### PR DESCRIPTION
Phase 1 implementation for `p0-tca-6` (#669).

## Summary

Replaces the empty Phase-0 stub at `EyePostureReminder/TCA/Features/SettingsFeature.swift` with the full reducer surface required by the Phase 1 spec.

Mirrors `SettingsViewModel`'s observable behaviour so a later Phase 2 issue (`p0-tca-14` / #677) can swap `SettingsView` to read from this store and the legacy view-model can be deleted.

## What's in the reducer

- **State** holds eyes-side bindable mirrors (`eyesInterval`, `eyesBreakDuration`), `prev*` capture fields for analytics deltas (eyes + posture; posture is wired in by `p0-tca-15` / #678), and the two UI flags `showResetConfirm` / `showSavedBanner`. A computed `var settings: ReminderSettings` aggregator preserves the spec's downstream accessor used by `scheduler.rescheduleReminder(_:_:)`.
- **`Action`** vocabulary matches the spec: `binding(BindingAction<State>)`, `onAppear`, `settingsChanged(ReminderSettings)`, `snoozeTapped(SnoozeOption)`, `resetConfirmed`, `savedBannerExpired`.
- **`SnoozeOption`** (`fiveMinutes` / `oneHour` / `restOfDay`) carries the stable analytics codes (`5m` / `1h` / `rest_of_day`) and a `endDate(referenceDate:calendar:)` helper copied verbatim from `SettingsViewModel.SnoozeOption` so the rest-of-day midnight calculation continues to honour DST transitions.
- **Effects:**
  - `.binding(\.eyesInterval)` and `.binding(\.eyesBreakDuration)` each schedule a 300 ms-debounced effect (`.cancellable(id:cancelInFlight: true)`) that persists via the matching `settingsClient.update*` setter, calls `scheduler.rescheduleReminder(.eyes, state.settings)` for the affected type only, logs a `.settingChanged` analytics delta against the captured `prev*`, and emits `.savedBannerExpired` after a 2 s `clock.sleep(for: .seconds(2))`.
  - `.settingsChanged(snapshot)` mirrors stream updates into state and rebases `prev*` to the committed snapshot so subsequent deltas use the correct baseline.
  - `.snoozeTapped(option)` computes the absolute end date via `option.endDate(referenceDate: now(), calendar: calendar)`, persists `setSnoozedUntil` + `setSnoozeCount(0)`, logs `.snoozeActivated`, and shows the saved banner for 2 s.
  - `.resetConfirmed` dismisses the confirmation flag and restores defaults via `settingsClient.resetToDefaults()`.

## Why `settings` is computed (deviation from spec)

`ReminderSettings.interval` and `ReminderSettings.breakDuration` are declared `let`, which makes `\State.settings.interval` only a read-only `KeyPath`. `BindableAction` requires `WritableKeyPath`, so the bindable surface uses the top-level `eyesInterval` / `eyesBreakDuration` mirrors and `settings` is derived from them. The accessor surface (`state.settings`) the spec assumes for `scheduler.rescheduleReminder(_:_:)` is preserved.

## Notes on dependency accessor names

The issue spec lists `\.settings`, `\.reminderScheduler`, and `\.analytics`. The Phase-0 `DependencyValues` extensions that ship in this repo declare `settingsClient`, `reminderSchedulerClient`, and `analyticsClient`; the implementation uses those names to match the conventions established by `HomeFeature` (#690) and `OverlayFeature` (#691).

## Notes on the analytics surface

The spec lists `.snoozeActivated(code:)`. The actual `AnalyticsEvent` case is `.snoozeActivated(durationOption:)`; the implementation forwards `SnoozeOption.analyticsCode` through that parameter without fabricating new cases or modifying `AnalyticsLogger.swift`.

## Verification

- `./scripts/build.sh all` passes locally — build, lint (SwiftLint), and the full 2,075-test suite (106 s).
- No file outside `EyePostureReminder/TCA/Features/SettingsFeature.swift` was modified.
- Branch matches the spec: `users/squad/issue-669-settings-feature-reducer`.

## Out of scope (per spec)

- Deleting `SettingsViewModel.swift` — Phase 2 issue `p0-tca-14` (#677).
- Migrating `SettingsView.swift` — Phase 2 issue `p0-tca-14` (#677).

Closes #669
