### PR TITLE
Implement OnboardingFeature reducer (Phase 1)

### DIFF
--- a/EyePostureReminder/TCA/Features/OnboardingFeature.swift
+++ b/EyePostureReminder/TCA/Features/OnboardingFeature.swift
@@ -1,17 +1,141 @@
 import ComposableArchitecture
 import Foundation
+import UserNotifications
 
-/// Phase-0 stub for the Onboarding feature reducer.
+/// Phase 1 reducer (`p0-tca-7` / #670) backing the onboarding flow.
 ///
-/// Follows the empty-stub contract defined by `p0-tca-3` (#666) so Phase 1
-/// issue `p0-tca-7` (#670) can replace this file in isolation without merge
-/// conflicts against the root `AppFeature` skeleton.
+/// Mirrors the observable behaviour of `OnboardingView` and the
+/// `OnboardingCoordinator`-style hooks routed through `AppCoordinator`
+/// today, so a later Phase 2 issue (`p0-tca-14` / #677) can swap the
+/// onboarding views to read from this store and the legacy
+/// `AppCoordinator` plumbing can be retired.
+///
+/// ## Persistence and parent wiring
+///
+/// `.completedOnboarding` is emitted but never acted on locally; the parent
+/// (`AppFeature`) listens for it to flip
+/// `@AppStorage(AppStorageKey.hasSeenOnboarding)` and dismiss the
+/// onboarding flow. `showAppCategoryPicker` follows the same parent-driven
+/// presentation contract: this reducer only flips the flag while the parent
+/// presents `Destination.appCategoryPicker` (Phase 2 wiring lives in
+/// `p0-tca-11` / #674).
 @Reducer
 struct OnboardingFeature {
     @ObservableState
-    struct State: Equatable {}
+    struct State: Equatable {
+        /// Index of the visible page (0 … 3) inside the onboarding `TabView`.
+        var currentPage: Int = 0
 
-    enum Action: Equatable {}
+        /// Latest `ScreenTimeAuthorizationStatus` observed via
+        /// `ScreenTimeAuthorizationClient`. Defaults to `.unavailable` until
+        /// the FamilyControls entitlement is provisioned (#201).
+        var screenTimeStatus: ScreenTimeAuthorizationStatus = .unavailable
 
-    var body: some ReducerOf<Self> { EmptyReducer() }
+        /// Latest `UNAuthorizationStatus` observed via `NotificationClient`.
+        var notificationAuthStatus: UNAuthorizationStatus = .notDetermined
+
+        /// Drives parent-side presentation of `AppCategoryPickerView`.
+        var showAppCategoryPicker: Bool = false
+    }
+
+    enum Action: Equatable {
+        case onAppear
+        case nextTapped
+        case skipTapped
+        case finishTapped
+        case finishAndCustomizeTapped
+        case requestNotificationPermission
+        case requestScreenTimeAuthorization
+        case notificationStatusChanged(UNAuthorizationStatus)
+        case screenTimeStatusChanged(ScreenTimeAuthorizationStatus)
+        case openAppCategoryPicker
+        case dismissAppCategoryPicker
+        case completedOnboarding
+    }
+
+    @Dependency(\.notificationClient) var notification: NotificationClient
+    @Dependency(\.screenTimeAuthorizationClient) var screenTimeAuth: ScreenTimeAuthorizationClient
+    @Dependency(\.analyticsClient) var analytics: AnalyticsClient
+
+    /// Final page index in the 4-page onboarding `TabView`.
+    static let lastPageIndex: Int = 3
+
+    /// Notification authorisation options requested by the onboarding
+    /// permission page. Mirrors the set used by `AppCoordinator` so the
+    /// system prompt copy stays identical across the migration.
+    static let notificationOptions: UNAuthorizationOptions = [.alert, .sound, .badge]
+
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .onAppear:
+                return .run { send in
+                    let notificationStatus = await notification.authorizationStatus()
+                    await send(.notificationStatusChanged(notificationStatus))
+                    let screenTime = await screenTimeAuth.status()
+                    await send(.screenTimeStatusChanged(screenTime))
+                }
+
+            case .nextTapped:
+                state.currentPage = min(state.currentPage + 1, Self.lastPageIndex)
+                return .none
+
+            case .skipTapped, .finishTapped:
+                analytics.log(.onboardingCompleted(cta: .getStarted))
+                return .send(.completedOnboarding)
+
+            case .finishAndCustomizeTapped:
+                analytics.log(.onboardingCompleted(cta: .customize))
+                return .merge(
+                    .send(.completedOnboarding),
+                    .send(.openAppCategoryPicker)
+                )
+
+            case .requestNotificationPermission:
+                return .run { send in
+                    // Permission grant outcome (granted / denied) is reflected
+                    // in the subsequent authorisation status read; the boolean
+                    // result and any throws are intentionally swallowed here
+                    // because `notificationStatusChanged` is the single
+                    // source of truth for downstream UI.
+                    _ = try? await notification.requestAuthorization(Self.notificationOptions)
+                    let status = await notification.authorizationStatus()
+                    await send(.notificationStatusChanged(status))
+                    // Spec calls for `.notificationPermissionResponded(...)` here;
+                    // that case is not present in the current `AnalyticsEvent`
+                    // surface and adding it would violate the "own this file
+                    // only" constraint, so the analytics call is deferred to
+                    // the AnalyticsLogger surface extension that owns it.
+                }
+
+            case .requestScreenTimeAuthorization:
+                return .run { send in
+                    let status = await screenTimeAuth.requestAuthorization()
+                    await send(.screenTimeStatusChanged(status))
+                }
+
+            case let .notificationStatusChanged(status):
+                state.notificationAuthStatus = status
+                return .none
+
+            case let .screenTimeStatusChanged(status):
+                state.screenTimeStatus = status
+                return .none
+
+            case .openAppCategoryPicker:
+                state.showAppCategoryPicker = true
+                return .none
+
+            case .dismissAppCategoryPicker:
+                state.showAppCategoryPicker = false
+                return .none
+
+            case .completedOnboarding:
+                // Parent (`AppFeature`) intercepts to flip
+                // `hasSeenOnboarding` and dismiss onboarding (Phase 2,
+                // `p0-tca-11`); the reducer itself has no local effect.
+                return .none
+            }
+        }
+    }
 }


### PR DESCRIPTION
Phase 1 implementation for `p0-tca-7` (#670).

## Summary

Replaces the empty Phase-0 stub at `EyePostureReminder/TCA/Features/OnboardingFeature.swift` with the full reducer surface required by the Phase 1 spec.

Mirrors the observable behaviour of `OnboardingView` and the `OnboardingCoordinator`-style hooks routed through `AppCoordinator` today, so a later Phase 2 issue (`p0-tca-14` / #677) can swap the onboarding views to read from this store and the legacy `AppCoordinator` plumbing can be retired.

## What's in the reducer

- **State** matches the spec: `currentPage` (0 … 3), `screenTimeStatus` (defaults to `.unavailable` until the FamilyControls entitlement is provisioned in #201), `notificationAuthStatus` (defaults to `.notDetermined`), and `showAppCategoryPicker` for parent-driven sheet presentation.
- **`Action`** vocabulary matches the spec exactly: `onAppear`, `nextTapped`, `skipTapped`, `finishTapped`, `finishAndCustomizeTapped`, `requestNotificationPermission`, `requestScreenTimeAuthorization`, `notificationStatusChanged(UNAuthorizationStatus)`, `screenTimeStatusChanged(ScreenTimeAuthorizationStatus)`, `openAppCategoryPicker`, `dismissAppCategoryPicker`, `completedOnboarding`.
- **Effects:**
  - `.onAppear` reads both authorisation surfaces and dispatches the matching `*Changed` action for each (sequential `.run` send so the notification status lands first, mirroring the page order).
  - `.nextTapped` clamps `currentPage` to 3.
  - `.skipTapped` / `.finishTapped` log `.onboardingCompleted(cta: .getStarted)` and emit `.completedOnboarding` for the parent to act on.
  - `.finishAndCustomizeTapped` logs `.onboardingCompleted(cta: .customize)` and merges `.completedOnboarding` with `.openAppCategoryPicker` so the parent both dismisses onboarding and presents the picker sheet — matching `OnboardingView.finishOnboardingAndCustomize`.
  - `.requestNotificationPermission` requests `[.alert, .sound, .badge]`, swallows the boolean grant result and any throws (the subsequent `authorizationStatus()` read is the single source of truth), and dispatches `.notificationStatusChanged`.
  - `.requestScreenTimeAuthorization` forwards through the screen-time client and dispatches `.screenTimeStatusChanged`.
  - `.openAppCategoryPicker` / `.dismissAppCategoryPicker` only flip the state flag — actual sheet presentation is owned by `AppFeature`.
  - `.completedOnboarding` is a parent-listened bubble; the reducer itself performs no local mutation.

## Notes on dependency accessor names

The issue spec lists `\.notification`, `\.screenTimeAuthorization`, and `\.analytics`. The Phase-0 `DependencyValues` extensions that ship in this repo declare `notificationClient`, `screenTimeAuthorizationClient`, and `analyticsClient`; the implementation uses those names to match `HomeFeature` (#690), `OverlayFeature` (#691), and `SettingsFeature` (#692).

## Notes on the analytics surface

The spec lists `.notificationPermissionResponded(...)`. That case is not present in the current `AnalyticsEvent` surface and adding it would violate the "own this file only" constraint, so the analytics call is deferred to the AnalyticsLogger surface extension that owns it.

## Verification

- `./scripts/build.sh all` passes locally — build, lint (SwiftLint), and the full 2,075-test suite (106 s).
- No file outside `EyePostureReminder/TCA/Features/OnboardingFeature.swift` was modified.
- Branch matches the spec: `users/squad/issue-670-onboarding-feature-reducer`.

## Out of scope (per spec)

- Modifying any existing `Onboarding/*.swift` view — Phase 2 issue `p0-tca-14` (#677).
- Wiring `hasSeenOnboarding` into `AppFeature` — parent wiring is part of `p0-tca-3` (#666); the `.completedOnboarding` bubble is the contract for that integration.

Closes #670
