### PR TITLE
Implement AppCategoryPickerFeature reducer (Phase 1)

### DIFF
--- a/EyePostureReminder/TCA/Features/AppCategoryPickerFeature.swift
+++ b/EyePostureReminder/TCA/Features/AppCategoryPickerFeature.swift
@@ -1,17 +1,84 @@
 import ComposableArchitecture
 import Foundation
+import ScreenTimeExtensionShared
+#if canImport(UIKit)
+import UIKit
+#endif
 
-/// Phase-0 stub for the App-Category-Picker feature reducer.
+/// Phase-1 reducer for the True Interrupt Mode app/category configuration
+/// surface.
 ///
-/// Follows the empty-stub contract defined by `p0-tca-3` (#666) so Phase 1
-/// issue `p0-tca-9` (#672) can replace this file in isolation without merge
-/// conflicts against the root `AppFeature` skeleton.
+/// Mirrors the observable behaviour of `AppCategoryPickerView` +
+/// `SelectedAppsState`: tracks the Screen Time authorisation status, holds the
+/// latest `AppGroupSelectionSnapshot`, drives the authorisation request flow,
+/// and routes the `denied` recovery path through iOS Settings. The parent
+/// `AppFeature` is responsible for dismissing the destination on `.doneTapped`
+/// (e.g. by clearing `state.destination`).
 @Reducer
 struct AppCategoryPickerFeature {
     @ObservableState
-    struct State: Equatable {}
+    struct State: Equatable {
+        var authorizationStatus: ScreenTimeAuthorizationStatus = .unavailable
+        var selection: AppGroupSelectionSnapshot = .empty
+        var isLoadingSelection: Bool = false
+        var lastError: String?
+    }
 
-    enum Action: Equatable {}
+    enum Action: Equatable {
+        case onAppear
+        case requestAuthorizationTapped
+        case openSettingsTapped
+        case selectionChanged(AppGroupSelectionSnapshot)
+        case authorizationStatusChanged(ScreenTimeAuthorizationStatus)
+        case doneTapped
+    }
 
-    var body: some ReducerOf<Self> { EmptyReducer() }
+    @Dependency(\.screenTimeAuthorizationClient) var screenTimeAuthorizationClient
+    @Dependency(\.openURL) var openURL
+
+    var body: some ReducerOf<Self> {
+        Reduce { state, action in
+            switch action {
+            case .onAppear:
+                state.isLoadingSelection = true
+                // Selection persistence to App Group is owned by p0-tca-15 (#678) —
+                // IPCClient surface is intentionally not extended here.
+                state.selection = .empty
+                state.isLoadingSelection = false
+                return .run { send in
+                    let status = await screenTimeAuthorizationClient.status()
+                    await send(.authorizationStatusChanged(status))
+                }
+
+            case .requestAuthorizationTapped:
+                return .run { send in
+                    let status = await screenTimeAuthorizationClient.requestAuthorization()
+                    await send(.authorizationStatusChanged(status))
+                }
+
+            case .openSettingsTapped:
+                #if canImport(UIKit)
+                guard let settingsURL = URL(string: UIApplication.openSettingsURLString) else {
+                    return .none
+                }
+                return .run { _ in await openURL(settingsURL) }
+                #else
+                return .none
+                #endif
+
+            case .selectionChanged(let snapshot):
+                state.selection = snapshot
+                // Selection persistence to App Group is owned by p0-tca-15 (#678) —
+                // IPCClient surface is intentionally not extended here.
+                return .none
+
+            case .authorizationStatusChanged(let status):
+                state.authorizationStatus = status
+                return .none
+
+            case .doneTapped:
+                return .none
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Replaces the Phase-0 empty stub at `EyePostureReminder/TCA/Features/AppCategoryPickerFeature.swift` with the Phase-1 reducer specified in issue #672. Mirrors the observable behaviour of the existing MVVM pair `AppCategoryPickerView` + `SelectedAppsState` without modifying them — Phase 2 (#677) owns the legacy deletion.

Only `EyePostureReminder/TCA/Features/AppCategoryPickerFeature.swift` is touched.

## Behaviours implemented

- `.onAppear`: sets `isLoadingSelection = true`, hydrates `selection` to `.empty` (see deviation #2 below), clears the flag, and kicks off a `.run` effect that reads `screenTimeAuthorizationClient.status()` and feeds it back via `.authorizationStatusChanged`.
- `.requestAuthorizationTapped`: calls `screenTimeAuthorizationClient.requestAuthorization()` and emits `.authorizationStatusChanged(result)`.
- `.openSettingsTapped`: opens `URL(string: UIApplication.openSettingsURLString)` via the TCA `\.openURL` dependency. Guarded by `#if canImport(UIKit)` and uses a `guard let` rather than a force-unwrap to satisfy SwiftLint's `force_unwrapping` rule.
- `.selectionChanged(snapshot)`: assigns the snapshot to state (persistence deferred — see deviation #2).
- `.authorizationStatusChanged(status)`: assigns the status to state.
- `.doneTapped`: returns `.none`; the parent `AppFeature` is responsible for clearing the destination.

## Deviations from the issue spec

1. **Dependency accessor names.** The issue text references `\.screenTimeAuthorization` and `\.ipc`. The dependency clients on `main` actually expose `\.screenTimeAuthorizationClient` and `\.ipcClient` (see `EyePostureReminder/TCA/Dependencies/ScreenTimeAuthorizationClient.swift` and `IPCClient.swift`). This reducer consumes the real accessors. This matches the same deviation already in flight in PR #693 (OnboardingFeature).

2. **Selection persistence deferred to #678.** Acceptance criterion #3 forbids modifying any file outside `AppCategoryPickerFeature.swift`. The current `IPCClient` surface only exposes `isTrueInterruptEnabled`, `record(AppGroupIPCEvent, String?)`, and `trueInterruptChanges`; there is no `readSelection`/`writeSelection`, and `AppGroupIPCEventKind` has no `selectionUpdated` case. Per the spec's tension-resolution guidance, the reducer updates `state.selection` immediately and skips persistence, with a one-line code comment in both `.onAppear` and `.selectionChanged` noting that App-Group persistence is owned by p0-tca-15 (#678).

## Verification

`./scripts/build.sh all` passes — 2075 tests, build, lint (runtime ~106 s on this machine).

Closes #672
