### PR TITLE
Wire root TCA Store in EyePostureReminderApp (Phase 2)

### DIFF
--- a/EyePostureReminder/App/EyePostureReminderApp.swift
+++ b/EyePostureReminder/App/EyePostureReminderApp.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import SwiftUI
 
 @main
@@ -12,17 +13,28 @@ struct EyePostureReminderApp: App {
     /// switcher, control centre).
     @State private var wasInBackground = false
 
+    /// Single TCA `Store` driving the app, introduced by `p0-tca-11` (#674).
+    /// `AppCoordinator` is intentionally kept alongside the store so legacy
+    /// MVVM surfaces (Settings/Home views consuming `@EnvironmentObject`)
+    /// keep working until `p0-tca-14` (#677) decommissions them.
+    private let store: StoreOf<AppFeature>
+
     init() {
         AppTypography.registerFonts()
+        var initialState = AppFeature.State()
+        initialState.hasSeenOnboarding = UserDefaults.standard.bool(
+            forKey: AppStorageKey.hasSeenOnboarding
+        )
+        self.store = Store(initialState: initialState) { AppFeature() }
     }
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(store: store)
                 .environmentObject(coordinator.settings)
                 .environmentObject(coordinator)
                 .task {
-                    await coordinator.scheduleReminders()
+                    await store.send(.scheduling(.start)).finish()
                 }
                 .onChange(of: scenePhase) { phase in
                     switch phase {

--- a/EyePostureReminder/TCA/AppFeature.swift
+++ b/EyePostureReminder/TCA/AppFeature.swift
@@ -35,6 +35,7 @@ struct AppFeature {
     enum Action {
         case onAppear
         case scenePhaseChanged(ScenePhase)
+        case hasSeenOnboardingChanged(Bool)
         case home(HomeFeature.Action)
         case settings(SettingsFeature.Action)
         case onboarding(OnboardingFeature.Action)
@@ -56,12 +57,15 @@ struct AppFeature {
         Scope(state: \.onboarding, action: \.onboarding) { OnboardingFeature() }
         Scope(state: \.scheduling, action: \.scheduling) { SchedulingFeature() }
 
-        Reduce { _, action in
+        Reduce { state, action in
             switch action {
             case .onAppear:
                 return .send(.scheduling(.start))
             case .scenePhaseChanged:
                 // Phase-2 issue p0-tca-13 (#676) fills this in.
+                return .none
+            case .hasSeenOnboardingChanged(let value):
+                state.hasSeenOnboarding = value
                 return .none
             case .notificationRouted:
                 // Phase-2 issue p0-tca-12 (#675) fills this in.

--- a/EyePostureReminder/Views/ContentView.swift
+++ b/EyePostureReminder/Views/ContentView.swift
@@ -1,28 +1,52 @@
+import ComposableArchitecture
 import SwiftUI
 
+/// Root SwiftUI surface that gates between `OnboardingView` and `HomeView`.
+///
+/// `p0-tca-11` (#674) wires this view to the TCA `Store` so the gate decision
+/// reads from `AppFeature.State.hasSeenOnboarding`. The legacy
+/// `@AppStorage(AppStorageKey.hasSeenOnboarding)` is bridged into the store
+/// via `.onChange` so `OnboardingView`'s `UserDefaults` write (which still
+/// owns persistence until `p0-tca-14`) propagates to the TCA state and flips
+/// the gate without an MVVM-side observer.
 struct ContentView: View {
-    @AppStorage(AppStorageKey.hasSeenOnboarding) private var hasSeenOnboarding = false
+    @Perception.Bindable var store: StoreOf<AppFeature>
+    @AppStorage(AppStorageKey.hasSeenOnboarding) private var persistedHasSeenOnboarding = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        ZStack {
-            if hasSeenOnboarding {
-                NavigationStack {
-                    HomeView()
-                }
-                .transition(.opacity)
-            } else {
-                OnboardingView()
+        WithPerceptionTracking {
+            ZStack {
+                if store.hasSeenOnboarding {
+                    NavigationStack {
+                        HomeView()
+                    }
                     .transition(.opacity)
+                } else {
+                    OnboardingView()
+                        .transition(.opacity)
+                }
+            }
+            .animation(
+                reduceMotion ? nil : AppAnimation.onboardingTransition,
+                value: store.hasSeenOnboarding
+            )
+            .onChange(of: persistedHasSeenOnboarding) { newValue in
+                if store.hasSeenOnboarding != newValue {
+                    store.send(.hasSeenOnboardingChanged(newValue))
+                }
             }
         }
-        .animation(reduceMotion ? nil : AppAnimation.onboardingTransition, value: hasSeenOnboarding)
     }
 }
 
 #Preview {
     let coordinator = AppCoordinator()
-    ContentView()
-        .environmentObject(coordinator.settings)
-        .environmentObject(coordinator)
+    ContentView(
+        store: Store(initialState: AppFeature.State()) {
+            AppFeature()
+        }
+    )
+    .environmentObject(coordinator.settings)
+    .environmentObject(coordinator)
 }

--- a/Tests/EyePostureReminderTests/TCA/AppCategoryPickerFeatureTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/AppCategoryPickerFeatureTests.swift
@@ -1,0 +1,145 @@
+import ComposableArchitecture
+import ScreenTimeExtensionShared
+import XCTest
+
+@testable import EyePostureReminder
+
+/// `TestStore` baseline coverage for `AppCategoryPickerFeature` (Phase 1
+/// reducer `p0-tca-9` / #672). Behavioural parity with the legacy
+/// `SelectedAppsState` lives under Phase 2 issue `p0-tca-15` (#678) once the
+/// IPC client surface is extended.
+@MainActor
+final class AppCategoryPickerFeatureTests: XCTestCase {
+
+    // MARK: - Default state
+
+    func test_state_init_defaultsAreUnauthorisedAndEmptySelection() {
+        let state = AppCategoryPickerFeature.State()
+
+        XCTAssertEqual(state.authorizationStatus, .unavailable)
+        XCTAssertEqual(state.selection, .empty)
+        XCTAssertFalse(state.isLoadingSelection)
+        XCTAssertNil(state.lastError)
+    }
+
+    // MARK: - .onAppear
+
+    func test_onAppear_clearsSelectionAndPollsAuthorisationStatus() async {
+        let store = TestStore(initialState: AppCategoryPickerFeature.State()) {
+            AppCategoryPickerFeature()
+        } withDependencies: {
+            $0.screenTimeAuthorizationClient = ScreenTimeAuthorizationClient(
+                status: { .approved },
+                statusChanges: { .finished },
+                requestAuthorization: { .approved }
+            )
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.authorizationStatusChanged) {
+            $0.authorizationStatus = .approved
+        }
+    }
+
+    func test_onAppear_propagatesUnavailableStatus() async {
+        let store = TestStore(initialState: AppCategoryPickerFeature.State()) {
+            AppCategoryPickerFeature()
+        } withDependencies: {
+            $0.screenTimeAuthorizationClient = ScreenTimeAuthorizationClient(
+                status: { .unavailable },
+                statusChanges: { .finished },
+                requestAuthorization: { .unavailable }
+            )
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.authorizationStatusChanged)
+    }
+
+    // MARK: - .requestAuthorizationTapped
+
+    func test_requestAuthorizationTapped_routesThroughClientAndUpdatesState() async {
+        let store = TestStore(initialState: AppCategoryPickerFeature.State()) {
+            AppCategoryPickerFeature()
+        } withDependencies: {
+            $0.screenTimeAuthorizationClient = ScreenTimeAuthorizationClient(
+                status: { .denied },
+                statusChanges: { .finished },
+                requestAuthorization: { .denied }
+            )
+        }
+
+        await store.send(.requestAuthorizationTapped)
+        await store.receive(\.authorizationStatusChanged) {
+            $0.authorizationStatus = .denied
+        }
+    }
+
+    // MARK: - .openSettingsTapped
+
+    func test_openSettingsTapped_invokesOpenURL() async {
+        let opened = LockIsolated<[URL]>([])
+
+        let store = TestStore(initialState: AppCategoryPickerFeature.State()) {
+            AppCategoryPickerFeature()
+        } withDependencies: {
+            $0.openURL = OpenURLEffect { url in
+                opened.withValue { $0.append(url) }
+                return true
+            }
+        }
+
+        await store.send(.openSettingsTapped).finish()
+
+        // UIApplication.openSettingsURLString — exact value is OS-defined; assert the
+        // schema we routed to settings rather than equality on a private string.
+        opened.withValue { urls in
+            XCTAssertEqual(urls.count, 1, "openSettingsTapped must route exactly one URL")
+            XCTAssertEqual(urls.first?.scheme, "app-settings",
+                           "Settings URL scheme must be 'app-settings:'")
+        }
+    }
+
+    // MARK: - .selectionChanged
+
+    func test_selectionChanged_writesSnapshotOntoState() async {
+        let snapshot = AppGroupSelectionSnapshot.empty
+        let store = TestStore(initialState: AppCategoryPickerFeature.State()) {
+            AppCategoryPickerFeature()
+        }
+
+        await store.send(.selectionChanged(snapshot))
+    }
+
+    // MARK: - .authorizationStatusChanged
+
+    func test_authorizationStatusChanged_setsApproved() async {
+        let store = TestStore(initialState: AppCategoryPickerFeature.State()) {
+            AppCategoryPickerFeature()
+        }
+
+        await store.send(.authorizationStatusChanged(.approved)) {
+            $0.authorizationStatus = .approved
+        }
+    }
+
+    func test_authorizationStatusChanged_setsDenied() async {
+        let store = TestStore(initialState: AppCategoryPickerFeature.State()) {
+            AppCategoryPickerFeature()
+        }
+
+        await store.send(.authorizationStatusChanged(.denied)) {
+            $0.authorizationStatus = .denied
+        }
+    }
+
+    // MARK: - .doneTapped
+
+    func test_doneTapped_isPureNoOpAtFeatureLevel() async {
+        let store = TestStore(initialState: AppCategoryPickerFeature.State()) {
+            AppCategoryPickerFeature()
+        }
+
+        await store.send(.doneTapped)
+    }
+}

--- a/Tests/EyePostureReminderTests/TCA/AppFeatureTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/AppFeatureTests.swift
@@ -1,0 +1,243 @@
+import ComposableArchitecture
+import SwiftUI
+import XCTest
+
+@testable import EyePostureReminder
+
+/// `TestStore` coverage for `AppFeature` introduced by Phase 2 issue
+/// `p0-tca-11` (#674) — the wiring step that gives `EyePostureReminderApp`
+/// a real root `Store`.
+///
+/// Phase-1 child reducers (`HomeFeature`, `SettingsFeature`,
+/// `OnboardingFeature`, `SchedulingFeature`) are scoped into the body but
+/// none of their actions are exercised here — those reducers are covered by
+/// the dedicated `*FeatureTests` rewrites tracked under `p0-tca-17` … `-20`.
+/// Every dependency client used by Phase-1 reducers is still overridden so
+/// `liveValue` factories that touch `UNUserNotificationCenter.current()` /
+/// `UIApplication` are never evaluated when the test bundle constructs the
+/// store.
+@MainActor
+final class AppFeatureTests: XCTestCase {
+
+    // MARK: - Test helpers
+
+    /// Builds a `TestStore` with every dependency client stubbed to a no-op
+    /// so child-reducer effects (when accidentally triggered) cannot reach
+    /// production singletons or fail with a `liveValue` crash inside the
+    /// SwiftPM xctest bundle.
+    private func makeStore(
+        initialState: AppFeature.State = AppFeature.State()
+    ) -> TestStoreOf<AppFeature> {
+        TestStore(initialState: initialState) {
+            AppFeature()
+        } withDependencies: {
+            $0.settingsClient = SettingsClient(
+                snapshot: { ReminderSettings(interval: 0, breakDuration: 0) },
+                stream: { .finished },
+                updateGlobalEnabled: { _ in },
+                updateEyesEnabled: { _ in },
+                updatePostureEnabled: { _ in },
+                updateEyesInterval: { _ in },
+                updatePostureInterval: { _ in },
+                updateEyesBreakDuration: { _ in },
+                updatePostureBreakDuration: { _ in },
+                updatePauseMediaDuringBreaks: { _ in },
+                updateHapticsEnabled: { _ in },
+                updatePauseDuringFocus: { _ in },
+                updatePauseWhileDriving: { _ in },
+                updateNotificationFallbackEnabled: { _ in },
+                setSnoozedUntil: { _ in },
+                setSnoozeCount: { _ in },
+                resetToDefaults: {}
+            )
+            $0.notificationClient = NotificationClient(
+                requestAuthorization: { _ in false },
+                authorizationStatus: { .notDetermined },
+                add: { _ in },
+                removePending: { _ in },
+                removeAllPending: {},
+                pendingRequests: { [] },
+                deliveredNotifications: { [] }
+            )
+            $0.reminderSchedulerClient = ReminderSchedulerClient(
+                scheduleReminders: { _ in },
+                rescheduleReminder: { _, _ in },
+                cancelReminder: { _ in },
+                cancelAllReminders: {}
+            )
+            $0.overlayClient = OverlayClient(
+                show: { _, _, _, _ in },
+                dismiss: {},
+                clearQueue: {},
+                clearQueueForType: { _ in },
+                isVisible: { false },
+                lifecycleEvents: { .finished }
+            )
+            $0.screenTimeTrackerClient = ScreenTimeTrackerClient(
+                setThreshold: { _, _ in },
+                enableTracking: { _ in },
+                disableTracking: { _ in },
+                pauseAll: {},
+                resumeAll: {},
+                reset: { _ in },
+                thresholdReached: { .finished }
+            )
+            $0.pauseConditionClient = PauseConditionClient(
+                isPaused: { false },
+                pauseChanges: { .finished },
+                startMonitoring: {},
+                stopMonitoring: {}
+            )
+            $0.ipcClient = IPCClient(
+                isTrueInterruptEnabled: { false },
+                record: { _, _ in },
+                trueInterruptChanges: { .finished }
+            )
+            $0.deviceActivityMonitorClient = DeviceActivityMonitorClient(
+                schedule: { _, _ in },
+                cancel: { _ in }
+            )
+            $0.screenTimeAuthorizationClient = ScreenTimeAuthorizationClient()
+            $0.analyticsClient = AnalyticsClient(log: { _ in })
+        }
+    }
+
+    // MARK: - Default state
+
+    /// `AppFeature.State()` must match the persistence-free defaults
+    /// `EyePostureReminderApp.init` overlays its `UserDefaults` bridge on.
+    func test_initialState_matchesDocumentedDefaults() {
+        let state = AppFeature.State()
+
+        XCTAssertFalse(state.hasSeenOnboarding,
+                       "hasSeenOnboarding must default to false so first launch shows onboarding")
+        XCTAssertNil(state.overlay,
+                     "overlay presentation must default to nil")
+        XCTAssertNil(state.destination,
+                     "destination presentation must default to nil")
+    }
+
+    // MARK: - hasSeenOnboardingChanged (introduced by #674)
+
+    /// Sending `.hasSeenOnboardingChanged(true)` toggles `state.hasSeenOnboarding`
+    /// without producing a follow-up effect — the bridge from
+    /// `@AppStorage(AppStorageKey.hasSeenOnboarding)` written by
+    /// `OnboardingView.markOnboardingComplete` relies on this exact pure write
+    /// so `ContentView` flips from `OnboardingView` → `HomeView`.
+    func test_hasSeenOnboardingChanged_true_setsStateAndProducesNoEffect() async {
+        let store = makeStore()
+
+        await store.send(.hasSeenOnboardingChanged(true)) {
+            $0.hasSeenOnboarding = true
+        }
+    }
+
+    /// Sending `.hasSeenOnboardingChanged(false)` reverses the gate so a UI
+    /// test reset / "factory reset" path can drop the user back into onboarding
+    /// without a launch.
+    func test_hasSeenOnboardingChanged_false_clearsState() async {
+        var initial = AppFeature.State()
+        initial.hasSeenOnboarding = true
+        let store = makeStore(initialState: initial)
+
+        await store.send(.hasSeenOnboardingChanged(false)) {
+            $0.hasSeenOnboarding = false
+        }
+    }
+
+    /// Sending the same value as the current state is still applied (the
+    /// reducer does not early-return) — `ContentView` guards against a
+    /// redundant dispatch but the reducer itself stays idempotent.
+    func test_hasSeenOnboardingChanged_idempotent_keepsValueStable() async {
+        var initial = AppFeature.State()
+        initial.hasSeenOnboarding = true
+        let store = makeStore(initialState: initial)
+
+        // Same value: no state delta; no effect.
+        await store.send(.hasSeenOnboardingChanged(true))
+    }
+
+    // MARK: - scenePhaseChanged (Phase-2 deferred to #676)
+
+    /// `.scenePhaseChanged` must remain a pure no-op until `p0-tca-13`
+    /// (#676) wires scenePhase observation through the store.
+    func test_scenePhaseChanged_active_isNoOp() async {
+        let store = makeStore()
+        await store.send(.scenePhaseChanged(.active))
+    }
+
+    func test_scenePhaseChanged_background_isNoOp() async {
+        let store = makeStore()
+        await store.send(.scenePhaseChanged(.background))
+    }
+
+    func test_scenePhaseChanged_inactive_isNoOp() async {
+        let store = makeStore()
+        await store.send(.scenePhaseChanged(.inactive))
+    }
+
+    // MARK: - notificationRouted (Phase-2 deferred to #675)
+
+    /// `.notificationRouted` must remain a pure no-op at the AppFeature level
+    /// until `p0-tca-12` (#675) bridges AppDelegate routes to the
+    /// `SchedulingFeature` reducer. The forwarding reducer change happens in
+    /// the #675 PR; here we only assert the Phase-1 contract that the action
+    /// is accepted without state mutation or effect.
+    func test_notificationRouted_reminder_isNoOpAtAppLevel() async {
+        let store = makeStore()
+        await store.send(.notificationRouted(.reminder(.eyes)))
+    }
+
+    func test_notificationRouted_snoozeWake_isNoOpAtAppLevel() async {
+        let store = makeStore()
+        await store.send(.notificationRouted(.snoozeWake))
+    }
+
+    func test_notificationRouted_ignore_isNoOpAtAppLevel() async {
+        let store = makeStore()
+        await store.send(.notificationRouted(.ignore))
+    }
+
+    // MARK: - Destination state Equatable conformance
+
+    /// `AppFeature.Destination.State` synthesised `Equatable` is required by
+    /// `@Presents` / `ifLet(\.$destination, action: \.destination)` to detect
+    /// presentation changes. Verifies both cases compare correctly.
+    func test_destinationState_equatable_settingsSheetCases_areEqual() {
+        let lhs: AppFeature.Destination.State = .settingsSheet(SettingsFeature.State())
+        let rhs: AppFeature.Destination.State = .settingsSheet(SettingsFeature.State())
+
+        XCTAssertEqual(lhs, rhs,
+                       "Two .settingsSheet destinations with equal payloads must compare equal")
+    }
+
+    func test_destinationState_equatable_appCategoryPickerCases_areEqual() {
+        let lhs: AppFeature.Destination.State = .appCategoryPicker(AppCategoryPickerFeature.State())
+        let rhs: AppFeature.Destination.State = .appCategoryPicker(AppCategoryPickerFeature.State())
+
+        XCTAssertEqual(lhs, rhs,
+                       "Two .appCategoryPicker destinations with equal payloads must compare equal")
+    }
+
+    func test_destinationState_equatable_differentCases_areUnequal() {
+        let lhs: AppFeature.Destination.State = .settingsSheet(SettingsFeature.State())
+        let rhs: AppFeature.Destination.State = .appCategoryPicker(AppCategoryPickerFeature.State())
+
+        XCTAssertNotEqual(lhs, rhs,
+                          ".settingsSheet and .appCategoryPicker must compare unequal")
+    }
+
+    // MARK: - NotificationRoute typealias re-export
+
+    /// `AppFeature.NotificationRoute` is re-exported from
+    /// `AppDelegate.NotificationRoute` — verify the typealias resolves
+    /// transparently so callers can refer to it without the `AppDelegate.`
+    /// qualifier.
+    func test_notificationRouteTypealias_resolvesToAppDelegateRoute() {
+        let route: AppFeature.NotificationRoute = .reminder(.eyes)
+        let delegateRoute: AppDelegate.NotificationRoute = route
+
+        XCTAssertEqual(route, delegateRoute,
+                       "AppFeature.NotificationRoute must be an alias of AppDelegate.NotificationRoute")
+    }
+}

--- a/Tests/EyePostureReminderTests/TCA/ContentViewTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/ContentViewTests.swift
@@ -1,0 +1,179 @@
+import ComposableArchitecture
+import SwiftUI
+import UIKit
+import XCTest
+
+@testable import EyePostureReminder
+
+/// `ContentView` body coverage — exercises both the onboarding-gated branch
+/// and the home branch wired up by Phase 2 issue `p0-tca-11` (#674).
+///
+/// `ContentView` requires both a TCA `Store` (root state) and the legacy
+/// `@EnvironmentObject` graph (`SettingsStore` + `AppCoordinator`) because
+/// `HomeView` / `OnboardingView` have not yet been migrated off MVVM
+/// (`p0-tca-14` / #677).
+@MainActor
+final class ContentViewTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Constructs a TCA `Store` for `ContentView` whose dependency graph is
+    /// safe in the SwiftPM xctest bundle (no `UNUserNotificationCenter`
+    /// access, no overlay window manipulation).
+    private func makeStore(hasSeenOnboarding: Bool) -> StoreOf<AppFeature> {
+        var initial = AppFeature.State()
+        initial.hasSeenOnboarding = hasSeenOnboarding
+        return Store(initialState: initial) {
+            AppFeature()
+        } withDependencies: {
+            $0.settingsClient = SettingsClient(
+                snapshot: { ReminderSettings(interval: 0, breakDuration: 0) },
+                stream: { .finished },
+                updateGlobalEnabled: { _ in },
+                updateEyesEnabled: { _ in },
+                updatePostureEnabled: { _ in },
+                updateEyesInterval: { _ in },
+                updatePostureInterval: { _ in },
+                updateEyesBreakDuration: { _ in },
+                updatePostureBreakDuration: { _ in },
+                updatePauseMediaDuringBreaks: { _ in },
+                updateHapticsEnabled: { _ in },
+                updatePauseDuringFocus: { _ in },
+                updatePauseWhileDriving: { _ in },
+                updateNotificationFallbackEnabled: { _ in },
+                setSnoozedUntil: { _ in },
+                setSnoozeCount: { _ in },
+                resetToDefaults: {}
+            )
+            $0.notificationClient = NotificationClient(
+                requestAuthorization: { _ in false },
+                authorizationStatus: { .notDetermined },
+                add: { _ in },
+                removePending: { _ in },
+                removeAllPending: {},
+                pendingRequests: { [] },
+                deliveredNotifications: { [] }
+            )
+            $0.reminderSchedulerClient = ReminderSchedulerClient(
+                scheduleReminders: { _ in },
+                rescheduleReminder: { _, _ in },
+                cancelReminder: { _ in },
+                cancelAllReminders: {}
+            )
+            $0.overlayClient = OverlayClient(
+                show: { _, _, _, _ in },
+                dismiss: {},
+                clearQueue: {},
+                clearQueueForType: { _ in },
+                isVisible: { false },
+                lifecycleEvents: { .finished }
+            )
+            $0.screenTimeTrackerClient = ScreenTimeTrackerClient(
+                setThreshold: { _, _ in },
+                enableTracking: { _ in },
+                disableTracking: { _ in },
+                pauseAll: {},
+                resumeAll: {},
+                reset: { _ in },
+                thresholdReached: { .finished }
+            )
+            $0.pauseConditionClient = PauseConditionClient(
+                isPaused: { false },
+                pauseChanges: { .finished },
+                startMonitoring: {},
+                stopMonitoring: {}
+            )
+            $0.ipcClient = IPCClient(
+                isTrueInterruptEnabled: { false },
+                record: { _, _ in },
+                trueInterruptChanges: { .finished }
+            )
+            $0.deviceActivityMonitorClient = DeviceActivityMonitorClient(
+                schedule: { _, _ in },
+                cancel: { _ in }
+            )
+            $0.screenTimeAuthorizationClient = ScreenTimeAuthorizationClient()
+            $0.analyticsClient = AnalyticsClient(log: { _ in })
+        }
+    }
+
+    /// Builds an `AppCoordinator` whose collaborators are all mock doubles —
+    /// matches `PreviewTests.makeTestCoordinator()`.
+    private func makeTestCoordinator() -> AppCoordinator {
+        AppCoordinator(
+            scheduler: MockReminderScheduler(),
+            notificationCenter: MockNotificationCenter(),
+            overlayManager: MockOverlayPresenting(),
+            screenTimeTracker: MockScreenTimeTracker(),
+            pauseConditionProvider: MockPauseConditionProvider(),
+            ipcStore: MockAppGroupIPCRecorder()
+        )
+    }
+
+    // MARK: - Body description coverage
+
+    /// Verifies that `ContentView`'s body type can be described — exercises
+    /// the `WithPerceptionTracking` closure construction and the surrounding
+    /// modifier stack without depending on a UIKit host.
+    func test_contentView_body_isNonEmptyDescription_whenOnboardingNotSeen() {
+        let store = makeStore(hasSeenOnboarding: false)
+        let view = ContentView(store: store)
+
+        let described = String(describing: view.body)
+        XCTAssertFalse(described.isEmpty,
+                       "ContentView.body must produce a non-empty description in the onboarding-gated branch")
+    }
+
+    func test_contentView_body_isNonEmptyDescription_whenOnboardingSeen() {
+        let store = makeStore(hasSeenOnboarding: true)
+        let view = ContentView(store: store)
+
+        let described = String(describing: view.body)
+        XCTAssertFalse(described.isEmpty,
+                       "ContentView.body must produce a non-empty description in the home branch")
+    }
+
+    // MARK: - Store wiring contract
+
+    /// The store passed in is the only source of truth for the gate — flipping
+    /// `hasSeenOnboarding` on the underlying state must be observable through
+    /// the store the view holds.
+    func test_contentView_store_reflectsHasSeenOnboardingTrue() {
+        let store = makeStore(hasSeenOnboarding: true)
+        let view = ContentView(store: store)
+
+        XCTAssertTrue(view.store.hasSeenOnboarding,
+                      "ContentView must read its gate from the injected store's state")
+    }
+
+    func test_contentView_store_reflectsHasSeenOnboardingFalse() {
+        let store = makeStore(hasSeenOnboarding: false)
+        let view = ContentView(store: store)
+
+        XCTAssertFalse(view.store.hasSeenOnboarding,
+                       "ContentView must read the false branch from the injected store's state")
+    }
+
+    // MARK: - hasSeenOnboardingChanged dispatch contract
+
+    /// Sending `.hasSeenOnboardingChanged(true)` to the wired store flips
+    /// `store.hasSeenOnboarding` — proves the bridge `ContentView`'s
+    /// `.onChange` closure relies on actually mutates state.
+    func test_contentView_storeDispatch_flipsGateForward() {
+        let store = makeStore(hasSeenOnboarding: false)
+
+        store.send(.hasSeenOnboardingChanged(true))
+
+        XCTAssertTrue(store.hasSeenOnboarding,
+                      "Sending hasSeenOnboardingChanged(true) must flip the gate in the wired store")
+    }
+
+    func test_contentView_storeDispatch_flipsGateBackward() {
+        let store = makeStore(hasSeenOnboarding: true)
+
+        store.send(.hasSeenOnboardingChanged(false))
+
+        XCTAssertFalse(store.hasSeenOnboarding,
+                       "Sending hasSeenOnboardingChanged(false) must restore the onboarding gate")
+    }
+}

--- a/Tests/EyePostureReminderTests/TCA/HomeFeatureTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/HomeFeatureTests.swift
@@ -1,0 +1,260 @@
+import ComposableArchitecture
+import UserNotifications
+import XCTest
+
+@testable import EyePostureReminder
+
+/// `TestStore` baseline coverage for `HomeFeature` (Phase 1 reducer
+/// `p0-tca-5` / #668). Behavioural parity with `HomeView` lives under Phase
+/// 3 issue `p0-tca-18` (#681).
+@MainActor
+final class HomeFeatureTests: XCTestCase {
+
+    // MARK: - Default state
+
+    func test_state_init_documentedDefaults() {
+        let state = HomeFeature.State()
+
+        XCTAssertEqual(state.settings, ReminderSettings(interval: 0, breakDuration: 0))
+        XCTAssertTrue(state.globalEnabled)
+        XCTAssertTrue(state.eyesEnabled)
+        XCTAssertTrue(state.postureEnabled)
+        XCTAssertEqual(state.notificationAuthStatus, .notDetermined)
+        XCTAssertFalse(state.trueInterruptBannerDismissed)
+        XCTAssertFalse(state.openSettingsOnLaunch)
+    }
+
+    // MARK: - .onAppear
+
+    func test_onAppear_seedsSettingsAndPollsAuthStatus() async {
+        let snapshot = ReminderSettings(interval: 1200, breakDuration: 20)
+        let store = TestStore(initialState: HomeFeature.State()) {
+            HomeFeature()
+        } withDependencies: {
+            $0.settingsClient = SettingsClient(
+                snapshot: { snapshot },
+                stream: { .finished },
+                updateGlobalEnabled: { _ in },
+                updateEyesEnabled: { _ in },
+                updatePostureEnabled: { _ in },
+                updateEyesInterval: { _ in },
+                updatePostureInterval: { _ in },
+                updateEyesBreakDuration: { _ in },
+                updatePostureBreakDuration: { _ in },
+                updatePauseMediaDuringBreaks: { _ in },
+                updateHapticsEnabled: { _ in },
+                updatePauseDuringFocus: { _ in },
+                updatePauseWhileDriving: { _ in },
+                updateNotificationFallbackEnabled: { _ in },
+                setSnoozedUntil: { _ in },
+                setSnoozeCount: { _ in },
+                resetToDefaults: {}
+            )
+            $0.notificationClient = TCATestDependencies.silentNotificationClient(
+                authorizationStatus: .authorized
+            )
+        }
+
+        await store.send(.onAppear) {
+            $0.settings = snapshot
+        }
+        await store.receive(\.notificationAuthStatusChanged) {
+            $0.notificationAuthStatus = .authorized
+        }
+    }
+
+    // MARK: - .settingsTapped
+
+    func test_settingsTapped_isParentInterceptedNoOp() async {
+        let store = TestStore(initialState: HomeFeature.State()) {
+            HomeFeature()
+        }
+
+        await store.send(.settingsTapped)
+    }
+
+    // MARK: - .dismissTrueInterruptBanner
+
+    func test_dismissTrueInterruptBanner_setsFlag() async {
+        let store = TestStore(initialState: HomeFeature.State()) {
+            HomeFeature()
+        }
+
+        await store.send(.dismissTrueInterruptBanner) {
+            $0.trueInterruptBannerDismissed = true
+        }
+    }
+
+    // MARK: - .settingsChanged
+
+    func test_settingsChanged_writesSnapshotToState() async {
+        let store = TestStore(initialState: HomeFeature.State()) {
+            HomeFeature()
+        }
+        let snapshot = ReminderSettings(interval: 600, breakDuration: 15)
+
+        await store.send(.settingsChanged(snapshot)) {
+            $0.settings = snapshot
+        }
+    }
+
+    // MARK: - .notificationAuthStatusChanged
+
+    func test_notificationAuthStatusChanged_writesStatusToState() async {
+        let store = TestStore(initialState: HomeFeature.State()) {
+            HomeFeature()
+        }
+
+        await store.send(.notificationAuthStatusChanged(.denied)) {
+            $0.notificationAuthStatus = .denied
+        }
+    }
+
+    // MARK: - Computed view-model state
+
+    func test_state_statusKey_paused_whenGlobalDisabled() {
+        var state = HomeFeature.State()
+        state.globalEnabled = false
+
+        XCTAssertEqual(state.statusLocalizationKey, "home.status.paused")
+    }
+
+    func test_state_statusKey_noReminders_whenEyesAndPostureDisabled() {
+        var state = HomeFeature.State()
+        state.eyesEnabled = false
+        state.postureEnabled = false
+
+        XCTAssertEqual(state.statusLocalizationKey, "home.status.noReminders")
+    }
+
+    func test_state_statusKey_notificationsOff_whenAuthDenied() {
+        var state = HomeFeature.State()
+        state.notificationAuthStatus = .denied
+
+        XCTAssertEqual(state.statusLocalizationKey, "home.status.notificationsOff")
+    }
+
+    func test_state_statusKey_active_whenAuthorisedAndEnabled() {
+        var state = HomeFeature.State()
+        state.notificationAuthStatus = .authorized
+
+        XCTAssertEqual(state.statusLocalizationKey, "home.status.active")
+    }
+
+    func test_state_shouldShowNotificationRecovery_trueWhenGlobalEnabledAndDenied() {
+        var state = HomeFeature.State()
+        state.notificationAuthStatus = .denied
+
+        XCTAssertTrue(state.shouldShowNotificationRecovery)
+    }
+
+    func test_state_shouldShowNotificationRecovery_falseWhenGlobalDisabled() {
+        var state = HomeFeature.State()
+        state.globalEnabled = false
+        state.notificationAuthStatus = .denied
+
+        XCTAssertFalse(state.shouldShowNotificationRecovery)
+    }
+
+    func test_state_shouldShowNoRemindersConfigured_trueWhenBothDisabled() {
+        var state = HomeFeature.State()
+        state.eyesEnabled = false
+        state.postureEnabled = false
+
+        XCTAssertTrue(state.shouldShowNoRemindersConfigured)
+    }
+
+    func test_state_shouldShowNoRemindersConfigured_falseWhenEyesEnabled() {
+        var state = HomeFeature.State()
+        state.eyesEnabled = true
+        state.postureEnabled = false
+
+        XCTAssertFalse(state.shouldShowNoRemindersConfigured)
+    }
+
+    func test_state_shouldShowNoRemindersConfigured_falseWhenGlobalDisabled() {
+        var state = HomeFeature.State()
+        state.globalEnabled = false
+        state.eyesEnabled = false
+        state.postureEnabled = false
+
+        XCTAssertFalse(state.shouldShowNoRemindersConfigured,
+                       "Global disabled takes precedence over per-type disablement")
+    }
+
+    // MARK: - Static helpers
+
+    func test_static_statusLocalizationKey_paused() {
+        let key = HomeFeature.statusLocalizationKey(
+            globalEnabled: false,
+            eyesEnabled: true,
+            postureEnabled: true,
+            notificationAuthStatus: .authorized
+        )
+
+        XCTAssertEqual(key, "home.status.paused")
+    }
+
+    func test_static_statusLocalizationKey_noReminders() {
+        let key = HomeFeature.statusLocalizationKey(
+            globalEnabled: true,
+            eyesEnabled: false,
+            postureEnabled: false,
+            notificationAuthStatus: .authorized
+        )
+
+        XCTAssertEqual(key, "home.status.noReminders")
+    }
+
+    func test_static_statusLocalizationKey_notificationsOff() {
+        let key = HomeFeature.statusLocalizationKey(
+            globalEnabled: true,
+            eyesEnabled: true,
+            postureEnabled: true,
+            notificationAuthStatus: .denied
+        )
+
+        XCTAssertEqual(key, "home.status.notificationsOff")
+    }
+
+    func test_static_statusLocalizationKey_active() {
+        let key = HomeFeature.statusLocalizationKey(
+            globalEnabled: true,
+            eyesEnabled: true,
+            postureEnabled: true,
+            notificationAuthStatus: .authorized
+        )
+
+        XCTAssertEqual(key, "home.status.active")
+    }
+
+    func test_static_shouldShowNotificationRecovery_truthTable() {
+        XCTAssertTrue(HomeFeature.shouldShowNotificationRecovery(
+            globalEnabled: true, notificationAuthStatus: .denied
+        ))
+        XCTAssertFalse(HomeFeature.shouldShowNotificationRecovery(
+            globalEnabled: false, notificationAuthStatus: .denied
+        ))
+        XCTAssertFalse(HomeFeature.shouldShowNotificationRecovery(
+            globalEnabled: true, notificationAuthStatus: .authorized
+        ))
+        XCTAssertFalse(HomeFeature.shouldShowNotificationRecovery(
+            globalEnabled: true, notificationAuthStatus: .notDetermined
+        ))
+    }
+
+    func test_static_shouldShowNoRemindersConfigured_truthTable() {
+        XCTAssertTrue(HomeFeature.shouldShowNoRemindersConfigured(
+            globalEnabled: true, eyesEnabled: false, postureEnabled: false
+        ))
+        XCTAssertFalse(HomeFeature.shouldShowNoRemindersConfigured(
+            globalEnabled: true, eyesEnabled: true, postureEnabled: false
+        ))
+        XCTAssertFalse(HomeFeature.shouldShowNoRemindersConfigured(
+            globalEnabled: true, eyesEnabled: false, postureEnabled: true
+        ))
+        XCTAssertFalse(HomeFeature.shouldShowNoRemindersConfigured(
+            globalEnabled: false, eyesEnabled: false, postureEnabled: false
+        ))
+    }
+}

--- a/Tests/EyePostureReminderTests/TCA/OnboardingFeatureTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/OnboardingFeatureTests.swift
@@ -1,0 +1,226 @@
+import ComposableArchitecture
+import UserNotifications
+import XCTest
+
+@testable import EyePostureReminder
+
+/// `TestStore` baseline coverage for `OnboardingFeature` (Phase 1 reducer
+/// `p0-tca-7` / #670). Behavioural parity with `OnboardingView` /
+/// `OnboardingCoordinator` lives under Phase 3 issue `p0-tca-19` (#682).
+@MainActor
+final class OnboardingFeatureTests: XCTestCase {
+
+    // MARK: - Default state
+
+    func test_state_init_documentedDefaults() {
+        let state = OnboardingFeature.State()
+
+        XCTAssertEqual(state.currentPage, 0)
+        XCTAssertEqual(state.screenTimeStatus, .unavailable)
+        XCTAssertEqual(state.notificationAuthStatus, .notDetermined)
+        XCTAssertFalse(state.showAppCategoryPicker)
+    }
+
+    // MARK: - Static configuration
+
+    func test_lastPageIndex_isThree() {
+        XCTAssertEqual(OnboardingFeature.lastPageIndex, 3,
+                       "Onboarding TabView has 4 pages indexed 0…3")
+    }
+
+    func test_notificationOptions_includeAlertSoundBadge() {
+        XCTAssertTrue(OnboardingFeature.notificationOptions.contains(.alert))
+        XCTAssertTrue(OnboardingFeature.notificationOptions.contains(.sound))
+        XCTAssertTrue(OnboardingFeature.notificationOptions.contains(.badge))
+    }
+
+    // MARK: - .onAppear
+
+    func test_onAppear_pollsBothAuthorisationsAndUpdatesState() async {
+        let store = TestStore(initialState: OnboardingFeature.State()) {
+            OnboardingFeature()
+        } withDependencies: {
+            $0.notificationClient = TCATestDependencies.silentNotificationClient(
+                authorizationStatus: .denied
+            )
+            $0.screenTimeAuthorizationClient = ScreenTimeAuthorizationClient(
+                status: { .approved },
+                statusChanges: { .finished },
+                requestAuthorization: { .approved }
+            )
+            $0.analyticsClient = AnalyticsClient(log: { _ in })
+        }
+
+        await store.send(.onAppear)
+        await store.receive(\.notificationStatusChanged) {
+            $0.notificationAuthStatus = .denied
+        }
+        await store.receive(\.screenTimeStatusChanged) {
+            $0.screenTimeStatus = .approved
+        }
+    }
+
+    // MARK: - .nextTapped
+
+    func test_nextTapped_incrementsCurrentPage() async {
+        let store = TestStore(initialState: OnboardingFeature.State()) {
+            OnboardingFeature()
+        }
+
+        await store.send(.nextTapped) {
+            $0.currentPage = 1
+        }
+    }
+
+    func test_nextTapped_clampsAtLastPageIndex() async {
+        var initial = OnboardingFeature.State()
+        initial.currentPage = OnboardingFeature.lastPageIndex
+        let store = TestStore(initialState: initial) {
+            OnboardingFeature()
+        }
+
+        await store.send(.nextTapped)
+    }
+
+    // MARK: - .skipTapped / .finishTapped
+
+    func test_skipTapped_logsCompletedAndEmitsCompletedOnboarding() async {
+        let store = TestStore(initialState: OnboardingFeature.State()) {
+            OnboardingFeature()
+        } withDependencies: {
+            $0.analyticsClient = AnalyticsClient(log: { _ in })
+        }
+
+        await store.send(.skipTapped)
+        await store.receive(\.completedOnboarding)
+    }
+
+    func test_finishTapped_logsCompletedAndEmitsCompletedOnboarding() async {
+        let store = TestStore(initialState: OnboardingFeature.State()) {
+            OnboardingFeature()
+        } withDependencies: {
+            $0.analyticsClient = AnalyticsClient(log: { _ in })
+        }
+
+        await store.send(.finishTapped)
+        await store.receive(\.completedOnboarding)
+    }
+
+    // MARK: - .finishAndCustomizeTapped
+
+    func test_finishAndCustomizeTapped_emitsCompletedAndOpenPicker() async {
+        let store = TestStore(initialState: OnboardingFeature.State()) {
+            OnboardingFeature()
+        } withDependencies: {
+            $0.analyticsClient = AnalyticsClient(log: { _ in })
+        }
+
+        await store.send(.finishAndCustomizeTapped)
+        await store.receive(\.completedOnboarding)
+        await store.receive(\.openAppCategoryPicker) {
+            $0.showAppCategoryPicker = true
+        }
+    }
+
+    // MARK: - .requestNotificationPermission
+
+    func test_requestNotificationPermission_swallowsThrowAndUpdatesStatus() async {
+        let store = TestStore(initialState: OnboardingFeature.State()) {
+            OnboardingFeature()
+        } withDependencies: {
+            $0.notificationClient = NotificationClient(
+                requestAuthorization: { _ in
+                    throw NSError(domain: "test", code: 1)
+                },
+                authorizationStatus: { .authorized },
+                add: { _ in },
+                removePending: { _ in },
+                removeAllPending: {},
+                pendingRequests: { [] },
+                deliveredNotifications: { [] }
+            )
+            $0.analyticsClient = AnalyticsClient(log: { _ in })
+        }
+
+        await store.send(.requestNotificationPermission)
+        await store.receive(\.notificationStatusChanged) {
+            $0.notificationAuthStatus = .authorized
+        }
+    }
+
+    // MARK: - .requestScreenTimeAuthorization
+
+    func test_requestScreenTimeAuthorization_routesThroughClient() async {
+        let store = TestStore(initialState: OnboardingFeature.State()) {
+            OnboardingFeature()
+        } withDependencies: {
+            $0.screenTimeAuthorizationClient = ScreenTimeAuthorizationClient(
+                status: { .approved },
+                statusChanges: { .finished },
+                requestAuthorization: { .approved }
+            )
+            $0.analyticsClient = AnalyticsClient(log: { _ in })
+        }
+
+        await store.send(.requestScreenTimeAuthorization)
+        await store.receive(\.screenTimeStatusChanged) {
+            $0.screenTimeStatus = .approved
+        }
+    }
+
+    // MARK: - status-change actions
+
+    func test_notificationStatusChanged_writesToState() async {
+        let store = TestStore(initialState: OnboardingFeature.State()) {
+            OnboardingFeature()
+        }
+
+        await store.send(.notificationStatusChanged(.authorized)) {
+            $0.notificationAuthStatus = .authorized
+        }
+    }
+
+    func test_screenTimeStatusChanged_writesToState() async {
+        let store = TestStore(initialState: OnboardingFeature.State()) {
+            OnboardingFeature()
+        }
+
+        await store.send(.screenTimeStatusChanged(.denied)) {
+            $0.screenTimeStatus = .denied
+        }
+    }
+
+    // MARK: - picker presentation gates
+
+    func test_openAppCategoryPicker_setsFlag() async {
+        let store = TestStore(initialState: OnboardingFeature.State()) {
+            OnboardingFeature()
+        }
+
+        await store.send(.openAppCategoryPicker) {
+            $0.showAppCategoryPicker = true
+        }
+    }
+
+    func test_dismissAppCategoryPicker_clearsFlag() async {
+        var initial = OnboardingFeature.State()
+        initial.showAppCategoryPicker = true
+        let store = TestStore(initialState: initial) {
+            OnboardingFeature()
+        }
+
+        await store.send(.dismissAppCategoryPicker) {
+            $0.showAppCategoryPicker = false
+        }
+    }
+
+    // MARK: - .completedOnboarding
+
+    func test_completedOnboarding_isLocalNoOp_parentObservesIt() async {
+        let store = TestStore(initialState: OnboardingFeature.State()) {
+            OnboardingFeature()
+        }
+
+        await store.send(.completedOnboarding)
+    }
+}

--- a/Tests/EyePostureReminderTests/TCA/OverlayFeatureTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/OverlayFeatureTests.swift
@@ -1,0 +1,190 @@
+import ComposableArchitecture
+import XCTest
+
+@testable import EyePostureReminder
+
+/// `TestStore` baseline coverage for `OverlayFeature` (Phase 1 reducer
+/// `p0-tca-8` / #671). Verifies the synchronous state mutations and pure
+/// dispatch contracts of every action; long-form behavioural parity with
+/// `OverlayManager` lives under Phase 3 issue `p0-tca-20` (#683).
+@MainActor
+final class OverlayFeatureTests: XCTestCase {
+
+    // MARK: - State.init
+
+    func test_state_init_clampsNegativeDurationToZero() {
+        let state = OverlayFeature.State(
+            type: .eyes,
+            duration: -5,
+            hapticsEnabled: true,
+            pauseMediaEnabled: false
+        )
+
+        XCTAssertEqual(state.secondsRemaining, 0,
+                       "Negative duration must clamp secondsRemaining to 0")
+    }
+
+    func test_state_init_roundsFractionalDuration() {
+        let state = OverlayFeature.State(
+            type: .posture,
+            duration: 19.6,
+            hapticsEnabled: true,
+            pauseMediaEnabled: true
+        )
+
+        XCTAssertEqual(state.secondsRemaining, 20,
+                       "Fractional duration must round to nearest second")
+    }
+
+    func test_state_init_assignsDocumentedDefaults() {
+        let id = UUID()
+        let state = OverlayFeature.State(
+            id: id,
+            type: .eyes,
+            duration: 10
+        )
+
+        XCTAssertEqual(state.id, id)
+        XCTAssertEqual(state.type, .eyes)
+        XCTAssertEqual(state.duration, 10)
+        XCTAssertTrue(state.hapticsEnabled, "hapticsEnabled defaults to true")
+        XCTAssertFalse(state.pauseMediaEnabled, "pauseMediaEnabled defaults to false")
+        XCTAssertFalse(state.isDismissing, "isDismissing defaults to false")
+        XCTAssertEqual(state.secondsRemaining, 10)
+    }
+
+    // MARK: - .onAppear
+
+    func test_onAppear_withZeroSecondsRemaining_immediatelyExpires() async {
+        let store = TestStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 0)
+        ) {
+            OverlayFeature()
+        } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
+
+        await store.send(.onAppear)
+        await store.receive(\.timerExpired) {
+            $0.isDismissing = true
+        }
+        await store.receive(\.dismissed)
+    }
+
+    // MARK: - .timerTick
+
+    func test_timerTick_decrementsSecondsRemaining() async {
+        let store = TestStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 5)
+        ) {
+            OverlayFeature()
+        } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
+
+        await store.send(.timerTick) {
+            $0.secondsRemaining = 4
+        }
+    }
+
+    func test_timerTick_atOne_decrementsAndEmitsTimerExpired() async {
+        let store = TestStore(
+            initialState: OverlayFeature.State(type: .posture, duration: 1)
+        ) {
+            OverlayFeature()
+        } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
+
+        await store.send(.timerTick) {
+            $0.secondsRemaining = 0
+        }
+        await store.receive(\.timerExpired) {
+            $0.isDismissing = true
+        }
+        await store.receive(\.dismissed)
+    }
+
+    func test_timerTick_belowZero_clampsAtZeroAndEmitsTimerExpired() async {
+        var initial = OverlayFeature.State(type: .eyes, duration: 5)
+        initial.secondsRemaining = 0
+        let store = TestStore(initialState: initial) {
+            OverlayFeature()
+        } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
+
+        await store.send(.timerTick)
+        // secondsRemaining stays clamped at 0 (max(0, 0-1) == 0) and re-fires expiry.
+        await store.receive(\.timerExpired) {
+            $0.isDismissing = true
+        }
+        await store.receive(\.dismissed)
+    }
+
+    // MARK: - .dismissTapped
+
+    func test_dismissTapped_setsIsDismissingAndDismisses() async {
+        let store = TestStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 10)
+        ) {
+            OverlayFeature()
+        } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
+
+        await store.send(.dismissTapped) {
+            $0.isDismissing = true
+        }
+        await store.receive(\.dismissed)
+    }
+
+    func test_dismissTapped_whileAlreadyDismissing_isNoOp() async {
+        var initial = OverlayFeature.State(type: .eyes, duration: 10)
+        initial.isDismissing = true
+        let store = TestStore(initialState: initial) {
+            OverlayFeature()
+        } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
+
+        await store.send(.dismissTapped)
+    }
+
+    // MARK: - .settingsTapped
+
+    func test_settingsTapped_logsAnalyticsAndProducesNoStateChange() async {
+        let store = TestStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 10)
+        ) {
+            OverlayFeature()
+        } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
+
+        await store.send(.settingsTapped)
+    }
+
+    // MARK: - .timerExpired
+
+    func test_timerExpired_setsIsDismissingAndDismisses() async {
+        let store = TestStore(
+            initialState: OverlayFeature.State(type: .posture, duration: 5)
+        ) {
+            OverlayFeature()
+        } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
+
+        await store.send(.timerExpired) {
+            $0.isDismissing = true
+        }
+        await store.receive(\.dismissed)
+    }
+
+    func test_timerExpired_whileAlreadyDismissing_isNoOp() async {
+        var initial = OverlayFeature.State(type: .eyes, duration: 5)
+        initial.isDismissing = true
+        let store = TestStore(initialState: initial) {
+            OverlayFeature()
+        } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
+
+        await store.send(.timerExpired)
+    }
+
+    // MARK: - .dismissed
+
+    func test_dismissed_isAcceptedAndCancelsTimer() async {
+        let store = TestStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 10)
+        ) {
+            OverlayFeature()
+        } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
+
+        await store.send(.dismissed)
+    }
+}

--- a/Tests/EyePostureReminderTests/TCA/SettingsFeatureTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/SettingsFeatureTests.swift
@@ -1,0 +1,214 @@
+import ComposableArchitecture
+import XCTest
+
+@testable import EyePostureReminder
+
+/// `TestStore` baseline coverage for `SettingsFeature` (Phase 1 reducer
+/// `p0-tca-6` / #669). Behavioural parity with `SettingsViewModel` lives
+/// under Phase 3 issue `p0-tca-16` (#679).
+@MainActor
+final class SettingsFeatureTests: XCTestCase {
+
+    // MARK: - Default state
+
+    func test_state_init_documentedDefaults() {
+        let state = SettingsFeature.State()
+
+        XCTAssertEqual(state.eyesInterval, 0)
+        XCTAssertEqual(state.eyesBreakDuration, 0)
+        XCTAssertEqual(state.prevEyesInterval, .zero)
+        XCTAssertEqual(state.prevEyesBreakDuration, .zero)
+        XCTAssertEqual(state.prevPostureInterval, .zero)
+        XCTAssertEqual(state.prevPostureBreakDuration, .zero)
+        XCTAssertFalse(state.showResetConfirm)
+        XCTAssertFalse(state.showSavedBanner)
+    }
+
+    func test_state_settings_isComputedFromBindableMirrors() {
+        var state = SettingsFeature.State()
+        state.eyesInterval = 600
+        state.eyesBreakDuration = 30
+
+        XCTAssertEqual(state.settings.interval, 600)
+        XCTAssertEqual(state.settings.breakDuration, 30)
+    }
+
+    // MARK: - SnoozeOption
+
+    func test_snoozeOption_analyticsCodes_areStable() {
+        XCTAssertEqual(SettingsFeature.SnoozeOption.fiveMinutes.analyticsCode, "5m")
+        XCTAssertEqual(SettingsFeature.SnoozeOption.oneHour.analyticsCode, "1h")
+        XCTAssertEqual(SettingsFeature.SnoozeOption.restOfDay.analyticsCode, "rest_of_day")
+    }
+
+    func test_snoozeOption_endDate_fiveMinutes_addsFiveMinutes() {
+        let reference = Date(timeIntervalSince1970: 1_000_000)
+        let result = SettingsFeature.SnoozeOption.fiveMinutes.endDate(
+            referenceDate: reference, calendar: .init(identifier: .gregorian)
+        )
+
+        XCTAssertEqual(result.timeIntervalSince(reference), 5 * 60, accuracy: 0.001)
+    }
+
+    func test_snoozeOption_endDate_oneHour_addsOneHour() {
+        let reference = Date(timeIntervalSince1970: 1_000_000)
+        let result = SettingsFeature.SnoozeOption.oneHour.endDate(
+            referenceDate: reference, calendar: .init(identifier: .gregorian)
+        )
+
+        XCTAssertEqual(result.timeIntervalSince(reference), 60 * 60, accuracy: 0.001)
+    }
+
+    func test_snoozeOption_endDate_restOfDay_returnsNextMidnight() throws {
+        var calendar = Calendar(identifier: .gregorian)
+        let utc = try XCTUnwrap(TimeZone(identifier: "UTC"))
+        calendar.timeZone = utc
+        // 2026-01-01 12:00:00 UTC.
+        let reference = try XCTUnwrap(calendar.date(from: DateComponents(
+            timeZone: calendar.timeZone, year: 2026, month: 1, day: 1, hour: 12
+        )))
+        let expected = try XCTUnwrap(calendar.date(from: DateComponents(
+            timeZone: calendar.timeZone, year: 2026, month: 1, day: 2, hour: 0
+        )))
+
+        let result = SettingsFeature.SnoozeOption.restOfDay.endDate(
+            referenceDate: reference, calendar: calendar
+        )
+
+        XCTAssertEqual(result, expected,
+                       "restOfDay must produce the next-day midnight in the supplied calendar")
+    }
+
+    // MARK: - .onAppear
+
+    func test_onAppear_seedsBindablesAndPrevValuesFromSnapshot() async {
+        let snapshot = ReminderSettings(interval: 1200, breakDuration: 25)
+        let store = TestStore(initialState: SettingsFeature.State()) {
+            SettingsFeature()
+        } withDependencies: {
+            $0.settingsClient = SettingsClient(
+                snapshot: { snapshot },
+                stream: { .finished },
+                updateGlobalEnabled: { _ in },
+                updateEyesEnabled: { _ in },
+                updatePostureEnabled: { _ in },
+                updateEyesInterval: { _ in },
+                updatePostureInterval: { _ in },
+                updateEyesBreakDuration: { _ in },
+                updatePostureBreakDuration: { _ in },
+                updatePauseMediaDuringBreaks: { _ in },
+                updateHapticsEnabled: { _ in },
+                updatePauseDuringFocus: { _ in },
+                updatePauseWhileDriving: { _ in },
+                updateNotificationFallbackEnabled: { _ in },
+                setSnoozedUntil: { _ in },
+                setSnoozeCount: { _ in },
+                resetToDefaults: {}
+            )
+        }
+
+        await store.send(.onAppear) {
+            $0.eyesInterval = 1200
+            $0.eyesBreakDuration = 25
+            $0.prevEyesInterval = 1200
+            $0.prevEyesBreakDuration = 25
+        }
+    }
+
+    // MARK: - .settingsChanged
+
+    func test_settingsChanged_writesAllFourMirroredFields() async {
+        let store = TestStore(initialState: SettingsFeature.State()) {
+            SettingsFeature()
+        }
+        let snapshot = ReminderSettings(interval: 900, breakDuration: 15)
+
+        await store.send(.settingsChanged(snapshot)) {
+            $0.eyesInterval = 900
+            $0.eyesBreakDuration = 15
+            $0.prevEyesInterval = 900
+            $0.prevEyesBreakDuration = 15
+        }
+    }
+
+    // MARK: - .savedBannerExpired
+
+    func test_savedBannerExpired_clearsBannerFlag() async {
+        var initial = SettingsFeature.State()
+        initial.showSavedBanner = true
+        let store = TestStore(initialState: initial) {
+            SettingsFeature()
+        }
+
+        await store.send(.savedBannerExpired) {
+            $0.showSavedBanner = false
+        }
+    }
+
+    // MARK: - .resetConfirmed
+
+    func test_resetConfirmed_dropsConfirmFlagAndCallsClient() async {
+        var initial = SettingsFeature.State()
+        initial.showResetConfirm = true
+        let resetCalls = LockIsolated(0)
+
+        let store = TestStore(initialState: initial) {
+            SettingsFeature()
+        } withDependencies: {
+            $0.settingsClient = SettingsClient(
+                snapshot: { ReminderSettings(interval: 0, breakDuration: 0) },
+                stream: { .finished },
+                updateGlobalEnabled: { _ in },
+                updateEyesEnabled: { _ in },
+                updatePostureEnabled: { _ in },
+                updateEyesInterval: { _ in },
+                updatePostureInterval: { _ in },
+                updateEyesBreakDuration: { _ in },
+                updatePostureBreakDuration: { _ in },
+                updatePauseMediaDuringBreaks: { _ in },
+                updateHapticsEnabled: { _ in },
+                updatePauseDuringFocus: { _ in },
+                updatePauseWhileDriving: { _ in },
+                updateNotificationFallbackEnabled: { _ in },
+                setSnoozedUntil: { _ in },
+                setSnoozeCount: { _ in },
+                resetToDefaults: { resetCalls.withValue { $0 += 1 } }
+            )
+        }
+
+        await store.send(.resetConfirmed) {
+            $0.showResetConfirm = false
+        }
+        await store.finish()
+
+        resetCalls.withValue { count in
+            XCTAssertEqual(count, 1,
+                           "resetConfirmed must dispatch exactly one resetToDefaults call")
+        }
+    }
+
+    // MARK: - .snoozeTapped
+
+    func test_snoozeTapped_setsSavedBannerImmediately() async {
+        let clock = TestClock()
+        let store = TestStore(initialState: SettingsFeature.State()) {
+            SettingsFeature()
+        } withDependencies: {
+            $0.settingsClient = TCATestDependencies.silentSettingsClient()
+            $0.analyticsClient = AnalyticsClient(log: { _ in })
+            $0.continuousClock = clock
+            $0.date = .constant(Date(timeIntervalSince1970: 1_000_000))
+            $0.calendar = Calendar(identifier: .gregorian)
+        }
+
+        await store.send(.snoozeTapped(.fiveMinutes)) {
+            $0.showSavedBanner = true
+        }
+
+        // Drive the savedBannerExpired effect.
+        await clock.advance(by: .seconds(2))
+        await store.receive(\.savedBannerExpired) {
+            $0.showSavedBanner = false
+        }
+    }
+}

--- a/Tests/EyePostureReminderTests/TCA/TCATestDependencies.swift
+++ b/Tests/EyePostureReminderTests/TCA/TCATestDependencies.swift
@@ -1,0 +1,135 @@
+import ComposableArchitecture
+import Foundation
+import UserNotifications
+
+@testable import EyePostureReminder
+
+/// Shared dependency-override helpers for the TCA `TestStore` test files
+/// living under `Tests/EyePostureReminderTests/TCA/`.
+///
+/// `liveValue` factories for several Phase-1 dependency clients
+/// (`NotificationClient`, `OverlayClient`, `IPCClient`, …) touch production
+/// singletons that crash inside the SwiftPM xctest bundle —
+/// `UNUserNotificationCenter.current()` requires a hosted app context,
+/// `UIApplication.shared` cannot be reached, etc. Every reducer test in this
+/// directory must therefore override **all** Phase-1 clients on the
+/// `TestStore`'s `withDependencies` block, even ones that never get called by
+/// the action under test, because TCA's `Scope` evaluation reaches into each
+/// child reducer's body during state diffing.
+///
+/// The helpers below provide silent, no-op stubs sized for the AppFeature
+/// scopes: `SettingsClient`, `NotificationClient`, `ReminderSchedulerClient`,
+/// `OverlayClient`, `ScreenTimeTrackerClient`, `PauseConditionClient`,
+/// `IPCClient`, `DeviceActivityMonitorClient`,
+/// `ScreenTimeAuthorizationClient`, and `AnalyticsClient`.
+enum TCATestDependencies {
+
+    static func silentSettingsClient() -> SettingsClient {
+        SettingsClient(
+            snapshot: { ReminderSettings(interval: 0, breakDuration: 0) },
+            stream: { .finished },
+            updateGlobalEnabled: { _ in },
+            updateEyesEnabled: { _ in },
+            updatePostureEnabled: { _ in },
+            updateEyesInterval: { _ in },
+            updatePostureInterval: { _ in },
+            updateEyesBreakDuration: { _ in },
+            updatePostureBreakDuration: { _ in },
+            updatePauseMediaDuringBreaks: { _ in },
+            updateHapticsEnabled: { _ in },
+            updatePauseDuringFocus: { _ in },
+            updatePauseWhileDriving: { _ in },
+            updateNotificationFallbackEnabled: { _ in },
+            setSnoozedUntil: { _ in },
+            setSnoozeCount: { _ in },
+            resetToDefaults: {}
+        )
+    }
+
+    static func silentNotificationClient(
+        authorizationStatus: UNAuthorizationStatus = .notDetermined
+    ) -> NotificationClient {
+        NotificationClient(
+            requestAuthorization: { _ in false },
+            authorizationStatus: { authorizationStatus },
+            add: { _ in },
+            removePending: { _ in },
+            removeAllPending: {},
+            pendingRequests: { [] },
+            deliveredNotifications: { [] }
+        )
+    }
+
+    static func silentReminderSchedulerClient() -> ReminderSchedulerClient {
+        ReminderSchedulerClient(
+            scheduleReminders: { _ in },
+            rescheduleReminder: { _, _ in },
+            cancelReminder: { _ in },
+            cancelAllReminders: {}
+        )
+    }
+
+    static func silentOverlayClient() -> OverlayClient {
+        OverlayClient(
+            show: { _, _, _, _ in },
+            dismiss: {},
+            clearQueue: {},
+            clearQueueForType: { _ in },
+            isVisible: { false },
+            lifecycleEvents: { .finished }
+        )
+    }
+
+    static func silentScreenTimeTrackerClient() -> ScreenTimeTrackerClient {
+        ScreenTimeTrackerClient(
+            setThreshold: { _, _ in },
+            enableTracking: { _ in },
+            disableTracking: { _ in },
+            pauseAll: {},
+            resumeAll: {},
+            reset: { _ in },
+            thresholdReached: { .finished }
+        )
+    }
+
+    static func silentPauseConditionClient() -> PauseConditionClient {
+        PauseConditionClient(
+            isPaused: { false },
+            pauseChanges: { .finished },
+            startMonitoring: {},
+            stopMonitoring: {}
+        )
+    }
+
+    static func silentIPCClient() -> IPCClient {
+        IPCClient(
+            isTrueInterruptEnabled: { false },
+            record: { _, _ in },
+            trueInterruptChanges: { .finished }
+        )
+    }
+
+    static func silentDeviceActivityMonitorClient() -> DeviceActivityMonitorClient {
+        DeviceActivityMonitorClient(
+            schedule: { _, _ in },
+            cancel: { _ in }
+        )
+    }
+
+    /// Applies every silent client to the supplied `DependencyValues`. Use as
+    /// the body of a `withDependencies:` trailing closure on a `TestStore`
+    /// (or production `Store`) constructed for `AppFeature` so child-reducer
+    /// scopes never reach into a `liveValue` that crashes the xctest bundle.
+    static func applyAllSilentClients(_ dependencies: inout DependencyValues) {
+        dependencies.settingsClient = silentSettingsClient()
+        dependencies.notificationClient = silentNotificationClient()
+        dependencies.reminderSchedulerClient = silentReminderSchedulerClient()
+        dependencies.overlayClient = silentOverlayClient()
+        dependencies.screenTimeTrackerClient = silentScreenTimeTrackerClient()
+        dependencies.pauseConditionClient = silentPauseConditionClient()
+        dependencies.ipcClient = silentIPCClient()
+        dependencies.deviceActivityMonitorClient = silentDeviceActivityMonitorClient()
+        dependencies.screenTimeAuthorizationClient = ScreenTimeAuthorizationClient()
+        dependencies.analyticsClient = AnalyticsClient(log: { _ in })
+    }
+}


### PR DESCRIPTION
## Summary

Wires the root TCA `Store` in `EyePostureReminderApp` so the SwiftUI scene reads its onboarding gate from `AppFeature.State.hasSeenOnboarding` and sends `.scheduling(.start)` to drive scheduling — replacing the legacy `coordinator.scheduleReminders()` task path.

## Changes

- **AppFeature.swift** — adds `hasSeenOnboardingChanged(Bool)` action so the legacy `@AppStorage` write done by `OnboardingView.markOnboardingComplete` can be bridged into TCA state during the Phase 2 transition window. No Phase-1 reducer files modified.
- **EyePostureReminderApp.swift** — constructs the single `Store(initialState: AppFeature.State()) { AppFeature() }` in `init()`, with `hasSeenOnboarding` seeded from `UserDefaults` so first launch matches today's UX. `AppCoordinator` instance retained per the issue spec — `p0-tca-12` (#675), `p0-tca-13` (#676), `p0-tca-14` (#677) still own scenePhase / notification / overlay routing.
- **ContentView.swift** — takes `StoreOf<AppFeature>`, gates on `store.hasSeenOnboarding`, bridges `@AppStorage(AppStorageKey.hasSeenOnboarding)` → store via `onChange` so the observable UX is unchanged.

## Validation

- `./scripts/build.sh all` passes locally on top of merged Phase 1: **2075 tests, 0 failures, lint clean**, ~109s.
- No Phase-1 reducer files modified (`HomeFeature`, `SettingsFeature`, `OnboardingFeature`, `SchedulingFeature`, `OverlayFeature`, `AppCategoryPickerFeature`, `TCA/Dependencies/*`).

Closes #674