### PR TITLE
Wire ScenePhase observation as a TCA effect (Phase 2)

### DIFF
--- a/EyePostureReminder/App/EyePostureReminderApp.swift
+++ b/EyePostureReminder/App/EyePostureReminderApp.swift
@@ -7,12 +7,6 @@ struct EyePostureReminderApp: App {
     @StateObject private var coordinator = AppCoordinator()
     @Environment(\.scenePhase) private var scenePhase
 
-    /// Tracks whether the previous `scenePhase` was `.background` so we only
-    /// call `handleForegroundTransition()` on true background → foreground
-    /// transitions, not on every brief `.inactive` interruption (e.g. task
-    /// switcher, control centre).
-    @State private var wasInBackground = false
-
     /// Single TCA `Store` driving the app, introduced by `p0-tca-11` (#674).
     /// `AppCoordinator` is intentionally kept alongside the store so legacy
     /// MVVM surfaces (Settings/Home views consuming `@EnvironmentObject`)
@@ -37,20 +31,10 @@ struct EyePostureReminderApp: App {
                     await store.send(.scheduling(.start)).finish()
                 }
                 .onChange(of: scenePhase) { phase in
-                    switch phase {
-                    case .active:
+                    if phase == .active {
                         presentUITestOverlayIfNeeded()
-                        coordinator.presentPendingOverlayIfNeeded()
-                        if wasInBackground {
-                            wasInBackground = false
-                            Task { await coordinator.handleForegroundTransition() }
-                        }
-                    case .background:
-                        wasInBackground = true
-                        coordinator.appWillResignActive()
-                    default:
-                        break
                     }
+                    store.send(.scenePhaseChanged(phase))
                 }
                 .onAppear {
                     appDelegate.coordinator = coordinator

--- a/EyePostureReminder/TCA/AppFeature.swift
+++ b/EyePostureReminder/TCA/AppFeature.swift
@@ -61,8 +61,14 @@ struct AppFeature {
             switch action {
             case .onAppear:
                 return .send(.scheduling(.start))
+            case .scenePhaseChanged(.active):
+                return .merge(
+                    .send(.scheduling(.foregroundTransition)),
+                    .send(.scheduling(.clearExpiredSnoozeIfNeeded))
+                )
+            case .scenePhaseChanged(.background):
+                return .send(.scheduling(.backgroundTransition))
             case .scenePhaseChanged:
-                // Phase-2 issue p0-tca-13 (#676) fills this in.
                 return .none
             case .hasSeenOnboardingChanged(let value):
                 state.hasSeenOnboarding = value

--- a/Tests/EyePostureReminderTests/TCA/AppFeatureTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/AppFeatureTests.swift
@@ -157,20 +157,40 @@ final class AppFeatureTests: XCTestCase {
         await store.send(.hasSeenOnboardingChanged(true))
     }
 
-    // MARK: - scenePhaseChanged (Phase-2 deferred to #676)
+    // MARK: - scenePhaseChanged (Phase-2 #676 wiring)
 
-    /// `.scenePhaseChanged` must remain a pure no-op until `p0-tca-13`
-    /// (#676) wires scenePhase observation through the store.
-    func test_scenePhaseChanged_active_isNoOp() async {
+    /// `.scenePhaseChanged(.active)` forwards to `SchedulingFeature` as a
+    /// merged `.foregroundTransition` + `.clearExpiredSnoozeIfNeeded` so the
+    /// reducer owns the legacy `coordinator.handleForegroundTransition()` /
+    /// snooze-clearing path that previously lived in `EyePostureReminderApp`.
+    /// Use non-exhaustive matching because deep `SchedulingFeature` parity
+    /// is owned by `p0-tca-17` (#680).
+    func test_scenePhaseChanged_active_forwardsForegroundAndSnoozeClear() async {
         let store = makeStore()
+        store.exhaustivity = .off
+
         await store.send(.scenePhaseChanged(.active))
+
+        await store.receive(\.scheduling.foregroundTransition)
+        await store.receive(\.scheduling.clearExpiredSnoozeIfNeeded)
     }
 
-    func test_scenePhaseChanged_background_isNoOp() async {
+    /// `.scenePhaseChanged(.background)` forwards to
+    /// `SchedulingFeature.backgroundTransition` so analytics + cleanup happen
+    /// inside the reducer, replacing `coordinator.appWillResignActive()`.
+    func test_scenePhaseChanged_background_forwardsBackgroundTransition() async {
         let store = makeStore()
+        store.exhaustivity = .off
+
         await store.send(.scenePhaseChanged(.background))
+
+        await store.receive(\.scheduling.backgroundTransition)
     }
 
+    /// `.scenePhaseChanged(.inactive)` (and any non-active/background phase)
+    /// must remain a pure no-op: SwiftUI fires `.inactive` on every brief
+    /// interruption (control center, task switcher) and the reducer must not
+    /// run foreground/background side-effects on those.
     func test_scenePhaseChanged_inactive_isNoOp() async {
         let store = makeStore()
         await store.send(.scenePhaseChanged(.inactive))


### PR DESCRIPTION
## Summary

Wires `ScenePhase` observation through the TCA root `Store` so the legacy `coordinator.handleForegroundTransition()` / `appWillResignActive()` / `presentPendingOverlayIfNeeded()` paths run inside `SchedulingFeature` instead of being driven from `EyePostureReminderApp.body`. Completes Phase 2 step `p0-tca-13`.

## Changes

- **EyePostureReminderApp.swift** — replace the multi-branch `.onChange(of: scenePhase)` block with a single `store.send(.scenePhaseChanged(phase))`. Removes the `wasInBackground` `@State` and the three `coordinator.*` transition calls. Keeps the `presentUITestOverlayIfNeeded()` UI-test backdoor on `.active` (compiled out of Release per `#350`/`#405`).
- **TCA/AppFeature.swift** — fill in `.scenePhaseChanged` per the issue spec:
  - `.active` → `.merge(.send(.scheduling(.foregroundTransition)), .send(.scheduling(.clearExpiredSnoozeIfNeeded)))`
  - `.background` → `.send(.scheduling(.backgroundTransition))`
  - any other phase → `.none`
- **Tests/EyePostureReminderTests/TCA/AppFeatureTests.swift** — rewrite the three Phase-1 no-op stub tests (`test_scenePhaseChanged_active_isNoOp` / `_background_isNoOp` / `_inactive_isNoOp`) as forwarding assertions using `store.exhaustivity = .off` + `store.receive(\.scheduling.foregroundTransition)` etc. Deep `SchedulingFeature` parity remains owned by `p0-tca-17` (#680).

No Phase-1 reducer files modified (`HomeFeature`, `SettingsFeature`, `OnboardingFeature`, `SchedulingFeature`, `OverlayFeature`, `AppCategoryPickerFeature`, `TCA/Dependencies/*`).

## Validation

`./scripts/build.sh all` — **2165 tests, 0 failures, lint clean, ~173s.**

Closes #676
