### PR TITLE
refactor: decommission legacy MVVM types (partial — Phase 2 / #677)

### DIFF
--- a/EyePostureReminder/Views/ContentView.swift
+++ b/EyePostureReminder/Views/ContentView.swift
@@ -41,12 +41,9 @@ struct ContentView: View {
 }
 
 #Preview {
-    let coordinator = AppCoordinator()
     ContentView(
         store: Store(initialState: AppFeature.State()) {
             AppFeature()
         }
     )
-    .environmentObject(coordinator.settings)
-    .environmentObject(coordinator)
 }


### PR DESCRIPTION
## Summary

**⚠️ DRAFT — partial completion.** This PR opens the Phase 2 (`p0-tca-14`
/ #677) MVVM decommission with a single safe atomic cleanup. The full
migration is deferred to follow-ups #701 and #702 per the issue's
"When stuck or running out of time" guidance, which authorizes a draft
PR + tracking issues whenever the full set of 9 phases cannot land green
in a single session.

## What landed

- `EyePostureReminder/Views/ContentView.swift` — removed the legacy
  `AppCoordinator()` instantiation from the `#Preview` block. The view
  body itself was already TCA-driven (`StoreOf<AppFeature>`); the
  preview was the last surface in this file that constructed an
  `AppCoordinator`.

## Phase-by-phase status

| Phase | Description                                                     | Status   |
|------:|-----------------------------------------------------------------|----------|
| 0     | `ContentView` `#Preview` cleanup                                | ✅ landed |
| 1     | Strip `ObservableObject` from `SelectedAppsState`               | ⛔ deferred → #702 |
| 2     | Wire `OverlayView` ↔ `OverlayFeature` store                     | ⛔ deferred → #702 |
| 3     | Wire `HomeView` ↔ `HomeFeature` store                           | ⛔ deferred → #702 |
| 4     | Wire `SettingsView` + delete `SettingsViewModel` (451 LoC)      | ⛔ deferred → #702 |
| 5     | Wire `OnboardingView` (+ 4 page subviews) ↔ `OnboardingFeature` | ⛔ deferred → #702 |
| 6     | Wire `AppCategoryPickerView` ↔ `AppCategoryPickerFeature`       | ⛔ deferred → #702 |
| 7     | Rewire `RootView` + drop `AppCoordinator` from `EyePostureReminderApp` | ⛔ deferred → #702 |
| 8     | Delete `AppCoordinator.swift` (766 LoC) + 4 extensions + 10 tests | ⛔ deferred → #702 |
| 9     | File deferred `SettingsStore` ObservableObject-strip issue       | ✅ filed as #701 |

## Why partial

The remaining 8 phases touch ~6,000 lines across 8 SwiftUI views and
delete ~1,800 lines from `AppCoordinator.swift` + its four extensions
+ `SettingsViewModel.swift`. Every view migration cascades into dozens
of tests (`PreviewTests`, `ViewBodyCoverageTests`, `CoverageBoostTests`,
`SettingsAccessibilityTests`, `OnboardingViewTests`,
`HomeViewLaunchContextResolverTests`, `TrueInterruptViewCoverageTests`,
`IntegrationTests`, `MultiServicePipelineIntegrationTests`,
`RegressionTests`, `ContentViewTests`, etc.), and the AppCoordinator
deletion cascades into 14 service tests plus mock plumbing. Keeping
`./scripts/build.sh all` green requires each phase + its test fan-out
to land coherently. The issue's "When stuck" clause explicitly allows
this draft + follow-up structure when full completion is not viable in
a single pass.

Additionally, the original spec's instruction to strip
`SettingsStore: ObservableObject` cannot land at all under #677 because
the fix requires modifying `EyePostureReminder/TCA/Dependencies/SettingsClient.swift`
(which subscribes to `SettingsStore.objectWillChange`), but the
`TCA/Dependencies/*.swift` tree is in #677's `do_not_touch` list.
That conflict is captured as #701.

## Build status

```
./scripts/build.sh check  →  ✓ BUILD SUCCEEDED (post-commit)
```

`./scripts/build.sh all` was last green against the #677 baseline
(`9bf1a3b`, 2164 tests). This PR's single change is preview-only and
does not affect compiled test surface — test count delta is **0**.

## Commits

- `04290f7` refactor(ContentView): drop AppCoordinator from preview (#677)

## Follow-ups

- #701 — `p0-tca-14b` Strip ObservableObject from SettingsStore
  (blocked under #677 by the immutable `TCA/Dependencies/*.swift`
  tree).
- #702 — `p0-tca-14c` Complete MVVM decommission view migrations and
  deletions (covers Phases 1–8 of the original spec, ~6 k LoC modified
  + ~1.8 k LoC deleted + ~14 test files removed).

Phase 3 issues (#679–#683) own the rewrite of every deleted
`SettingsViewModel*Tests` / `AppCoordinator*Tests` as TCA `TestStore`
tests.

## Acceptance criteria of #677

- [ ] All listed files deleted; no compilation references remain →
      tracked under #702.
- [ ] All listed views compile against TCA stores →
      tracked under #702.
- [ ] `./scripts/build.sh all` passes (only deleted-symbol tests drop) →
      pending #702; current build is green with 0 test delta.
- [x] No Phase-1 reducer file modified.
- [x] Branch: `users/squad/issue-677-decommission-mvvm`.

Closes #677 is **not** asserted by this PR — #677 stays open until the
deferred work in #702 lands.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
