### PR TITLE
Fix CI: actor-isolation (#705) + --reset-onboarding launch arg (#707)

### DIFF
--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -98,13 +98,11 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     /// prevents `TrueInterruptSkippedBanner` from ever rendering on the first
     /// cold launch (#457).
     ///
-    /// Also pre-seeds `hasSeenOnboarding` so the TCA root state seeded in
-    /// `EyePostureReminderApp.init()` (`p0-tca-11` / #674) sees the correct
-    /// value. Without this, `--reset-onboarding` and `--skip-onboarding` are
-    /// applied too late (in `didFinishLaunching`) and the store keeps the
-    /// stale value left over from the previous test launch (#707).
+    /// `hasSeenOnboarding` is pre-seeded earlier — directly in
+    /// `EyePostureReminderApp.init()` — because `@UIApplicationDelegateAdaptor`
+    /// only instantiates this delegate as part of `UIApplicationMain`, which
+    /// runs *after* the App struct's `init()` body returns. See #707.
     private func preSeedUITestDefaults() {
-        preSeedHasSeenOnboardingIfNeeded()
         if launchArguments.contains("--simulate-screen-time-not-determined") {
             uiTestDefaults.set(
                 ScreenTimeAuthorizationStatus.notDetermined.rawValue,
@@ -123,31 +121,6 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
                !launchArguments.contains("--dismiss-true-interrupt-banner") {
                 uiTestDefaults.set(false, forKey: AppStorageKey.trueInterruptSkippedBannerDismissed)
             }
-        }
-    }
-
-    /// Synchronizes the `hasSeenOnboarding` UserDefaults key with the
-    /// onboarding-affecting launch args before `EyePostureReminderApp.init()`
-    /// reads it to seed `AppFeature.State.hasSeenOnboarding` (#707).
-    ///
-    /// `--reset-onboarding` removes the key; the four "skip past onboarding"
-    /// launch args (used by tests that need to start on Home/overlay screens)
-    /// set it to `true`. The full `applyUITestLaunchArguments()` pass still
-    /// runs from `didFinishLaunching` and handles `SettingsStore` resets and
-    /// overlay-type seeding — this hook only mirrors the onboarding gate so
-    /// the TCA store starts on the correct branch.
-    private func preSeedHasSeenOnboardingIfNeeded() {
-        if launchArguments.contains("--reset-onboarding") {
-            uiTestDefaults.removeObject(forKey: AppStorageKey.hasSeenOnboarding)
-            return
-        }
-        let skipsOnboarding =
-            launchArguments.contains("--skip-onboarding") ||
-            launchArguments.contains("--show-overlay-eyes") ||
-            launchArguments.contains("--show-overlay-posture") ||
-            launchArguments.contains("--simulate-screen-time-not-determined")
-        if skipsOnboarding {
-            uiTestDefaults.set(true, forKey: AppStorageKey.hasSeenOnboarding)
         }
     }
 #endif

--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -97,7 +97,14 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     /// and falls back to `ScreenTimeAuthorizationNoop(.unavailable)`, which
     /// prevents `TrueInterruptSkippedBanner` from ever rendering on the first
     /// cold launch (#457).
+    ///
+    /// Also pre-seeds `hasSeenOnboarding` so the TCA root state seeded in
+    /// `EyePostureReminderApp.init()` (`p0-tca-11` / #674) sees the correct
+    /// value. Without this, `--reset-onboarding` and `--skip-onboarding` are
+    /// applied too late (in `didFinishLaunching`) and the store keeps the
+    /// stale value left over from the previous test launch (#707).
     private func preSeedUITestDefaults() {
+        preSeedHasSeenOnboardingIfNeeded()
         if launchArguments.contains("--simulate-screen-time-not-determined") {
             uiTestDefaults.set(
                 ScreenTimeAuthorizationStatus.notDetermined.rawValue,
@@ -116,6 +123,31 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
                !launchArguments.contains("--dismiss-true-interrupt-banner") {
                 uiTestDefaults.set(false, forKey: AppStorageKey.trueInterruptSkippedBannerDismissed)
             }
+        }
+    }
+
+    /// Synchronizes the `hasSeenOnboarding` UserDefaults key with the
+    /// onboarding-affecting launch args before `EyePostureReminderApp.init()`
+    /// reads it to seed `AppFeature.State.hasSeenOnboarding` (#707).
+    ///
+    /// `--reset-onboarding` removes the key; the four "skip past onboarding"
+    /// launch args (used by tests that need to start on Home/overlay screens)
+    /// set it to `true`. The full `applyUITestLaunchArguments()` pass still
+    /// runs from `didFinishLaunching` and handles `SettingsStore` resets and
+    /// overlay-type seeding — this hook only mirrors the onboarding gate so
+    /// the TCA store starts on the correct branch.
+    private func preSeedHasSeenOnboardingIfNeeded() {
+        if launchArguments.contains("--reset-onboarding") {
+            uiTestDefaults.removeObject(forKey: AppStorageKey.hasSeenOnboarding)
+            return
+        }
+        let skipsOnboarding =
+            launchArguments.contains("--skip-onboarding") ||
+            launchArguments.contains("--show-overlay-eyes") ||
+            launchArguments.contains("--show-overlay-posture") ||
+            launchArguments.contains("--simulate-screen-time-not-determined")
+        if skipsOnboarding {
+            uiTestDefaults.set(true, forKey: AppStorageKey.hasSeenOnboarding)
         }
     }
 #endif

--- a/EyePostureReminder/App/EyePostureReminderApp.swift
+++ b/EyePostureReminder/App/EyePostureReminderApp.swift
@@ -15,12 +15,52 @@ struct EyePostureReminderApp: App {
 
     init() {
         AppTypography.registerFonts()
+#if DEBUG
+        // Mirror onboarding-affecting launch args into UserDefaults BEFORE the
+        // initial state seed below reads them. `AppDelegate.init()` runs too
+        // late under `@UIApplicationDelegateAdaptor` (UIKit only instantiates
+        // the delegate as part of `UIApplicationMain`, after this `App.init`
+        // returns), so deferring the sync to `AppDelegate` left the store on
+        // the stale `true` value left in UserDefaults from the previous test
+        // launch and onboarding tests landed on Home (#707).
+        Self.preSeedHasSeenOnboardingFromLaunchArgsIfNeeded()
+#endif
         var initialState = AppFeature.State()
         initialState.hasSeenOnboarding = UserDefaults.standard.bool(
             forKey: AppStorageKey.hasSeenOnboarding
         )
         self.store = Store(initialState: initialState) { AppFeature() }
     }
+
+#if DEBUG
+    /// Synchronizes the `hasSeenOnboarding` UserDefaults key with the
+    /// onboarding-affecting launch arguments before `init()` reads it to seed
+    /// `AppFeature.State` (#707).
+    ///
+    /// `--reset-onboarding` clears the key; the four "skip past onboarding"
+    /// launch arguments (used by tests that need to start on Home/overlay
+    /// screens) set it to `true`. The full `AppDelegate.applyUITestLaunch
+    /// Arguments()` pass still runs from `didFinishLaunchingWithOptions` and
+    /// handles `SettingsStore` resets and overlay-type seeding — this hook
+    /// only mirrors the onboarding gate so the TCA root state starts on the
+    /// correct branch. `#if DEBUG` keeps the launch-arg backdoor out of
+    /// Release/TestFlight builds (re: #350/#405).
+    private static func preSeedHasSeenOnboardingFromLaunchArgsIfNeeded() {
+        let args = CommandLine.arguments
+        if args.contains("--reset-onboarding") {
+            UserDefaults.standard.removeObject(forKey: AppStorageKey.hasSeenOnboarding)
+            return
+        }
+        let skipsOnboarding =
+            args.contains("--skip-onboarding") ||
+            args.contains("--show-overlay-eyes") ||
+            args.contains("--show-overlay-posture") ||
+            args.contains("--simulate-screen-time-not-determined")
+        if skipsOnboarding {
+            UserDefaults.standard.set(true, forKey: AppStorageKey.hasSeenOnboarding)
+        }
+    }
+#endif
 
     var body: some Scene {
         WindowGroup {

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -95,11 +95,20 @@ final class AppDelegateTests: XCTestCase {
         settings: SettingsStore,
         snoozeCountWrites: LockIsolated<[Int]>
     ) -> StoreOf<AppFeature> {
-        Store(initialState: AppFeature.State()) {
+        // The `snapshot` closure on `SettingsClient` is `@Sendable` and therefore
+        // cannot synchronously call `@MainActor`-isolated methods on
+        // `SettingsStore`. Capture the eyes snapshot once on the main actor (this
+        // function is invoked from a `@MainActor` test setUp) and return the
+        // captured value. The `SchedulingFeature` paths under test never re-read
+        // `snapshot`, so a stable initial value is sufficient.
+        let initialEyesSnapshot = MainActor.assumeIsolated {
+            settings.settings(for: .eyes)
+        }
+        return Store(initialState: AppFeature.State()) {
             AppFeature()
         } withDependencies: {
             $0.settingsClient = SettingsClient(
-                snapshot: { settings.settings(for: .eyes) },
+                snapshot: { initialEyesSnapshot },
                 stream: { .finished },
                 updateGlobalEnabled: { _ in },
                 updateEyesEnabled: { _ in },


### PR DESCRIPTION
Two p0 CI fixes bundled because #707 only surfaced once #705 unblocked Build & Test on this branch.

## #705 — Actor-isolation compile error (Build & Test job)
`AppDelegateTests.swift` captured an `@MainActor`-isolated reminders snapshot inside a `@Sendable` closure, which Swift 6 (Xcode 16.3+) rejects. Snapshot is now captured via `MainActor.assumeIsolated` before the closure is formed. (+11/-2, test-only.)

## #707 — `--reset-onboarding` ignored after TCA root-store wiring (UI Tests / Onboarding shard)
`EyePostureReminderApp.init()` (added by #696 / `p0-tca-11`) eagerly reads `UserDefaults` to seed `AppFeature.State.hasSeenOnboarding`. `@UIApplicationDelegateAdaptor` only instantiates `AppDelegate` as part of `UIApplicationMain` — *after* the App struct's `init` body returns — so the launch-arg sync deferred to `AppDelegate.didFinishLaunchingWithOptions` was running too late: the store kept the stale `true` from the previous test launch and onboarding tests landed on Home.

Fix: mirror the onboarding-affecting launch args (`--reset-onboarding`, `--skip-onboarding`, `--show-overlay-eyes`, `--show-overlay-posture`, `--simulate-screen-time-not-determined`) into `UserDefaults` from a `#if DEBUG` static helper called as the **first** statement of `EyePostureReminderApp.init()`, before the seed read. The rest of the AppDelegate UI-test seeding (SettingsStore reset, overlay-type stubs, ScreenTime stub) stays in `didFinishLaunching` where it belongs.

The `#if DEBUG` guard keeps the launch-arg backdoor out of Release/TestFlight builds (re: #350/#405).

## Verification
- `./scripts/build.sh all` — 2164 tests, 0 failures, 142s ✅
- `./scripts/build.sh uitest --only-testing OnboardingFlowTests` — 6 tests, 0 failures (was 2 failures pre-fix) ✅
- CI Build & Test job — passing on the prior commit (proving #705 fix) ✅

Closes #705
Closes #707