### PR TITLE
test(tca): OverlayFeature behavioural-parity TestStore coverage (#683)

### DIFF
--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -98,13 +98,11 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     /// prevents `TrueInterruptSkippedBanner` from ever rendering on the first
     /// cold launch (#457).
     ///
-    /// Also pre-seeds `hasSeenOnboarding` so the TCA root state seeded in
-    /// `EyePostureReminderApp.init()` (`p0-tca-11` / #674) sees the correct
-    /// value. Without this, `--reset-onboarding` and `--skip-onboarding` are
-    /// applied too late (in `didFinishLaunching`) and the store keeps the
-    /// stale value left over from the previous test launch (#707).
+    /// `hasSeenOnboarding` is pre-seeded earlier — directly in
+    /// `EyePostureReminderApp.init()` — because `@UIApplicationDelegateAdaptor`
+    /// only instantiates this delegate as part of `UIApplicationMain`, which
+    /// runs *after* the App struct's `init()` body returns. See #707.
     private func preSeedUITestDefaults() {
-        preSeedHasSeenOnboardingIfNeeded()
         if launchArguments.contains("--simulate-screen-time-not-determined") {
             uiTestDefaults.set(
                 ScreenTimeAuthorizationStatus.notDetermined.rawValue,
@@ -123,31 +121,6 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
                !launchArguments.contains("--dismiss-true-interrupt-banner") {
                 uiTestDefaults.set(false, forKey: AppStorageKey.trueInterruptSkippedBannerDismissed)
             }
-        }
-    }
-
-    /// Synchronizes the `hasSeenOnboarding` UserDefaults key with the
-    /// onboarding-affecting launch args before `EyePostureReminderApp.init()`
-    /// reads it to seed `AppFeature.State.hasSeenOnboarding` (#707).
-    ///
-    /// `--reset-onboarding` removes the key; the four "skip past onboarding"
-    /// launch args (used by tests that need to start on Home/overlay screens)
-    /// set it to `true`. The full `applyUITestLaunchArguments()` pass still
-    /// runs from `didFinishLaunching` and handles `SettingsStore` resets and
-    /// overlay-type seeding — this hook only mirrors the onboarding gate so
-    /// the TCA store starts on the correct branch.
-    private func preSeedHasSeenOnboardingIfNeeded() {
-        if launchArguments.contains("--reset-onboarding") {
-            uiTestDefaults.removeObject(forKey: AppStorageKey.hasSeenOnboarding)
-            return
-        }
-        let skipsOnboarding =
-            launchArguments.contains("--skip-onboarding") ||
-            launchArguments.contains("--show-overlay-eyes") ||
-            launchArguments.contains("--show-overlay-posture") ||
-            launchArguments.contains("--simulate-screen-time-not-determined")
-        if skipsOnboarding {
-            uiTestDefaults.set(true, forKey: AppStorageKey.hasSeenOnboarding)
         }
     }
 #endif

--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -97,7 +97,14 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     /// and falls back to `ScreenTimeAuthorizationNoop(.unavailable)`, which
     /// prevents `TrueInterruptSkippedBanner` from ever rendering on the first
     /// cold launch (#457).
+    ///
+    /// Also pre-seeds `hasSeenOnboarding` so the TCA root state seeded in
+    /// `EyePostureReminderApp.init()` (`p0-tca-11` / #674) sees the correct
+    /// value. Without this, `--reset-onboarding` and `--skip-onboarding` are
+    /// applied too late (in `didFinishLaunching`) and the store keeps the
+    /// stale value left over from the previous test launch (#707).
     private func preSeedUITestDefaults() {
+        preSeedHasSeenOnboardingIfNeeded()
         if launchArguments.contains("--simulate-screen-time-not-determined") {
             uiTestDefaults.set(
                 ScreenTimeAuthorizationStatus.notDetermined.rawValue,
@@ -116,6 +123,31 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
                !launchArguments.contains("--dismiss-true-interrupt-banner") {
                 uiTestDefaults.set(false, forKey: AppStorageKey.trueInterruptSkippedBannerDismissed)
             }
+        }
+    }
+
+    /// Synchronizes the `hasSeenOnboarding` UserDefaults key with the
+    /// onboarding-affecting launch args before `EyePostureReminderApp.init()`
+    /// reads it to seed `AppFeature.State.hasSeenOnboarding` (#707).
+    ///
+    /// `--reset-onboarding` removes the key; the four "skip past onboarding"
+    /// launch args (used by tests that need to start on Home/overlay screens)
+    /// set it to `true`. The full `applyUITestLaunchArguments()` pass still
+    /// runs from `didFinishLaunching` and handles `SettingsStore` resets and
+    /// overlay-type seeding — this hook only mirrors the onboarding gate so
+    /// the TCA store starts on the correct branch.
+    private func preSeedHasSeenOnboardingIfNeeded() {
+        if launchArguments.contains("--reset-onboarding") {
+            uiTestDefaults.removeObject(forKey: AppStorageKey.hasSeenOnboarding)
+            return
+        }
+        let skipsOnboarding =
+            launchArguments.contains("--skip-onboarding") ||
+            launchArguments.contains("--show-overlay-eyes") ||
+            launchArguments.contains("--show-overlay-posture") ||
+            launchArguments.contains("--simulate-screen-time-not-determined")
+        if skipsOnboarding {
+            uiTestDefaults.set(true, forKey: AppStorageKey.hasSeenOnboarding)
         }
     }
 #endif

--- a/EyePostureReminder/App/EyePostureReminderApp.swift
+++ b/EyePostureReminder/App/EyePostureReminderApp.swift
@@ -15,12 +15,52 @@ struct EyePostureReminderApp: App {
 
     init() {
         AppTypography.registerFonts()
+#if DEBUG
+        // Mirror onboarding-affecting launch args into UserDefaults BEFORE the
+        // initial state seed below reads them. `AppDelegate.init()` runs too
+        // late under `@UIApplicationDelegateAdaptor` (UIKit only instantiates
+        // the delegate as part of `UIApplicationMain`, after this `App.init`
+        // returns), so deferring the sync to `AppDelegate` left the store on
+        // the stale `true` value left in UserDefaults from the previous test
+        // launch and onboarding tests landed on Home (#707).
+        Self.preSeedHasSeenOnboardingFromLaunchArgsIfNeeded()
+#endif
         var initialState = AppFeature.State()
         initialState.hasSeenOnboarding = UserDefaults.standard.bool(
             forKey: AppStorageKey.hasSeenOnboarding
         )
         self.store = Store(initialState: initialState) { AppFeature() }
     }
+
+#if DEBUG
+    /// Synchronizes the `hasSeenOnboarding` UserDefaults key with the
+    /// onboarding-affecting launch arguments before `init()` reads it to seed
+    /// `AppFeature.State` (#707).
+    ///
+    /// `--reset-onboarding` clears the key; the four "skip past onboarding"
+    /// launch arguments (used by tests that need to start on Home/overlay
+    /// screens) set it to `true`. The full `AppDelegate.applyUITestLaunch
+    /// Arguments()` pass still runs from `didFinishLaunchingWithOptions` and
+    /// handles `SettingsStore` resets and overlay-type seeding — this hook
+    /// only mirrors the onboarding gate so the TCA root state starts on the
+    /// correct branch. `#if DEBUG` keeps the launch-arg backdoor out of
+    /// Release/TestFlight builds (re: #350/#405).
+    private static func preSeedHasSeenOnboardingFromLaunchArgsIfNeeded() {
+        let args = CommandLine.arguments
+        if args.contains("--reset-onboarding") {
+            UserDefaults.standard.removeObject(forKey: AppStorageKey.hasSeenOnboarding)
+            return
+        }
+        let skipsOnboarding =
+            args.contains("--skip-onboarding") ||
+            args.contains("--show-overlay-eyes") ||
+            args.contains("--show-overlay-posture") ||
+            args.contains("--simulate-screen-time-not-determined")
+        if skipsOnboarding {
+            UserDefaults.standard.set(true, forKey: AppStorageKey.hasSeenOnboarding)
+        }
+    }
+#endif
 
     var body: some Scene {
         WindowGroup {

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -95,11 +95,20 @@ final class AppDelegateTests: XCTestCase {
         settings: SettingsStore,
         snoozeCountWrites: LockIsolated<[Int]>
     ) -> StoreOf<AppFeature> {
-        Store(initialState: AppFeature.State()) {
+        // The `snapshot` closure on `SettingsClient` is `@Sendable` and therefore
+        // cannot synchronously call `@MainActor`-isolated methods on
+        // `SettingsStore`. Capture the eyes snapshot once on the main actor (this
+        // function is invoked from a `@MainActor` test setUp) and return the
+        // captured value. The `SchedulingFeature` paths under test never re-read
+        // `snapshot`, so a stable initial value is sufficient.
+        let initialEyesSnapshot = MainActor.assumeIsolated {
+            settings.settings(for: .eyes)
+        }
+        return Store(initialState: AppFeature.State()) {
             AppFeature()
         } withDependencies: {
             $0.settingsClient = SettingsClient(
-                snapshot: { settings.settings(for: .eyes) },
+                snapshot: { initialEyesSnapshot },
                 stream: { .finished },
                 updateGlobalEnabled: { _ in },
                 updateEyesEnabled: { _ in },

--- a/Tests/EyePostureReminderTests/TCA/OverlayFeatureBehaviorTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/OverlayFeatureBehaviorTests.swift
@@ -1,0 +1,310 @@
+import ComposableArchitecture
+import XCTest
+
+@testable import EyePostureReminder
+
+/// Phase 3 (`p0-tca-20` / #683) behavioural-parity coverage for
+/// `OverlayFeature`.
+///
+/// Complements the synchronous-only `OverlayFeatureTests` by exercising
+/// the reducer through its real `continuousClock` timer effect, the
+/// `OverlayClient.dismiss` side effect, and every analytics emission the
+/// previous `OverlayManager`/`OverlayManagerTests` pair guaranteed.
+@MainActor
+final class OverlayFeatureBehaviorTests: XCTestCase {
+
+    // MARK: - Helpers
+
+    /// Captured `AnalyticsEvent`s + `OverlayClient.dismiss` invocation count
+    /// for assertion. Lock-isolated so the `@Sendable` client closures may
+    /// mutate them safely from any executor.
+    private struct Spies {
+        let analytics: LockIsolated<[AnalyticsEvent]>
+        let dismissCalls: LockIsolated<Int>
+    }
+
+    private func makeSpies() -> Spies {
+        Spies(analytics: LockIsolated([]), dismissCalls: LockIsolated(0))
+    }
+
+    /// Builds a `TestStore` for `OverlayFeature` with a `TestClock`,
+    /// analytics capture, and an `OverlayClient` whose `dismiss` increments
+    /// `spies.dismissCalls`. Every other Phase-1 client is stubbed silent so
+    /// child-reducer scopes inside `AppFeature` would not crash if these
+    /// dependencies were ever read.
+    private func makeStore(
+        initialState: OverlayFeature.State,
+        clock: TestClock<Duration>,
+        spies: Spies
+    ) -> TestStoreOf<OverlayFeature> {
+        TestStore(initialState: initialState) {
+            OverlayFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.continuousClock = clock
+            $0.analyticsClient = AnalyticsClient(log: { event in
+                spies.analytics.withValue { $0.append(event) }
+            })
+            $0.overlayClient = OverlayClient(
+                show: { _, _, _, _ in },
+                dismiss: { spies.dismissCalls.withValue { $0 += 1 } },
+                clearQueue: {},
+                clearQueueForType: { _ in },
+                isVisible: { false },
+                lifecycleEvents: { .finished }
+            )
+        }
+    }
+
+    // MARK: - .onAppear: TestClock drives the 1 s tick
+
+    func test_onAppear_withPositiveDuration_emitsTickEverySecondUntilExpiry() async {
+        let clock = TestClock()
+        let spies = makeSpies()
+        let store = makeStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 3),
+            clock: clock,
+            spies: spies
+        )
+
+        await store.send(.onAppear)
+
+        await clock.advance(by: .seconds(1))
+        await store.receive(\.timerTick) { $0.secondsRemaining = 2 }
+
+        await clock.advance(by: .seconds(1))
+        await store.receive(\.timerTick) { $0.secondsRemaining = 1 }
+
+        await clock.advance(by: .seconds(1))
+        await store.receive(\.timerTick) { $0.secondsRemaining = 0 }
+        await store.receive(\.timerExpired) { $0.isDismissing = true }
+        await store.receive(\.dismissed)
+
+        XCTAssertEqual(spies.dismissCalls.value, 1,
+                       "overlayClient.dismiss must fire exactly once on auto-expiry")
+    }
+
+    // MARK: - .dismissTapped: cancels timer + side effects
+
+    func test_dismissTapped_cancelsRunningTimerEffectAndPreventsFurtherTicks() async {
+        let clock = TestClock()
+        let spies = makeSpies()
+        let store = makeStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 10),
+            clock: clock,
+            spies: spies
+        )
+
+        await store.send(.onAppear)
+
+        await clock.advance(by: .seconds(1))
+        await store.receive(\.timerTick) { $0.secondsRemaining = 9 }
+
+        await store.send(.dismissTapped) { $0.isDismissing = true }
+        await store.receive(\.dismissed)
+
+        // Advance well past the original duration: tick effect must be
+        // cancelled, so no further `timerTick` actions arrive.
+        await clock.advance(by: .seconds(30))
+    }
+
+    func test_dismissTapped_callsOverlayClientDismissExactlyOnce() async {
+        let clock = TestClock()
+        let spies = makeSpies()
+        let store = makeStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 10),
+            clock: clock,
+            spies: spies
+        )
+
+        await store.send(.dismissTapped) { $0.isDismissing = true }
+        await store.receive(\.dismissed)
+
+        XCTAssertEqual(spies.dismissCalls.value, 1,
+                       "overlayClient.dismiss must fire exactly once per user tap")
+    }
+
+    func test_dismissTapped_immediately_logsOverlayDismissedWithButtonAndZeroElapsed() async {
+        let clock = TestClock()
+        let spies = makeSpies()
+        let store = makeStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 20),
+            clock: clock,
+            spies: spies
+        )
+
+        await store.send(.dismissTapped) { $0.isDismissing = true }
+        await store.receive(\.dismissed)
+
+        let events = spies.analytics.value
+        XCTAssertEqual(events.count, 1,
+                       "Exactly one analytics event must be emitted on dismissTapped")
+        guard let event = events.first,
+              case let .overlayDismissed(type, method, elapsedS) = event else {
+            return XCTFail("Expected .overlayDismissed but got \(events)")
+        }
+        XCTAssertEqual(type, .eyes)
+        XCTAssertEqual(method, .button,
+                       "User-tap dismissal must use DismissMethod.button")
+        XCTAssertEqual(elapsedS, 0, accuracy: 0.001,
+                       "Immediate dismissal must report 0 elapsed seconds")
+    }
+
+    func test_dismissTapped_afterTicks_logsCorrectElapsedSeconds() async {
+        let clock = TestClock()
+        let spies = makeSpies()
+        let store = makeStore(
+            initialState: OverlayFeature.State(type: .posture, duration: 20),
+            clock: clock,
+            spies: spies
+        )
+
+        await store.send(.onAppear)
+        for tick in 1...3 {
+            await clock.advance(by: .seconds(1))
+            await store.receive(\.timerTick) { $0.secondsRemaining = 20 - tick }
+        }
+
+        await store.send(.dismissTapped) { $0.isDismissing = true }
+        await store.receive(\.dismissed)
+
+        let events = spies.analytics.value
+        guard let event = events.first,
+              case let .overlayDismissed(type, method, elapsedS) = event else {
+            return XCTFail("Expected .overlayDismissed but got \(events)")
+        }
+        XCTAssertEqual(type, .posture)
+        XCTAssertEqual(method, .button)
+        XCTAssertEqual(elapsedS, 3, accuracy: 0.001,
+                       "elapsedS must equal duration − secondsRemaining")
+    }
+
+    func test_dismissTapped_whileAlreadyDismissing_emitsNoAnalyticsAndNoOverlayCall() async {
+        let clock = TestClock()
+        let spies = makeSpies()
+        var initial = OverlayFeature.State(type: .eyes, duration: 10)
+        initial.isDismissing = true
+        let store = makeStore(initialState: initial, clock: clock, spies: spies)
+
+        await store.send(.dismissTapped)
+
+        XCTAssertEqual(spies.analytics.value.count, 0,
+                       "Re-entrant dismissTapped must not double-log analytics")
+        XCTAssertEqual(spies.dismissCalls.value, 0,
+                       "Re-entrant dismissTapped must not call overlay.dismiss again")
+    }
+
+    // MARK: - .settingsTapped: analytics-only side effect
+
+    func test_settingsTapped_logsOverlayDismissedWithSettingsTapMethod() async {
+        let clock = TestClock()
+        let spies = makeSpies()
+        let store = makeStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 15),
+            clock: clock,
+            spies: spies
+        )
+
+        await store.send(.settingsTapped)
+
+        let events = spies.analytics.value
+        XCTAssertEqual(events.count, 1)
+        guard let event = events.first,
+              case let .overlayDismissed(type, method, elapsedS) = event else {
+            return XCTFail("Expected .overlayDismissed but got \(events)")
+        }
+        XCTAssertEqual(type, .eyes)
+        XCTAssertEqual(method, .settingsTap,
+                       "Settings-tap dismissal must use DismissMethod.settingsTap")
+        XCTAssertEqual(elapsedS, 0, accuracy: 0.001)
+
+        XCTAssertEqual(spies.dismissCalls.value, 0,
+                       "settingsTapped does not itself dismiss the overlay")
+    }
+
+    func test_settingsTapped_afterTicks_reportsElapsedSeconds() async {
+        let clock = TestClock()
+        let spies = makeSpies()
+        let store = makeStore(
+            initialState: OverlayFeature.State(type: .posture, duration: 30),
+            clock: clock,
+            spies: spies
+        )
+
+        await store.send(.onAppear)
+        for tick in 1...5 {
+            await clock.advance(by: .seconds(1))
+            await store.receive(\.timerTick) { $0.secondsRemaining = 30 - tick }
+        }
+
+        await store.send(.settingsTapped)
+        // Cancel the still-running tick effect to let the test finish cleanly.
+        await store.send(.dismissed)
+
+        let dismissEvents = spies.analytics.value.compactMap { event -> TimeInterval? in
+            if case let .overlayDismissed(_, method, elapsed) = event,
+               method == .settingsTap {
+                return elapsed
+            }
+            return nil
+        }
+        XCTAssertEqual(dismissEvents.count, 1)
+        XCTAssertEqual(dismissEvents.first ?? -1, 5, accuracy: 0.001,
+                       "settingsTapped must report elapsed = duration − secondsRemaining")
+    }
+
+    // MARK: - .timerExpired: auto-dismissal analytics + overlay.dismiss
+
+    func test_timerExpired_logsOverlayAutoDismissedWithFullDuration() async {
+        let clock = TestClock()
+        let spies = makeSpies()
+        let store = makeStore(
+            initialState: OverlayFeature.State(type: .posture, duration: 25),
+            clock: clock,
+            spies: spies
+        )
+
+        await store.send(.timerExpired) { $0.isDismissing = true }
+        await store.receive(\.dismissed)
+
+        let events = spies.analytics.value
+        XCTAssertEqual(events.count, 1)
+        guard let event = events.first,
+              case let .overlayAutoDismissed(type, durationS) = event else {
+            return XCTFail("Expected .overlayAutoDismissed but got \(events)")
+        }
+        XCTAssertEqual(type, .posture)
+        XCTAssertEqual(durationS, 25, accuracy: 0.001,
+                       "Auto-dismissal analytics must report the full configured duration")
+    }
+
+    func test_timerExpired_callsOverlayClientDismissExactlyOnce() async {
+        let clock = TestClock()
+        let spies = makeSpies()
+        let store = makeStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 5),
+            clock: clock,
+            spies: spies
+        )
+
+        await store.send(.timerExpired) { $0.isDismissing = true }
+        await store.receive(\.dismissed)
+
+        XCTAssertEqual(spies.dismissCalls.value, 1)
+    }
+
+    func test_timerExpired_whileAlreadyDismissing_emitsNoAnalyticsAndNoOverlayCall() async {
+        let clock = TestClock()
+        let spies = makeSpies()
+        var initial = OverlayFeature.State(type: .eyes, duration: 5)
+        initial.isDismissing = true
+        let store = makeStore(initialState: initial, clock: clock, spies: spies)
+
+        await store.send(.timerExpired)
+
+        XCTAssertEqual(spies.analytics.value.count, 0,
+                       "Re-entrant timerExpired must not double-log auto-dismissal")
+        XCTAssertEqual(spies.dismissCalls.value, 0,
+                       "Re-entrant timerExpired must not call overlay.dismiss again")
+    }
+}


### PR DESCRIPTION
## Summary

Phase 3 (`p0-tca-20` / #683) coverage gap: the existing `OverlayFeatureTests` only exercises synchronous state mutations and pure dispatch — it never drives the real `continuousClock` tick effect, never asserts `OverlayClient.dismiss` was called, and never inspects the `AnalyticsEvent`s emitted on dismissal. `OverlayManager` / `OverlayManagerTests` (the legacy MVVM type the feature replaces) guaranteed all three; the TCA layer must too before the legacy types are deleted under #677/#702.

Pure test-only PR — no production code modified.

## Coverage matrix delta

Per #683:

| Behaviour | Test |
|---|---|
| `.onAppear` starts the 1 s tick effect | ✅ `test_onAppear_withPositiveDuration_emitsTickEverySecondUntilExpiry` (drives `TestClock` for 3 s, asserts one `.timerTick` per second + final `.timerExpired` + `.dismissed`) |
| `.timerTick` decrements `secondsRemaining` (clamped at 0) | ✅ already covered in baseline + indirectly by the new clock-driven test |
| `.timerExpired` fires when `secondsRemaining` reaches 0 | ✅ `test_onAppear_withPositiveDuration_emitsTickEverySecondUntilExpiry` |
| `.dismissTapped` stops the tick effect, calls `overlay.dismiss()`, logs `.overlayDismissed` | ✅ `test_dismissTapped_cancelsRunningTimerEffectAndPreventsFurtherTicks`, `test_dismissTapped_callsOverlayClientDismissExactlyOnce`, `test_dismissTapped_immediately_logsOverlayDismissedWithButtonAndZeroElapsed`, `test_dismissTapped_afterTicks_logsCorrectElapsedSeconds`, `test_dismissTapped_whileAlreadyDismissing_emitsNoAnalyticsAndNoOverlayCall` |
| `.settingsTapped` logs `.overlayDismissed(method: .settingsTap)` | ✅ `test_settingsTapped_logsOverlayDismissedWithSettingsTapMethod`, `test_settingsTapped_afterTicks_reportsElapsedSeconds` |
| `.timerExpired` logs `.overlayAutoDismissed` and dismisses overlay | ✅ `test_timerExpired_logsOverlayAutoDismissedWithFullDuration`, `test_timerExpired_callsOverlayClientDismissExactlyOnce`, `test_timerExpired_whileAlreadyDismissing_emitsNoAnalyticsAndNoOverlayCall` |

(Note: the issue's matrix mentions `.onAppear` emitting `overlayPresented` analytics, but `OverlayFeature.onAppear` does **not** emit any analytics today — overlay-presentation analytics live elsewhere in the pipeline. Per the acceptance criterion "No production code modified", I did not add an emission.)

## Test infrastructure

Capture pattern follows `SettingsFeatureTests.test_resetConfirmed_*`:

```swift
private struct Spies {
    let analytics: LockIsolated<[AnalyticsEvent]>
    let dismissCalls: LockIsolated<Int>
}
```

`AnalyticsEvent` is not `Equatable` so assertions use `case let` pattern matching on the variant (same idiom as the future `p0-tca-17` SchedulingFeature tests).

## Build status

```
./scripts/build.sh test  →  2175 tests, 0 failures, 102s
./scripts/build.sh lint  →  SwiftLint passed
```

Test count delta: **+11** new tests (was 2164 at the #706 baseline).

## Stacked on #706

This branch is based on `users/squad/issue-705-fix-ci-actor-isolation` (PR #706). Until #706 squash-merges, the diff against `main` will show #706's three commits in addition to mine. Rebase will collapse them once #706 lands.

Closes #683

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>