### PR TITLE
ci: bump pinned GitHub Actions to native Node 24 versions (#709)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Select Xcode ${{ env.XCODE_VERSION }}
         run: |
@@ -82,7 +82,7 @@ jobs:
 
       # ── Dependency cache ─────────────────────────────────────────────────────
       - name: Cache DerivedData
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ${{ env.DERIVED_DATA_PATH }}
           key: derived-data-branch-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-${{ github.head_ref || github.ref_name }}-${{ hashFiles('Package.swift', 'Package.resolved', 'scripts/build.sh', '.github/workflows/ci.yml') }}
@@ -91,7 +91,7 @@ jobs:
             derived-data-branch-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-main-
 
       - name: Cache SwiftPM SourcePackages
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: ${{ env.DERIVED_DATA_PATH }}/SourcePackages
           key: spm-sourcepackages-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-${{ hashFiles('Package.resolved') }}
@@ -101,7 +101,7 @@ jobs:
       # ── Homebrew package cache ───────────────────────────────────────────────
       - name: Cache Homebrew packages
         id: brew-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: |
             /opt/homebrew/Cellar/xcodegen
@@ -210,7 +210,7 @@ jobs:
           find "${{ env.DERIVED_DATA_PATH }}" -name "*.dSYM" -exec cp -r {} . \; 2>/dev/null || true
 
       - name: Upload dSYMs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: dSYMs-${{ env.MARKETING_VERSION }}-build${{ github.run_number }}
@@ -219,7 +219,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Upload test results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: test-results-${{ env.MARKETING_VERSION }}-build${{ github.run_number }}
@@ -234,7 +234,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Select Xcode ${{ env.XCODE_VERSION }}
         run: |
@@ -300,7 +300,7 @@ jobs:
           echo "Prepared xctestrun: $XCTESTRUN_PATH"
 
       - name: Upload UI prebuilt artifacts
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: ui-prebuilt-${{ github.run_id }}
           path: ${{ env.DERIVED_DATA_PATH }}/Build/Products
@@ -335,7 +335,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Select Xcode ${{ env.XCODE_VERSION }}
         run: |
@@ -487,7 +487,7 @@ jobs:
           PY
 
       - name: Upload UI test results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: ui-test-results-${{ matrix.shard.id }}-build${{ github.run_number }}
@@ -496,7 +496,7 @@ jobs:
           if-no-files-found: error
 
       - name: Upload UI retry failure report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         if: always()
         with:
           name: ui-retry-failures-${{ matrix.shard.id }}-build${{ github.run_number }}

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Check triage script
         id: check-script

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Identify assigned member and trigger work
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Triage issue via Lead agent
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Parse roster and sync labels
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -162,7 +162,7 @@ jobs:
       # ── xcodegen ─────────────────────────────────────────────────────────
       - name: Cache Homebrew packages
         id: brew-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: /opt/homebrew/Cellar/xcodegen
           key: ${{ runner.os }}-brew-xcodegen-v1
@@ -207,7 +207,7 @@ jobs:
           echo "IPA verified: $IPA_PATH ($(du -h "$IPA_PATH" | cut -f1))"
 
       - name: Upload IPA artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: EyePostureReminder-${{ env.MARKETING_VERSION }}-build${{ env.BUILD_NUMBER }}.ipa
           path: DerivedData/SignedBuild/Export/EyePostureReminder.ipa


### PR DESCRIPTION
## Summary

Replaces every pre-Node-24 pinned SHA in our workflows with the current
stable releases:

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4.3.1 (`34e1148...`) | **v6.0.2** (`de0fac2...`) |
| `actions/cache` | v4.3.0 (`0057852...`) | **v5.0.5** (`27d5ce7...`) |
| `actions/upload-artifact` | v4.6.2 (`ea165f8...`) | **v7.0.1** (`043fb46...`) |

Removes the recurring deprecation warning that appears on every job
today:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but
are being forced to run on Node.js 24: actions/cache@..., actions/checkout@...,
actions/upload-artifact@...
```

per https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## Files touched

- `.github/workflows/ci.yml` (10 refs across 3 actions)
- `.github/workflows/testflight.yml` (3)
- `.github/workflows/squad-heartbeat.yml` (1)
- `.github/workflows/squad-issue-assign.yml` (1)
- `.github/workflows/squad-triage.yml` (1)
- `.github/workflows/sync-squad-labels.yml` (1)

```
6 files changed, 18 insertions(+), 18 deletions(-)
```

## Compatibility check

Every `with:` parameter we use today exists unchanged in the new majors
(verified against the v6/v5/v7 READMEs):

- `actions/checkout` v6: `fetch-depth`, `ref`, `token` — unchanged
- `actions/cache` v5: `path`, `key`, `restore-keys` — unchanged
- `actions/upload-artifact` v7: `name`, `path`, `if-no-files-found`, `retention-days`, `compression-level`, `overwrite`, `include-hidden-files` — all unchanged

No workflow logic changes are required.

## Verification

- YAML lint: `python3 -c 'import yaml; ...'` parses every modified file ✅
- Local build unaffected (workflow YAML only — no Swift/test code touched)
- The CI run on this PR is the real verification — expectation is **0
  Node 20 deprecation warnings** in any job log

## Risk

Low. Workflow-only change, no overlap with any in-flight PR (#706 / #708 /
#704 / #703 — none of those touch `.github/workflows/*`). Easy rollback
by reverting the single commit if any job regresses.

Closes #709

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>