### PR TITLE
test: bump awaitCondition timeout in trueInterrupt fallback test (#712)

### DIFF
--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorNotificationFallbackTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorNotificationFallbackTests.swift
@@ -216,7 +216,10 @@ final class AppCoordinatorNotificationFallbackTests: XCTestCase {
             object: nil,
             userInfo: [AppGroupIPCStore.trueInterruptEnabledValueUserInfoKey: false]
         )
-        await awaitCondition {
+        // The notification → refreshAuthStatus → scheduleReminders → addRequest×2
+        // pipeline routinely exceeds the 1 s default on loaded CI runners (#712).
+        // Use the same 3 s budget as the sibling shieldPathSelected wait at line 173.
+        await awaitCondition(timeout: 3.0) {
             notificationCenter.addedRequests.count >= 2 &&
                 ipcStore.events.contains { $0.kind == .notificationFallbackScheduled }
         }


### PR DESCRIPTION
## Summary

Fixes the intermittent flake in `AppCoordinatorNotificationFallbackTests.test_trueInterruptEnabledChangeNotification_whenDisabled_switchesToNotificationFallback`.

## Root cause

`AppCoordinatorNotificationFallbackTests.swift:219` called `awaitCondition` without a timeout, defaulting to **1.0 s** (`AsyncTestHelpers.swift:20`). The notification → `refreshAuthStatus` → `scheduleReminders` → `addRequest`×2 pipeline routinely exceeds 1 s on loaded CI runners. The sibling shieldPathSelected wait at line 173 already uses `timeout: 3.0` — this is the only `awaitCondition` in the file using the default.

## Fix

Bump line 219 to `timeout: 3.0` to match the established pattern. Local patch only — production routing is correct, the test wait budget was the bug.

## Last observed flake

PR #704 run 25891873713 (job 76096640480):

```
✗ test_trueInterruptEnabledChangeNotification_whenDisabled_switchesToNotificationFallback, failed - awaitCondition timed out after 1.0s
✗ test_trueInterruptEnabledChangeNotification_whenDisabled_switchesToNotificationFallback, XCTUnwrap failed: expected non-nil value of type 'AppGroupIPCEvent'
```

## Verification

- `./scripts/build.sh lint` ✅
- 1-line semantic change; no production code touched
- Test runs locally pass (full `./scripts/build.sh all` was green on this branch's parent before changes)

## Risk

Trivial. Increases the test's max wait by 2 s; on the happy path (condition met immediately) the test still completes in <100 ms because `awaitCondition` polls every 1 ms.

Closes #712

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>