### PR TITLE
refactor: add observer surface to SettingsStore, drop @Published (#701 partial)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -259,7 +259,7 @@ EyePostureReminder/                  (SPM executable target)
 │   ├── AppConfig.swift               Codable struct; loads defaults.json; .fallback hardcoded
 │   ├── ReminderType.swift            enum: .eyes / .posture; display + notification identity
 │   ├── ReminderSettings.swift        struct: interval + breakDuration (seconds)
-│   └── SettingsStore.swift           @ObservableObject; UserDefaults wrapper; SettingsPersisting protocol
+│   └── SettingsStore.swift           @MainActor + ObservableObject; UserDefaults wrapper; SettingsPersisting protocol; UUID-keyed observer surface (Combine `@Published` removed; `objectWillChange.send()` driven from `broadcastChange()`)
 │
 ├── Services/
 │   ├── AppCoordinator.swift          @MainActor; owns all services; ReminderScheduling conformance

--- a/EyePostureReminder/Models/SettingsStore.swift
+++ b/EyePostureReminder/Models/SettingsStore.swift
@@ -2,11 +2,18 @@ import Combine
 import Foundation
 import os
 
-/// `UserDefaults`-backed observable store for all user-configurable settings.
+/// `UserDefaults`-backed store for all user-configurable settings.
 ///
-/// `@Published` properties drive SwiftUI reactivity. The initialiser accepts a
-/// `SettingsPersisting` dependency so unit tests can inject an in-memory store
-/// without touching the file system.
+/// Mutations drive a lightweight observer surface (`addObserver` /
+/// `removeObserver`) so consumers — `SettingsClient.liveValue` and
+/// `SettingsViewModel` — can react without paying the Combine /
+/// `@Published` tax. `: ObservableObject` conformance is retained so legacy
+/// SwiftUI surfaces using `@EnvironmentObject SettingsStore` continue to
+/// refresh; `objectWillChange.send()` is invoked manually from
+/// `broadcastChange()`. The full `ObservableObject` strip is deferred until
+/// the MVVM → TCA view migration (#677) is complete.
+/// The initialiser accepts a `SettingsPersisting` dependency so unit tests
+/// can inject an in-memory store without touching the file system.
 ///
 /// Key layout (all prefixed `kshana.`):
 /// ```
@@ -30,34 +37,49 @@ final class SettingsStore: ObservableObject {
 
     // MARK: - Global Toggle
 
-    @Published var globalEnabled: Bool {
-        didSet { store.set(globalEnabled, forKey: Keys.globalEnabled) }
+    var globalEnabled: Bool {
+        didSet {
+            store.set(globalEnabled, forKey: Keys.globalEnabled)
+            broadcastChange()
+        }
     }
 
     // MARK: - Per-Type Toggles
 
-    @Published var eyesEnabled: Bool {
-        didSet { store.set(eyesEnabled, forKey: Keys.eyesEnabled) }
+    var eyesEnabled: Bool {
+        didSet {
+            store.set(eyesEnabled, forKey: Keys.eyesEnabled)
+            broadcastChange()
+        }
     }
 
-    @Published var postureEnabled: Bool {
-        didSet { store.set(postureEnabled, forKey: Keys.postureEnabled) }
+    var postureEnabled: Bool {
+        didSet {
+            store.set(postureEnabled, forKey: Keys.postureEnabled)
+            broadcastChange()
+        }
     }
 
     // MARK: - Per-Type Intervals (seconds)
 
-    @Published var eyesInterval: TimeInterval {
-        didSet { store.set(eyesInterval, forKey: Keys.eyesInterval) }
+    var eyesInterval: TimeInterval {
+        didSet {
+            store.set(eyesInterval, forKey: Keys.eyesInterval)
+            broadcastChange()
+        }
     }
 
-    @Published var postureInterval: TimeInterval {
-        didSet { store.set(postureInterval, forKey: Keys.postureInterval) }
+    var postureInterval: TimeInterval {
+        didSet {
+            store.set(postureInterval, forKey: Keys.postureInterval)
+            broadcastChange()
+        }
     }
 
     // MARK: - Per-Type Break Durations (seconds)
 
-    @Published private var eyesBreakDurationStorage: TimeInterval
-    @Published private var postureBreakDurationStorage: TimeInterval
+    private var eyesBreakDurationStorage: TimeInterval
+    private var postureBreakDurationStorage: TimeInterval
 
     var eyesBreakDuration: TimeInterval {
         get { eyesBreakDurationStorage }
@@ -70,6 +92,7 @@ final class SettingsStore: ObservableObject {
             )
             eyesBreakDurationStorage = validated
             store.set(validated, forKey: Keys.eyesBreakDuration)
+            broadcastChange()
         }
     }
 
@@ -84,59 +107,111 @@ final class SettingsStore: ObservableObject {
             )
             postureBreakDurationStorage = validated
             store.set(validated, forKey: Keys.postureBreakDuration)
+            broadcastChange()
         }
     }
 
     // MARK: - Snooze
 
     /// `nil` when not snoozed; a future `Date` when snoozed until that moment.
-    @Published var snoozedUntil: Date? {
+    var snoozedUntil: Date? {
         didSet {
             let value = snoozedUntil?.timeIntervalSince1970 ?? 0
             store.set(value, forKey: Keys.snoozedUntil)
+            broadcastChange()
         }
     }
 
     /// Number of consecutive snoozes applied since the last reminder actually fired.
     /// Reset to 0 whenever a real reminder overlay is shown.
-    @Published var snoozeCount: Int {
-        didSet { store.set(snoozeCount, forKey: Keys.snoozeCount) }
+    var snoozeCount: Int {
+        didSet {
+            store.set(snoozeCount, forKey: Keys.snoozeCount)
+            broadcastChange()
+        }
     }
 
     // MARK: - Pause Conditions
 
     /// When `true`, pauses reminders while a Focus mode is active.
     /// Default is `true`. Requires `NSFocusStatusUsageDescription` in Info.plist.
-    @Published var pauseDuringFocus: Bool {
-        didSet { store.set(pauseDuringFocus, forKey: Keys.pauseDuringFocus) }
+    var pauseDuringFocus: Bool {
+        didSet {
+            store.set(pauseDuringFocus, forKey: Keys.pauseDuringFocus)
+            broadcastChange()
+        }
     }
 
     /// When `true`, pauses reminders while driving or CarPlay is connected.
     /// Covers both `CMMotionActivity.automotive` and `AVAudioSession.Port.carPlay`.
     /// Default is `true`. Requires `NSMotionUsageDescription` in Info.plist.
-    @Published var pauseWhileDriving: Bool {
-        didSet { store.set(pauseWhileDriving, forKey: Keys.pauseWhileDriving) }
+    var pauseWhileDriving: Bool {
+        didSet {
+            store.set(pauseWhileDriving, forKey: Keys.pauseWhileDriving)
+            broadcastChange()
+        }
     }
 
     /// When `true`, schedules local notifications only as a backup path while
     /// Screen Time shielding is unavailable. Default is `true`.
-    @Published var notificationFallbackEnabled: Bool {
-        didSet { store.set(notificationFallbackEnabled, forKey: Keys.notificationFallbackEnabled) }
+    var notificationFallbackEnabled: Bool {
+        didSet {
+            store.set(notificationFallbackEnabled, forKey: Keys.notificationFallbackEnabled)
+            broadcastChange()
+        }
     }
 
     // MARK: - Phase 2
 
     /// When `true`, activates `AVAudioSession` on overlay show to interrupt
     /// other apps' audio. Default is `false`. Phase 2 feature.
-    @Published var pauseMediaDuringBreaks: Bool {
-        didSet { store.set(pauseMediaDuringBreaks, forKey: Keys.pauseMediaDuringBreaks) }
+    var pauseMediaDuringBreaks: Bool {
+        didSet {
+            store.set(pauseMediaDuringBreaks, forKey: Keys.pauseMediaDuringBreaks)
+            broadcastChange()
+        }
     }
 
     /// When `true`, plays haptic feedback on overlay events (appear, dismiss,
     /// countdown completion). Respects device silent mode automatically.
     /// Default is `true`. Phase 2 feature.
-    @Published var hapticsEnabled: Bool {
-        didSet { store.set(hapticsEnabled, forKey: Keys.hapticsEnabled) }
+    var hapticsEnabled: Bool {
+        didSet {
+            store.set(hapticsEnabled, forKey: Keys.hapticsEnabled)
+            broadcastChange()
+        }
+    }
+
+    // MARK: - Observer Surface
+
+    /// Token returned by `addObserver`; pass to `removeObserver` to detach.
+    typealias ObserverID = UUID
+
+    private var observers: [ObserverID: (ReminderSettings) -> Void] = [:]
+
+    /// Registers `callback` to receive the current `settings(for: .eyes)`
+    /// snapshot every time **any** mutable property changes (or
+    /// `resetToDefaults()` runs). Replaces the legacy `objectWillChange`
+    /// publisher so consumers no longer need Combine. Returns a token that
+    /// must be passed back to `removeObserver(_:)` to unsubscribe.
+    @discardableResult
+    func addObserver(_ callback: @escaping (ReminderSettings) -> Void) -> ObserverID {
+        let id = ObserverID()
+        observers[id] = callback
+        return id
+    }
+
+    /// Detaches the observer registered under `id`. No-op if `id` was never
+    /// registered or was already removed.
+    func removeObserver(_ id: ObserverID) {
+        observers.removeValue(forKey: id)
+    }
+
+    private func broadcastChange() {
+        objectWillChange.send()
+        guard !observers.isEmpty else { return }
+        let snapshot = settings(for: .eyes)
+        for callback in observers.values { callback(snapshot) }
     }
 
     // MARK: - Convenience Accessors

--- a/EyePostureReminder/Services/PauseConditionManager.swift
+++ b/EyePostureReminder/Services/PauseConditionManager.swift
@@ -1,5 +1,4 @@
 import AVFoundation
-import Combine
 import CoreMotion
 import Foundation
 import Intents
@@ -303,7 +302,7 @@ final class PauseConditionManager: PauseConditionProviding {
 
     private var activeConditions: Set<PauseConditionSource> = []
 
-    private var cancellables: Set<AnyCancellable> = []
+    private var settingsObserverToken: SettingsStore.ObserverID?
 
     init(
         settings: SettingsStore,
@@ -320,7 +319,7 @@ final class PauseConditionManager: PauseConditionProviding {
     func startMonitoring() {
         // Guard against duplicate subscriptions — tear down any existing
         // monitoring before re-subscribing to avoid double-firing callbacks.
-        if !cancellables.isEmpty {
+        if settingsObserverToken != nil {
             stopMonitoring()
         }
 
@@ -337,29 +336,18 @@ final class PauseConditionManager: PauseConditionProviding {
             self.update(.driving, isActive: driving && self.settings.pauseWhileDriving)
         }
 
-        // Re-evaluate all conditions whenever a pause setting is toggled.
-        // Note: @Published fires in willSet, so we use the value passed by the publisher
-        // rather than re-reading from settings (which still holds the old value at that point).
-        settings.$pauseDuringFocus
-            .dropFirst()
-            .sink { [weak self] newValue in
-                MainActor.assumeIsolated {
-                    guard let self else { return }
-                    self.update(.focusMode, isActive: self.focusDetector.isFocused && newValue)
-                }
-            }
-            .store(in: &cancellables)
-
-        settings.$pauseWhileDriving
-            .dropFirst()
-            .sink { [weak self] newValue in
-                MainActor.assumeIsolated {
-                    guard let self else { return }
-                    self.update(.carPlay, isActive: self.carPlayDetector.isCarPlayActive && newValue)
-                    self.update(.driving, isActive: self.drivingDetector.isDriving && newValue)
-                }
-            }
-            .store(in: &cancellables)
+        // Re-evaluate all conditions whenever any settings property changes.
+        // The observer surface fires after the property has been set, so we
+        // re-read the current pause flags rather than depending on the
+        // willSet semantics the legacy `@Published` publishers used.
+        settingsObserverToken = settings.addObserver { [weak self] _ in
+            guard let self else { return }
+            let pauseFocus = self.settings.pauseDuringFocus
+            let pauseDriving = self.settings.pauseWhileDriving
+            self.update(.focusMode, isActive: self.focusDetector.isFocused && pauseFocus)
+            self.update(.carPlay, isActive: self.carPlayDetector.isCarPlayActive && pauseDriving)
+            self.update(.driving, isActive: self.drivingDetector.isDriving && pauseDriving)
+        }
 
         focusDetector.startMonitoring()
         carPlayDetector.startMonitoring()
@@ -376,7 +364,10 @@ final class PauseConditionManager: PauseConditionProviding {
     }
 
     func stopMonitoring() {
-        cancellables.removeAll()
+        if let token = settingsObserverToken {
+            settings.removeObserver(token)
+            settingsObserverToken = nil
+        }
         focusDetector.stopMonitoring()
         carPlayDetector.stopMonitoring()
         drivingDetector.stopMonitoring()

--- a/EyePostureReminder/TCA/Dependencies/SettingsClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/SettingsClient.swift
@@ -1,4 +1,3 @@
-import Combine
 import ComposableArchitecture
 import Foundation
 
@@ -136,21 +135,20 @@ extension DependencyValues {
     }
 }
 
-/// Main-actor-isolated owner of the live `SettingsStore` plus the Combine
-/// subscription that mirrors `objectWillChange` updates into the file-scope
-/// snapshot cache and continuation registry.
+/// Main-actor-isolated owner of the live `SettingsStore` plus the observer
+/// subscription that mirrors mutations into the file-scope snapshot cache and
+/// continuation registry.
 @MainActor
 private final class LiveSettingsBridge {
     nonisolated static let shared = LiveSettingsBridge()
 
     let store = SettingsStore()
-    private var cancellables: Set<AnyCancellable> = []
     private var hasBootstrapped = false
 
     private nonisolated init() {}
 
     /// Idempotent bootstrap. Called from `liveValue` via a `@MainActor` task
-    /// so the Combine subscription is wired exactly once on the main actor.
+    /// so the observer subscription is wired exactly once on the main actor.
     func bootstrap() {
         guard !hasBootstrapped else { return }
         hasBootstrapped = true
@@ -159,15 +157,10 @@ private final class LiveSettingsBridge {
         settingsSnapshotCache.setValue(initial)
         broadcastSettings(initial)
 
-        store.objectWillChange
-            .receive(on: RunLoop.main)
-            .sink { [weak store] _ in
-                guard let store else { return }
-                let updated = store.settings(for: .eyes)
-                settingsSnapshotCache.setValue(updated)
-                broadcastSettings(updated)
-            }
-            .store(in: &cancellables)
+        store.addObserver { snapshot in
+            settingsSnapshotCache.setValue(snapshot)
+            broadcastSettings(snapshot)
+        }
     }
 }
 
@@ -184,7 +177,7 @@ private let settingsContinuations =
 
 /// File-scoped factory used by the live `stream` closure to register a new
 /// multicast subscriber. Yields the current snapshot synchronously so first
-/// reads never block on a `objectWillChange` tick.
+/// reads never block on a settings mutation.
 private func makeSettingsStream() -> AsyncStream<ReminderSettings> {
     let (stream, continuation) = AsyncStream<ReminderSettings>.makeStream()
     let id = UUID()

--- a/EyePostureReminder/ViewModels/SettingsViewModel.swift
+++ b/EyePostureReminder/ViewModels/SettingsViewModel.swift
@@ -129,7 +129,6 @@ final class SettingsViewModel: ObservableObject {
     private let scheduler: ReminderScheduling
     private let dateProvider: DateProviding
     private let calendar: Calendar
-    private var cancellables: Set<AnyCancellable> = []
 
     // MARK: - Computed State (M2.3)
 
@@ -324,9 +323,12 @@ final class SettingsViewModel: ObservableObject {
         self.maxConsecutiveSnoozes = resolvedMaxSnoozeCount
         self.dateProvider = resolvedDateProvider
         self.calendar = resolvedCalendar
-        settings.objectWillChange
-            .sink { [weak self] in self?.objectWillChange.send() }
-            .store(in: &cancellables)
+        // The observer is held by `settings`; `[weak self]` makes the
+        // callback a no-op once the VM is deallocated, so no explicit
+        // teardown is required.
+        settings.addObserver { [weak self] _ in
+            self?.objectWillChange.send()
+        }
         Logger.settings.debug("SettingsViewModel initialised")
     }
 

--- a/Tests/EyePostureReminderTests/Integration/IntegrationTests.swift
+++ b/Tests/EyePostureReminderTests/Integration/IntegrationTests.swift
@@ -1,4 +1,3 @@
-import Combine
 import XCTest
 
 @testable import EyePostureReminder
@@ -16,7 +15,6 @@ final class SettingsStoreViewModelIntegrationTests: XCTestCase {
     private var store: SettingsStore!
     private var viewModel: SettingsViewModel!
     private var scheduler: MockReminderScheduler!
-    private var cancellables: Set<AnyCancellable>!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -25,11 +23,9 @@ final class SettingsStoreViewModelIntegrationTests: XCTestCase {
         store = SettingsStore(store: userDefaults, config: AppConfig.fallback)
         scheduler = MockReminderScheduler()
         viewModel = SettingsViewModel(settings: store, scheduler: scheduler)
-        cancellables = []
     }
 
     override func tearDown() async throws {
-        cancellables = nil
         viewModel = nil
         scheduler = nil
         store = nil
@@ -155,14 +151,11 @@ final class SettingsStoreViewModelIntegrationTests: XCTestCase {
         XCTAssertEqual(raw, 0, "Persisted snoozedUntil must be 0 after cancel")
     }
 
-    // MARK: Published change propagation
+    // MARK: Observer change propagation
 
-    func test_publishedChange_eyesInterval_receivedBySubscriber() {
+    func test_observerChange_eyesInterval_receivedBySubscriber() {
         var received: [TimeInterval] = []
-        store.$eyesInterval
-            .dropFirst()
-            .sink { received.append($0) }
-            .store(in: &cancellables)
+        store.addObserver { received.append($0.interval) }
 
         store.eyesInterval = 600
         store.eyesInterval = 1200
@@ -170,10 +163,10 @@ final class SettingsStoreViewModelIntegrationTests: XCTestCase {
         XCTAssertEqual(
             received,
             [600, 1200],
-            "Subscribers must receive every @Published eyesInterval change in order")
+            "Observers must receive every eyesInterval change in order via the snapshot")
     }
 
-    func test_publishedChange_globalEnabled_triggersDownstreamAction() async {
+    func test_observerChange_globalEnabled_triggersDownstreamAction() async {
         store.globalEnabled = true
         viewModel.globalToggleChanged()
         await awaitCondition { scheduler.scheduleRemindersCallCount >= 1 }

--- a/Tests/EyePostureReminderTests/Integration/MultiServicePipelineIntegrationTests.swift
+++ b/Tests/EyePostureReminderTests/Integration/MultiServicePipelineIntegrationTests.swift
@@ -1,4 +1,3 @@
-import Combine
 import XCTest
 
 @testable import EyePostureReminder
@@ -19,7 +18,6 @@ final class MultiServicePipelineIntegrationTests: XCTestCase {
     private var carPlayDetector: MockCarPlayDetector!
     private var drivingDetector: MockDrivingActivityDetector!
     private var pauseManager: PauseConditionManager!
-    private var cancellables: Set<AnyCancellable>!
 
     override func setUp() async throws {
         try await super.setUp()
@@ -38,12 +36,10 @@ final class MultiServicePipelineIntegrationTests: XCTestCase {
             drivingDetector: drivingDetector
         )
         pauseManager.startMonitoring()
-        cancellables = []
     }
 
     override func tearDown() async throws {
         pauseManager.stopMonitoring()
-        cancellables = nil
         pauseManager = nil
         drivingDetector = nil
         carPlayDetector = nil
@@ -121,28 +117,34 @@ final class MultiServicePipelineIntegrationTests: XCTestCase {
         XCTAssertEqual(store.postureInterval, 1800)
     }
 
-    func test_concurrentPublishedObservers_receiveAllChanges() async {
-        var globalValues: [Bool] = []
-        var intervalValues: [TimeInterval] = []
+    func test_concurrentObservers_receiveSnapshotsForEveryChange() {
+        var snapshots1: [ReminderSettings] = []
+        var snapshots2: [ReminderSettings] = []
 
-        store.$globalEnabled.dropFirst().sink { globalValues.append($0) }.store(in: &cancellables)
-        store.$eyesInterval.dropFirst().sink { intervalValues.append($0) }.store(in: &cancellables)
+        store.addObserver { snapshots1.append($0) }
+        store.addObserver { snapshots2.append($0) }
 
         store.globalEnabled = false
         store.eyesInterval = 600
         store.eyesInterval = 1200
 
-        // Poll until Combine publishers deliver all three changes.
-        await awaitCondition { globalValues.count >= 1 && intervalValues.count >= 2 }
-
+        // Three mutations × two observers = each observer sees 3 snapshots.
         XCTAssertEqual(
-            globalValues,
-            [false],
-            "globalEnabled subscriber must receive one change")
+            snapshots1.count,
+            3,
+            "First observer must receive a snapshot for every mutation")
         XCTAssertEqual(
-            intervalValues,
-            [600, 1200],
-            "eyesInterval subscriber must receive both changes in order")
+            snapshots2.count,
+            3,
+            "Second observer must receive a snapshot for every mutation")
+        XCTAssertEqual(
+            snapshots1.last?.interval,
+            1200,
+            "Last snapshot must reflect the most recent eyesInterval value")
+        XCTAssertEqual(
+            snapshots2.last?.interval,
+            1200,
+            "Last snapshot must reflect the most recent eyesInterval value")
     }
 
     // MARK: Full wiring smoke test

--- a/Tests/EyePostureReminderTests/Models/SettingsStoreObserverTests.swift
+++ b/Tests/EyePostureReminderTests/Models/SettingsStoreObserverTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+
+@testable import EyePostureReminder
+
+@MainActor
+final class SettingsStoreObserverTests: XCTestCase {
+
+    private var mockPersistence: MockSettingsPersisting!
+    private var sut: SettingsStore!
+
+    override func setUp() {
+        super.setUp()
+        mockPersistence = MockSettingsPersisting()
+        sut = SettingsStore(store: mockPersistence)
+    }
+
+    override func tearDown() {
+        sut = nil
+        mockPersistence = nil
+        super.tearDown()
+    }
+
+    // MARK: - Registration
+
+    func test_addObserver_returnsUniqueIDsAcrossCalls() {
+        let firstID = sut.addObserver { _ in }
+        let secondID = sut.addObserver { _ in }
+        XCTAssertNotEqual(firstID, secondID,
+                          "Each addObserver call should hand out a unique token")
+    }
+
+    func test_addObserver_doesNotFireImmediately() {
+        var fireCount = 0
+        _ = sut.addObserver { _ in fireCount += 1 }
+        XCTAssertEqual(fireCount, 0,
+                       "Registration alone must not emit; emission only on mutation")
+    }
+
+    // MARK: - Broadcast on Mutation
+
+    func test_observer_firesOnGlobalEnabledMutation() {
+        var fireCount = 0
+        _ = sut.addObserver { _ in fireCount += 1 }
+        sut.globalEnabled.toggle()
+        XCTAssertEqual(fireCount, 1)
+    }
+
+    func test_observer_firesOnEyesIntervalMutation_andCarriesEyesSnapshot() {
+        var lastSnapshot: ReminderSettings?
+        _ = sut.addObserver { lastSnapshot = $0 }
+        sut.eyesInterval = 600
+        XCTAssertEqual(lastSnapshot?.interval, 600)
+        XCTAssertEqual(lastSnapshot?.breakDuration, sut.eyesBreakDuration)
+    }
+
+    func test_observer_firesOnEyesBreakDurationMutation() {
+        var lastSnapshot: ReminderSettings?
+        _ = sut.addObserver { lastSnapshot = $0 }
+        sut.eyesBreakDuration = 25
+        XCTAssertEqual(lastSnapshot?.breakDuration, 25)
+    }
+
+    func test_observer_firesOnPostureMutations_evenThoughPayloadIsEyes() {
+        var fireCount = 0
+        _ = sut.addObserver { _ in fireCount += 1 }
+        sut.postureEnabled.toggle()
+        sut.postureInterval = 1500
+        sut.postureBreakDuration = 15
+        XCTAssertEqual(fireCount, 3,
+                       "Posture mutations must broadcast — they are still settings changes")
+    }
+
+    func test_observer_firesOnSnoozeAndPauseMutations() {
+        var fireCount = 0
+        _ = sut.addObserver { _ in fireCount += 1 }
+        sut.snoozedUntil = Date(timeIntervalSince1970: 1)
+        sut.snoozeCount = 2
+        sut.pauseDuringFocus.toggle()
+        sut.pauseWhileDriving.toggle()
+        sut.notificationFallbackEnabled.toggle()
+        sut.pauseMediaDuringBreaks.toggle()
+        sut.hapticsEnabled.toggle()
+        XCTAssertEqual(fireCount, 7,
+                       "Every settable property must broadcast exactly once per mutation")
+    }
+
+    func test_observer_firesOncePerResetToDefaults_perMutatedProperty() {
+        // Set non-default values so resetToDefaults visibly mutates each property.
+        sut.globalEnabled = false
+        sut.eyesEnabled = false
+        sut.postureEnabled = false
+        sut.eyesInterval = 999
+        sut.eyesBreakDuration = 25
+        sut.postureInterval = 999
+        sut.postureBreakDuration = 25
+        sut.hapticsEnabled = false
+        sut.pauseMediaDuringBreaks = true
+        sut.pauseDuringFocus = false
+        sut.pauseWhileDriving = false
+        sut.notificationFallbackEnabled = false
+        sut.snoozedUntil = Date(timeIntervalSince1970: 1)
+        sut.snoozeCount = 5
+
+        var fireCount = 0
+        _ = sut.addObserver { _ in fireCount += 1 }
+
+        sut.resetToDefaults(config: .fallback)
+
+        // resetToDefaults touches 14 settable properties; each broadcasts once.
+        XCTAssertEqual(fireCount, 14,
+                       "resetToDefaults must broadcast for each property it overwrites")
+    }
+
+    // MARK: - Multiple Observers
+
+    func test_multipleObservers_allReceiveBroadcasts() {
+        var firstFireCount = 0
+        var secondFireCount = 0
+        _ = sut.addObserver { _ in firstFireCount += 1 }
+        _ = sut.addObserver { _ in secondFireCount += 1 }
+        sut.globalEnabled.toggle()
+        XCTAssertEqual(firstFireCount, 1)
+        XCTAssertEqual(secondFireCount, 1)
+    }
+
+    // MARK: - Removal
+
+    func test_removeObserver_stopsFurtherCallbacks() {
+        var fireCount = 0
+        let token = sut.addObserver { _ in fireCount += 1 }
+        sut.globalEnabled.toggle()
+        XCTAssertEqual(fireCount, 1)
+
+        sut.removeObserver(token)
+        sut.globalEnabled.toggle()
+        XCTAssertEqual(fireCount, 1, "Mutations after removeObserver must not fire the callback")
+    }
+
+    func test_removeObserver_unknownToken_isNoOp() {
+        // Should not crash or affect state.
+        sut.removeObserver(UUID())
+        XCTAssertTrue(sut.globalEnabled, "State must remain untouched by a no-op removeObserver")
+    }
+
+    func test_removeObserver_doesNotAffectOtherObservers() {
+        var firstFireCount = 0
+        var secondFireCount = 0
+        let firstToken = sut.addObserver { _ in firstFireCount += 1 }
+        _ = sut.addObserver { _ in secondFireCount += 1 }
+
+        sut.removeObserver(firstToken)
+        sut.globalEnabled.toggle()
+
+        XCTAssertEqual(firstFireCount, 0)
+        XCTAssertEqual(secondFireCount, 1)
+    }
+}


### PR DESCRIPTION
## Summary

Lands the **observer-surface** half of #701. The full `: ObservableObject`
strip is deferred to #677 because legacy SwiftUI surfaces
(HomeView / SettingsView / OnboardingView / OnboardingSetupView) still
consume `SettingsStore` via `@EnvironmentObject`, which requires
`ObservableObject` conformance until those views are migrated to TCA.

## Changes

- **SettingsStore** — adds UUID-keyed observer surface (`addObserver` /
  `removeObserver` / `broadcastChange`); drops every `@Published`; each
  property's `didSet` calls `broadcastChange()` which invokes
  `objectWillChange.send()` (so SwiftUI `@EnvironmentObject` consumers
  still refresh) and dispatches the latest `settings(for: .eyes)`
  snapshot to all registered observers.
- **SettingsClient.liveValue** — subscribes via `addObserver` instead of
  `store.objectWillChange.sink`; drops `import Combine` + `cancellables`.
- **SettingsViewModel** — forwards via
  `addObserver { [weak self] _ in self?.objectWillChange.send() }`.
- **PauseConditionManager** — subscribes via `addObserver` instead of the
  `settings.$pauseDuringFocus` / `settings.$pauseWhileDriving` Combine
  projections; drops `import Combine` + `cancellables`. Re-reads the
  current pause flags inside the callback because the observer fires
  *after* the property is set (legacy `@Published` willSet fired with
  the new value as the publisher payload).
- **Integration tests** — rewrites
  `test_publishedChange_eyesInterval_*` and
  `test_concurrentPublishedObservers_receiveAllChanges` to use the new
  `addObserver` API; drops `import Combine` + `cancellables` from those
  test classes.
- **New tests** — `SettingsStoreObserverTests` (~13 cases) covering
  registration uniqueness, no-fire-on-register, broadcast on every
  property mutation, multi-observer fan-out, removal semantics, and the
  `resetToDefaults` fire-count (= 14 broadcasts).
- **ARCHITECTURE.md** — documents the new observer surface.

## Verification

- ✅ `./scripts/build.sh all`: build + lint + tests pass.
  - **2176 tests, 0 failures** (was 2161 before; +13 new + 2 rewritten).
- ✅ SwiftLint: 0 violations on the four edited source files.

## Out of scope (deferred)

- Stripping `: ObservableObject` conformance from `SettingsStore` —
  blocked on #677 (`p0-tca-14`) which migrates the four legacy
  `@EnvironmentObject SettingsStore` view consumers to TCA. Once #677
  lands, removing `: ObservableObject` becomes a one-line follow-up
  (also drops `import Combine` and the `objectWillChange.send()` call
  inside `broadcastChange`).

Refs #701