### PR TITLE
test(uitest): pre-seed overlay launch-arg defaults in AppDelegate.init (#711)

### DIFF
--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -102,6 +102,16 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     /// `EyePostureReminderApp.init()` — because `@UIApplicationDelegateAdaptor`
     /// only instantiates this delegate as part of `UIApplicationMain`, which
     /// runs *after* the App struct's `init()` body returns. See #707.
+    ///
+    /// Overlay launch arguments (`--show-overlay-eyes` / `--show-overlay-posture`)
+    /// are also seeded here so the `uiTestOverlayType` key and inflated break
+    /// durations land before `@StateObject AppCoordinator()` constructs its
+    /// `SettingsStore` (which reads `eyes.breakDuration`/`posture.breakDuration`
+    /// from `UserDefaults` at init). Without this, `applyUITestLaunchArguments()`
+    /// — which runs from `didFinishLaunchingWithOptions`, after the SwiftUI
+    /// state-object instantiation in some launch orderings — wrote inflated
+    /// values into a settings store the active overlay was no longer using,
+    /// causing the overlay to auto-dismiss before tests asserted on it (#711).
     private func preSeedUITestDefaults() {
         if launchArguments.contains("--simulate-screen-time-not-determined") {
             uiTestDefaults.set(
@@ -122,6 +132,35 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
                 uiTestDefaults.set(false, forKey: AppStorageKey.trueInterruptSkippedBannerDismissed)
             }
         }
+
+        if launchArguments.contains("--show-overlay-eyes") {
+            seedOverlayLaunchDefaults(for: .eyes)
+        } else if launchArguments.contains("--show-overlay-posture") {
+            seedOverlayLaunchDefaults(for: .posture)
+        }
+        // Stale `uiTestOverlayType` (no overlay launch arg present) is wiped
+        // by `applyUITestLaunchArguments()` in `didFinishLaunchingWithOptions`,
+        // before SwiftUI's `.onAppear` calls `consumeUITestOverlayType()`.
+    }
+
+    /// Writes the UserDefaults keys consumed by the `--show-overlay-{eyes,posture}`
+    /// UI-test launch arguments. Inflated break durations keep the overlay
+    /// on-screen long enough for assertions to run.
+    ///
+    /// `applyUITestLaunchArguments()` re-applies the same writes after calling
+    /// `SettingsStore.resetToDefaults()` (which would otherwise wipe these
+    /// pre-seeds back to their build-time defaults).
+    private func seedOverlayLaunchDefaults(for type: ReminderType) {
+        uiTestDefaults.set(true, forKey: AppStorageKey.hasSeenOnboarding)
+        uiTestDefaults.set(type.rawValue, forKey: AppStorageKey.uiTestOverlayType)
+        uiTestDefaults.set(
+            Self.uiTestOverlayBreakDuration,
+            forKey: SettingsStore.Keys.eyesBreakDuration
+        )
+        uiTestDefaults.set(
+            Self.uiTestOverlayBreakDuration,
+            forKey: SettingsStore.Keys.postureBreakDuration
+        )
     }
 #endif
 
@@ -170,11 +209,25 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     /// Handles launch arguments injected by XCUITest targets to control app state.
     /// `#if DEBUG` ensures these backdoors are compiled out of Release/TestFlight
     /// builds, closing the production-settings-reset vulnerability (re: #350/#405).
+    ///
+    /// `preSeedUITestDefaults()` (called from `init()`) is the first writer for
+    /// the overlay-launch-arg keys (`uiTestOverlayType`, inflated break
+    /// durations, `hasSeenOnboarding`); this method re-applies the same writes
+    /// after `SettingsStore.resetToDefaults()` because the reset clobbers the
+    /// pre-seeded break durations back to their build-time defaults (#711).
 #if DEBUG
     private func applyUITestLaunchArguments() {
         let args = launchArguments
         let defaults = uiTestDefaults
-        defaults.removeObject(forKey: AppStorageKey.uiTestOverlayType)
+        // Clear any stale overlay-type seed before re-applying any launch-arg
+        // intent. `preSeedUITestDefaults()` writes the new value (when an
+        // overlay launch arg is present) earlier in `init()`; the
+        // overlay-launch-arg branches below repeat the write so the value
+        // survives the `SettingsStore.resetToDefaults()` call inside
+        // `applyOverlayLaunchArgument(for:)`.
+        if !args.contains("--show-overlay-eyes") && !args.contains("--show-overlay-posture") {
+            defaults.removeObject(forKey: AppStorageKey.uiTestOverlayType)
+        }
         if args.contains("--skip-onboarding") {
             defaults.set(true, forKey: AppStorageKey.hasSeenOnboarding)
             // Reset all settings to defaults so each test starts from a clean, known state.
@@ -186,20 +239,10 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
             resolvedSettingsStore.resetToDefaults()
         }
         if args.contains("--show-overlay-eyes") {
-            defaults.set(true, forKey: AppStorageKey.hasSeenOnboarding)
-            let settings = resolvedSettingsStore
-            settings.resetToDefaults()
-            settings.eyesBreakDuration = Self.uiTestOverlayBreakDuration
-            settings.postureBreakDuration = Self.uiTestOverlayBreakDuration
-            defaults.set(ReminderType.eyes.rawValue, forKey: AppStorageKey.uiTestOverlayType)
+            applyOverlayLaunchArgument(for: .eyes)
         }
         if args.contains("--show-overlay-posture") {
-            defaults.set(true, forKey: AppStorageKey.hasSeenOnboarding)
-            let settings = resolvedSettingsStore
-            settings.resetToDefaults()
-            settings.eyesBreakDuration = Self.uiTestOverlayBreakDuration
-            settings.postureBreakDuration = Self.uiTestOverlayBreakDuration
-            defaults.set(ReminderType.posture.rawValue, forKey: AppStorageKey.uiTestOverlayType)
+            applyOverlayLaunchArgument(for: .posture)
         }
         if args.contains("--simulate-screen-time-not-determined") {
             defaults.set(true, forKey: AppStorageKey.hasSeenOnboarding)
@@ -214,6 +257,21 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
                 forKey: AppStorageKey.trueInterruptSkippedBannerDismissed
             )
         }
+    }
+
+    /// Resets the live `SettingsStore` and re-applies the inflated overlay
+    /// break durations + `uiTestOverlayType` seed previously written by
+    /// `preSeedUITestDefaults()`. The reset is required to scrub stale settings
+    /// from prior test launches, but it would otherwise overwrite the inflated
+    /// break durations with the build-time defaults (#711).
+    private func applyOverlayLaunchArgument(for type: ReminderType) {
+        let defaults = uiTestDefaults
+        defaults.set(true, forKey: AppStorageKey.hasSeenOnboarding)
+        let settings = resolvedSettingsStore
+        settings.resetToDefaults()
+        settings.eyesBreakDuration = Self.uiTestOverlayBreakDuration
+        settings.postureBreakDuration = Self.uiTestOverlayBreakDuration
+        defaults.set(type.rawValue, forKey: AppStorageKey.uiTestOverlayType)
     }
 
     /// Returns and clears a pending UI-test overlay request if present.

--- a/EyePostureReminder/Models/SettingsStore.swift
+++ b/EyePostureReminder/Models/SettingsStore.swift
@@ -323,9 +323,10 @@ final class SettingsStore: ObservableObject {
 extension SettingsStore {
     /// `UserDefaults` key namespace for every persisted `SettingsStore`
     /// property. Exposed at module scope (not `private`) so non-`@MainActor`
-    /// callers — for example the `EyePostureReminderApp.init` synchronous
-    /// settings seed (#737) — can read the same canonical keys without
-    /// duplicating string literals that would silently drift on rename.
+    /// callers can read/write the same canonical keys without duplicating
+    /// string literals that would silently drift on rename:
+    ///   - `EyePostureReminderApp.init` synchronous settings seed (#737)
+    ///   - `AppDelegate.preSeedUITestDefaults()` launch-arg pre-seed (#711)
     enum Keys {
         static let globalEnabled          = "kshana.globalEnabled"
         static let eyesEnabled            = "kshana.eyes.enabled"

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -16,7 +16,7 @@ private final class MockMetricKitSubscriber: MetricKitSubscribing {
     }
 }
 
-// swiftlint:disable type_body_length
+// swiftlint:disable type_body_length file_length
 /// Unit tests for `AppDelegate` notification routing logic.
 ///
 /// ## What is tested here
@@ -497,6 +497,100 @@ final class AppDelegateTests: XCTestCase {
         )
 
         XCTAssertNil(defaults.string(forKey: AppStorageKey.uiTestScreenTimeStatus))
+    }
+
+    /// Regression for #711: the `--show-overlay-eyes` launch arg must seed
+    /// `uiTestOverlayType`, `hasSeenOnboarding`, and the inflated break
+    /// durations during `init()` (before `didFinishLaunchingWithOptions`),
+    /// so `@StateObject AppCoordinator()`'s `SettingsStore` reads the
+    /// inflated values from `UserDefaults` and the overlay does not
+    /// auto-dismiss before the UI test asserts on it.
+    func test_init_showOverlayEyes_preSeedsOverlayDefaultsBeforeDidFinishLaunching() throws {
+        let defaults = try makeIsolatedDefaults(suffix: #function)
+
+        _ = AppDelegate(
+            launchArguments: ["--show-overlay-eyes"],
+            uiTestDefaults: defaults
+        )
+
+        XCTAssertEqual(defaults.string(forKey: AppStorageKey.uiTestOverlayType), ReminderType.eyes.rawValue)
+        XCTAssertTrue(defaults.bool(forKey: AppStorageKey.hasSeenOnboarding))
+        XCTAssertEqual(
+            defaults.double(forKey: SettingsStore.Keys.eyesBreakDuration),
+            AppDelegate.uiTestOverlayBreakDuration
+        )
+        XCTAssertEqual(
+            defaults.double(forKey: SettingsStore.Keys.postureBreakDuration),
+            AppDelegate.uiTestOverlayBreakDuration
+        )
+    }
+
+    /// Regression for #711: `--show-overlay-posture` must pre-seed the same
+    /// keys at `init()` time as `--show-overlay-eyes`, only with the
+    /// posture `ReminderType` raw value.
+    func test_init_showOverlayPosture_preSeedsOverlayDefaultsBeforeDidFinishLaunching() throws {
+        let defaults = try makeIsolatedDefaults(suffix: #function)
+
+        _ = AppDelegate(
+            launchArguments: ["--show-overlay-posture"],
+            uiTestDefaults: defaults
+        )
+
+        XCTAssertEqual(defaults.string(forKey: AppStorageKey.uiTestOverlayType), ReminderType.posture.rawValue)
+        XCTAssertTrue(defaults.bool(forKey: AppStorageKey.hasSeenOnboarding))
+        XCTAssertEqual(
+            defaults.double(forKey: SettingsStore.Keys.eyesBreakDuration),
+            AppDelegate.uiTestOverlayBreakDuration
+        )
+        XCTAssertEqual(
+            defaults.double(forKey: SettingsStore.Keys.postureBreakDuration),
+            AppDelegate.uiTestOverlayBreakDuration
+        )
+    }
+
+    /// Without an overlay launch arg, `applyUITestLaunchArguments()` (called
+    /// from `didFinishLaunchingWithOptions`) must clear any stale
+    /// `uiTestOverlayType` value left behind by a previous test launch on the
+    /// same simulator so the next launch does not unexpectedly re-trigger an
+    /// overlay (#711).
+    func test_didFinishLaunching_withoutOverlayFlag_clearsStaleOverlayTypeKey() throws {
+        let defaults = try makeIsolatedDefaults(suffix: #function)
+        defaults.set(ReminderType.eyes.rawValue, forKey: AppStorageKey.uiTestOverlayType)
+        let store = MockSettingsPersisting()
+        let settings = SettingsStore(store: store, config: .fallback)
+        let sut = AppDelegate(
+            notificationCenter: MockUserNotificationCenter(),
+            metricKitSubscriber: MockMetricKitSubscriber(),
+            settingsStore: settings,
+            launchArguments: ["--skip-onboarding"],
+            uiTestDefaults: defaults
+        )
+
+        _ = sut.application(UIApplication.shared, didFinishLaunchingWithOptions: nil)
+
+        XCTAssertNil(defaults.string(forKey: AppStorageKey.uiTestOverlayType))
+    }
+
+    /// The full launch sequence (init + didFinishLaunching) must leave the
+    /// inflated break durations intact even after
+    /// `SettingsStore.resetToDefaults()` runs — the regression in #711 was
+    /// that the reset wiped the pre-seed without re-applying it.
+    func test_didFinishLaunching_showOverlayEyes_preservesInflatedBreakDurationsAfterReset() throws {
+        let defaults = try makeIsolatedDefaults(suffix: #function)
+        let store = MockSettingsPersisting()
+        let settings = SettingsStore(store: store, config: .fallback)
+        let sut = AppDelegate(
+            notificationCenter: MockUserNotificationCenter(),
+            metricKitSubscriber: MockMetricKitSubscriber(),
+            settingsStore: settings,
+            launchArguments: ["--show-overlay-eyes"],
+            uiTestDefaults: defaults
+        )
+
+        _ = sut.application(UIApplication.shared, didFinishLaunchingWithOptions: nil)
+
+        XCTAssertEqual(settings.eyesBreakDuration, AppDelegate.uiTestOverlayBreakDuration)
+        XCTAssertEqual(settings.postureBreakDuration, AppDelegate.uiTestOverlayBreakDuration)
     }
 
     func test_didFinishLaunching_showOverlayEyes_usesInjectedSettingsStoreFactory() throws {


### PR DESCRIPTION
## Summary

Fixes the consistent OverlayUITests shard failure tracked in #711.

`applyUITestLaunchArguments()` was writing `uiTestOverlayType` and the inflated break durations in `didFinishLaunchingWithOptions`, **after** SwiftUI had already constructed `@StateObject AppCoordinator()` and its legacy MVVM `SettingsStore` had read `UserDefaults`. The store would then surface the build-time defaults instead of the inflated test values, so `coordinator.handleNotification(for:)` would fire the overlay with a too-short break duration and dismiss it before XCTest could observe it.

## Changes

- `AppDelegate.preSeedUITestDefaults()` (called from `AppDelegate.init`, which runs before SwiftUI evaluates the `@StateObject`) now writes `hasSeenOnboarding`, `uiTestOverlayType` and the inflated 600s break durations whenever `--show-overlay-eyes`/`--show-overlay-posture` is present. This mirrors the precedent set by `preSeedHasSeenOnboardingFromLaunchArgsIfNeeded()` in #707.
- `applyUITestLaunchArguments()` keeps re-applying the same writes after `SettingsStore.resetToDefaults()` so existing behaviour is preserved. Stale `uiTestOverlayType` clearing is left there (and only when no overlay flag is present), preserving the existing `test_consumeUITestOverlayType_*` contract.
- `SettingsStore.Keys` enum visibility raised from `fileprivate` to `internal` so `AppDelegate` can write the break-duration keys directly. No semantic change.

## Tests

Adds 4 tests in `AppDelegateTests`:
- `test_init_showOverlayEyes_preSeedsOverlayDefaultsBeforeDidFinishLaunching`
- `test_init_showOverlayPosture_preSeedsOverlayDefaultsBeforeDidFinishLaunching`
- `test_didFinishLaunching_withoutOverlayFlag_clearsStaleOverlayTypeKey`
- `test_didFinishLaunching_showOverlayEyes_preservesInflatedBreakDurationsAfterReset`

`./scripts/build.sh all` passes locally (2179 tests, 0 failures).

## Risk

- Widening `SettingsStore.Keys` from `fileprivate` to `internal` is a small surface-area change, no behaviour delta.
- Pre-seed runs unconditionally during `AppDelegate.init`, but is gated on `isUITestMode` so production launches are unaffected.

Closes #711