### PR TITLE
test: harden launch-readiness latency assertion against analytics handler bleed-through (#718)

### DIFF
--- a/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppCoordinatorTests.swift
@@ -831,12 +831,20 @@ final class AppCoordinatorTests: XCTestCase {
             return nil
         }
 
-        XCTAssertEqual(latencies.count, 1)
+        // #718: `AnalyticsLogger.testEventHandler` is a process-global hook,
+        // so any AppCoordinator instance from an earlier test whose async
+        // work outlives its test body can still emit `appLaunchReadiness`
+        // events into this test's `captured` array — usually with a
+        // wall-clock latency unrelated to our injected `MockDateProvider`.
+        // Match against the injected 42 s value explicitly so this assertion
+        // measures *our* coordinator's behaviour, not the bleed-through.
+        let injectedLatencies = latencies.filter { abs($0 - 42) < 0.001 }
         XCTAssertEqual(
-            latencies[0],
-            42,
-            accuracy: 0.001,
-            "handleForegroundTransition should derive readiness latency from injected DateProviding")
+            injectedLatencies.count,
+            1,
+            "handleForegroundTransition should emit exactly one readiness " +
+            "event sourced from the injected DateProviding " +
+            "(captured: \(latencies))")
     }
 
     // MARK: - ReminderScheduling conformance (crash-safety)


### PR DESCRIPTION
## Summary

Closes #718.

`AppCoordinatorTests.test_handleForegroundTransition_usesInjectedDateProvider_forLaunchReadinessLatency`
was failing intermittently on CI with two `appLaunchReadiness` events
captured where the assertion expects exactly one (e.g. PR #716 attempt 1,
run 25894158125):

```
✗ XCTAssertEqual failed: ("2") is not equal to ("1")
✗ XCTAssertEqualWithAccuracy failed: ("0.6835839748382568") is not equal to ("42.0")
   - handleForegroundTransition should derive readiness latency from injected DateProviding
```

`AnalyticsLogger.testEventHandler` is a process-global
`nonisolated(unsafe)` static, so any AppCoordinator instance from an
earlier test whose async work (`refreshAuthStatus`, watchdog recovery,
trueInterruptEnabled NotificationCenter handlers, …) outlives its test
body keeps firing events into the next test's `captured` array. The
~0.68 s latency in the first leaked event is wall-clock elapsed inside
a stale coordinator's `SystemDateProvider` read.

This change keeps the test scoped to the *injected* 42 s value: filter
`latencies` to entries within ε of 42 before asserting the count is 1,
and dump the full captured array in the failure message so the next
diagnosis is one log read away. The coordinator-under-test still must
emit exactly one matching event, so behaviour coverage is preserved.

The wider root-cause fix (turning `testEventHandler` into a
per-test-keyed table) is left to a follow-up; this PR is the minimal
change to stop the flake from blocking CI.

## Verification

```
./scripts/build.sh all
✓ Build succeeded
✓ Lint passed
✓ Tests passed (2175 tests, 0 failures, 117 s)
```

## Risk

Test-only change in a single test case. No production code touched.
