### PR TITLE
refactor(views): drive AppCategoryPickerView from AppCategoryPickerFeature store (#702 Phase 6)

### DIFF
--- a/EyePostureReminder/Views/AppCategoryPickerView.swift
+++ b/EyePostureReminder/Views/AppCategoryPickerView.swift
@@ -10,116 +10,132 @@
 // will host the real picker once #201 is resolved.
 //
 // View boundary contract:
-//   - Accepts `SelectedAppsState` as `@ObservedObject` — no @EnvironmentObject.
-//   - Accepts `authorizationStatus` as a plain value — no live FamilyControls import.
-//   - Calls injected action closures — no navigation or UIApplication coupling.
-// This keeps the view testable via body-description inspection without a SwiftUI host.
+//   - Driven by a `StoreOf<AppCategoryPickerFeature>` (TCA Phase 1 reducer).
+//   - `onSelectApps` remains an injected closure: the `FamilyActivityPicker`
+//     invocation is parent-owned and not modeled in the Phase-1 reducer
+//     (extending it is deferred to #678 / Phase 2 of the TCA migration).
+//   - Done dismisses via `@Environment(\.dismiss)` after dispatching
+//     `.doneTapped` to the store, so the parent reducer can clear its
+//     destination once `RootView` takes ownership of presentation
+//     (Phase 7 of #702).
 
+import ComposableArchitecture
 import SwiftUI
 
 // MARK: - AppCategoryPickerView
 
 /// Presents the True Interrupt Mode configuration surface.
 ///
-/// Renders one of four states based on `authorizationStatus`:
+/// Renders one of four states based on `store.authorizationStatus`:
 /// - `.unavailable`   — Entitlement pending; informational banner, CTA disabled.
 /// - `.notDetermined` — Pre-permission copy; "Enable Screen Time Access" CTA.
 /// - `.denied`        — Re-authorize nudge; "Open Settings" CTA.
 /// - `.approved`      — Selection summary; placeholder for FamilyActivityPicker (#201).
 struct AppCategoryPickerView: View {
-    @ObservedObject var appsState: SelectedAppsState
-    let authorizationStatus: ScreenTimeAuthorizationStatus
-    /// Called when the user can still request Screen Time authorization.
-    let onRequestAuthorization: () -> Void
-    /// Called when authorization is denied and iOS Settings is the recovery path.
-    var onOpenSettings: () -> Void = {}
-    /// Called when authorization is approved and the app/category picker is available.
+    @Perception.Bindable var store: StoreOf<AppCategoryPickerFeature>
+    /// Called when authorization is approved and the FamilyActivityPicker can be
+    /// presented. Remains a closure because the picker invocation is parent-owned
+    /// and not modeled in the Phase-1 reducer (#678 will fold it into the store).
     var onSelectApps: () -> Void = {}
-    let onDone: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: AppSpacing.lg) {
-                    Spacer(minLength: AppSpacing.xl)
+        WithPerceptionTracking {
+            NavigationStack {
+                ScrollView {
+                    VStack(spacing: AppSpacing.lg) {
+                        Spacer(minLength: AppSpacing.xl)
 
-                    // Hero icon
+                        // Hero icon
                         Image(systemName: AppSymbol.trueInterrupt)
-                        .font(AppFont.trueInterruptIcon)
-                        .symbolRenderingMode(.hierarchical)
-                        .foregroundStyle(AppColor.primaryRest)
-                        .frame(
-                            width: AppLayout.onboardingIllustrationSize,
-                            height: AppLayout.onboardingIllustrationSize
+                            .font(AppFont.trueInterruptIcon)
+                            .symbolRenderingMode(.hierarchical)
+                            .foregroundStyle(AppColor.primaryRest)
+                            .frame(
+                                width: AppLayout.onboardingIllustrationSize,
+                                height: AppLayout.onboardingIllustrationSize
+                            )
+                            .background(Circle().fill(AppColor.surfaceTint))
+                            .accessibilityHidden(true)
+
+                        // Title + context subtitle
+                        VStack(spacing: AppSpacing.sm) {
+                            Text("appCategoryPicker.title", bundle: .module)
+                                .font(AppFont.headline)
+                                .foregroundStyle(AppColor.textPrimary)
+                                .multilineTextAlignment(.center)
+                            Text(subtitleKey, bundle: .module)
+                                .font(AppFont.body)
+                                .foregroundStyle(AppColor.textSecondary)
+                                .multilineTextAlignment(.center)
+                        }
+
+                        // Status-specific information card
+                        statusCard
+                            .padding(.horizontal, AppSpacing.md)
+
+                        Spacer(minLength: AppSpacing.lg)
+
+                        // Primary CTA
+                        Button(action: performPrimaryAction) {
+                            Text(primaryButtonKey, bundle: .module)
+                                .frame(maxWidth: .infinity)
+                        }
+                        .buttonStyle(.primary)
+                        .disabled(store.authorizationStatus == .unavailable)
+                        .padding(.horizontal, AppSpacing.xl)
+                        .accessibilityIdentifier("appCategoryPicker.primaryButton")
+                        .accessibilityHint(Text(primaryButtonHintKey, bundle: .module))
+
+                        // Secondary dismiss
+                        Button(action: performDoneAction) {
+                            Text("appCategoryPicker.doneButton", bundle: .module)
+                        }
+                        .buttonStyle(.secondary)
+                        .padding(.horizontal, AppSpacing.xl)
+                        .accessibilityIdentifier("appCategoryPicker.doneButton")
+                        .accessibilityHint(
+                            Text("appCategoryPicker.doneButton.hint", bundle: .module)
                         )
-                        .background(Circle().fill(AppColor.surfaceTint))
-                        .accessibilityHidden(true)
-
-                    // Title + context subtitle
-                    VStack(spacing: AppSpacing.sm) {
-                        Text("appCategoryPicker.title", bundle: .module)
-                            .font(AppFont.headline)
-                            .foregroundStyle(AppColor.textPrimary)
-                            .multilineTextAlignment(.center)
-                        Text(subtitleKey, bundle: .module)
-                            .font(AppFont.body)
-                            .foregroundStyle(AppColor.textSecondary)
-                            .multilineTextAlignment(.center)
                     }
-
-                    // Status-specific information card
-                    statusCard
-                        .padding(.horizontal, AppSpacing.md)
-
-                    Spacer(minLength: AppSpacing.lg)
-
-                    // Primary CTA
-                    Button(action: performPrimaryAction) {
-                        Text(primaryButtonKey, bundle: .module)
-                            .frame(maxWidth: .infinity)
-                    }
-                    .buttonStyle(.primary)
-                    .disabled(authorizationStatus == .unavailable)
-                    .padding(.horizontal, AppSpacing.xl)
-                    .accessibilityIdentifier("appCategoryPicker.primaryButton")
-                    .accessibilityHint(Text(primaryButtonHintKey, bundle: .module))
-
-                    // Secondary dismiss
-                    Button(action: onDone) {
-                        Text("appCategoryPicker.doneButton", bundle: .module)
-                    }
-                    .buttonStyle(.secondary)
-                    .padding(.horizontal, AppSpacing.xl)
-                    .accessibilityIdentifier("appCategoryPicker.doneButton")
-                    .accessibilityHint(Text("appCategoryPicker.doneButton.hint", bundle: .module))
+                    .padding(AppSpacing.md)
+                    .frame(maxWidth: AppLayout.onboardingMaxContentWidth)
+                    .frame(maxWidth: .infinity)
                 }
-                .padding(AppSpacing.md)
-                .frame(maxWidth: AppLayout.onboardingMaxContentWidth)
-                .frame(maxWidth: .infinity)
+                .background(AppColor.background.ignoresSafeArea())
+                .navigationTitle(Text("appCategoryPicker.navTitle", bundle: .module))
+                .navigationBarTitleDisplayMode(.inline)
             }
-            .background(AppColor.background.ignoresSafeArea())
-            .navigationTitle(Text("appCategoryPicker.navTitle", bundle: .module))
-            .navigationBarTitleDisplayMode(.inline)
+            .onAppear { store.send(.onAppear) }
         }
     }
 
     func performPrimaryAction() {
-        switch authorizationStatus {
+        switch store.authorizationStatus {
         case .unavailable:
             return
         case .notDetermined:
-            onRequestAuthorization()
+            store.send(.requestAuthorizationTapped)
         case .denied:
-            onOpenSettings()
+            store.send(.openSettingsTapped)
         case .approved:
             onSelectApps()
         }
     }
 
+    /// Dispatches `.doneTapped` for parent-side dismissal logic and dismisses the
+    /// presentation via SwiftUI environment so sheet bindings reset cleanly during
+    /// the transitional period before `RootView` owns the destination scope.
+    func performDoneAction() {
+        store.send(.doneTapped)
+        dismiss()
+    }
+
     // MARK: - Dynamic copy helpers
 
     private var subtitleKey: LocalizedStringKey {
-        switch authorizationStatus {
+        switch store.authorizationStatus {
         case .unavailable:   return "appCategoryPicker.subtitle.unavailable"
         case .notDetermined: return "appCategoryPicker.subtitle.notDetermined"
         case .denied:        return "appCategoryPicker.subtitle.denied"
@@ -128,7 +144,7 @@ struct AppCategoryPickerView: View {
     }
 
     private var primaryButtonKey: LocalizedStringKey {
-        switch authorizationStatus {
+        switch store.authorizationStatus {
         case .unavailable:   return "appCategoryPicker.button.pendingApproval"
         case .notDetermined: return "appCategoryPicker.button.enableAccess"
         case .denied:        return "appCategoryPicker.button.openSettings"
@@ -137,7 +153,7 @@ struct AppCategoryPickerView: View {
     }
 
     private var primaryButtonHintKey: LocalizedStringKey {
-        Self.primaryButtonHintKey(for: authorizationStatus)
+        Self.primaryButtonHintKey(for: store.authorizationStatus)
     }
 
     /// Maps `authorizationStatus` to the localized accessibility hint key for the primary CTA.
@@ -158,7 +174,7 @@ struct AppCategoryPickerView: View {
 
     @ViewBuilder
     private var statusCard: some View {
-        switch authorizationStatus {
+        switch store.authorizationStatus {
         case .unavailable:
             AppCategoryUnavailableBanner()
         case .notDetermined:
@@ -166,7 +182,7 @@ struct AppCategoryPickerView: View {
         case .denied:
             AppCategoryDeniedCard()
         case .approved:
-            AppCategoryApprovedCard(metadata: appsState.selectionMetadata)
+            AppCategoryApprovedCard(metadata: store.selection)
         }
     }
 }
@@ -305,18 +321,16 @@ enum AppCategorySelectionSummary {
 
 #Preview("Unavailable") {
     AppCategoryPickerView(
-        appsState: SelectedAppsState(),
-        authorizationStatus: .unavailable,
-        onRequestAuthorization: {},
-        onDone: {}
+        store: Store(
+            initialState: AppCategoryPickerFeature.State(authorizationStatus: .unavailable)
+        ) { AppCategoryPickerFeature() }
     )
 }
 
 #Preview("Not Determined") {
     AppCategoryPickerView(
-        appsState: SelectedAppsState(),
-        authorizationStatus: .notDetermined,
-        onRequestAuthorization: {},
-        onDone: {}
+        store: Store(
+            initialState: AppCategoryPickerFeature.State(authorizationStatus: .notDetermined)
+        ) { AppCategoryPickerFeature() }
     )
 }

--- a/EyePostureReminder/Views/Onboarding/OnboardingView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingView.swift
@@ -3,6 +3,7 @@
 //
 // Main onboarding container — 4-screen TabView with page indicator.
 
+import ComposableArchitecture
 import SwiftUI
 import UIKit
 
@@ -11,7 +12,6 @@ struct OnboardingView: View {
 
     @EnvironmentObject private var coordinator: AppCoordinator
     @EnvironmentObject private var settings: SettingsStore
-    @StateObject private var selectedAppsState = SelectedAppsState()
     @State private var currentPage = 0
     @State private var showAppCategoryPicker = false
 
@@ -68,16 +68,7 @@ struct OnboardingView: View {
             accessibilityNotificationPoster.postScreenChanged()
         }
         .sheet(isPresented: $showAppCategoryPicker) {
-            AppCategoryPickerView(
-                appsState: selectedAppsState,
-                authorizationStatus: coordinator.screenTimeAuthorization.authorizationStatus,
-                onRequestAuthorization: {
-                    Task { _ = await coordinator.screenTimeAuthorization.requestAuthorization() }
-                },
-                onOpenSettings: openApplicationSettings,
-                onSelectApps: {},
-                onDone: { showAppCategoryPicker = false }
-            )
+            OnboardingAppCategoryPickerSheet(onSelectApps: {})
         }
     }
 
@@ -113,6 +104,24 @@ struct OnboardingView: View {
         if let url = URL(string: UIApplication.openSettingsURLString) {
             UIApplication.shared.open(url)
         }
+    }
+}
+
+// MARK: - AppCategoryPicker Sheet Wrapper
+
+/// Owns a local `Store` for `AppCategoryPickerView` while `OnboardingView` is
+/// still presented from the legacy MVVM stack. When Phase 7 of #702 wires
+/// `RootView` as the destination owner, this wrapper is removed and the picker
+/// is presented via `$store.scope(...)`.
+private struct OnboardingAppCategoryPickerSheet: View {
+    let onSelectApps: () -> Void
+
+    @State private var store = Store(
+        initialState: AppCategoryPickerFeature.State()
+    ) { AppCategoryPickerFeature() }
+
+    var body: some View {
+        AppCategoryPickerView(store: store, onSelectApps: onSelectApps)
     }
 }
 

--- a/EyePostureReminder/Views/SettingsView.swift
+++ b/EyePostureReminder/Views/SettingsView.swift
@@ -1,3 +1,4 @@
+import ComposableArchitecture
 import SwiftUI
 import UIKit
 // swiftlint:disable file_length
@@ -721,7 +722,6 @@ private struct SettingsSmartPauseSection: View {
 /// Shows an inline denied-recovery warning (#252) and a status-aware footer (#250).
 private struct SettingsTrueInterruptSection: View {
     @EnvironmentObject private var coordinator: AppCoordinator
-    @StateObject private var selectedAppsState = SelectedAppsState()
     @State private var showPicker = false
 
     private var authStatus: ScreenTimeAuthorizationStatus {
@@ -822,17 +822,26 @@ private struct SettingsTrueInterruptSection: View {
             .foregroundStyle(AppColor.textSecondary)
         }
         .sheet(isPresented: $showPicker) {
-            AppCategoryPickerView(
-                appsState: selectedAppsState,
-                authorizationStatus: authStatus,
-                onRequestAuthorization: {
-                    Task { _ = await coordinator.screenTimeAuthorization.requestAuthorization() }
-                },
-                onOpenSettings: openApplicationSettings,
-                onSelectApps: {},
-                onDone: { showPicker = false }
-            )
+            AppCategoryPickerSheet(onSelectApps: {})
         }
+    }
+}
+
+// MARK: - AppCategoryPicker Sheet Wrapper
+
+/// Owns a local `Store` for `AppCategoryPickerView` while the picker is still
+/// presented from MVVM-era parents (`SettingsView`, `OnboardingView`). When
+/// Phase 7 of #702 wires `RootView` as the destination owner, both call sites
+/// can drop this wrapper and present via `$store.scope`.
+private struct AppCategoryPickerSheet: View {
+    let onSelectApps: () -> Void
+
+    @State private var store = Store(
+        initialState: AppCategoryPickerFeature.State()
+    ) { AppCategoryPickerFeature() }
+
+    var body: some View {
+        AppCategoryPickerView(store: store, onSelectApps: onSelectApps)
     }
 }
 

--- a/Tests/EyePostureReminderTests/Views/TrueInterruptViewCoverageTests.swift
+++ b/Tests/EyePostureReminderTests/Views/TrueInterruptViewCoverageTests.swift
@@ -1,3 +1,5 @@
+import ComposableArchitecture
+import ScreenTimeExtensionShared
 import SwiftUI
 import UIKit
 import XCTest
@@ -15,26 +17,28 @@ final class TrueInterruptViewCoverageTests: XCTestCase {
         XCTAssertNotNil(hostingController.view, file: file, line: line)
     }
 
-    private func makeSelectedAppsState(
-        appCount: Int = 0,
-        categoryCount: Int = 0,
-        file: StaticString = #filePath,
-        line: UInt = #line
-    ) -> SelectedAppsState {
-        let suiteName = "TrueInterruptViewCoverageTests.\(UUID().uuidString)"
-        guard let defaults = UserDefaults(suiteName: suiteName) else {
-            XCTFail("Failed to create isolated defaults", file: file, line: line)
-            return SelectedAppsState()
+    /// Builds a fresh `AppCategoryPickerView` store seeded with the given status and
+    /// optional selection snapshot. Stubs the screen-time client so the view's
+    /// `.onAppear` dispatch (which drains an async authorization probe) doesn't
+    /// race against test teardown or hit the live `FamilyControls` framework.
+    private func makePickerStore(
+        authorizationStatus: ScreenTimeAuthorizationStatus,
+        selection: AppGroupSelectionSnapshot = .empty
+    ) -> StoreOf<AppCategoryPickerFeature> {
+        withDependencies {
+            $0.screenTimeAuthorizationClient = ScreenTimeAuthorizationClient(
+                status: { authorizationStatus },
+                statusChanges: { .finished },
+                requestAuthorization: { authorizationStatus }
+            )
+        } operation: {
+            Store(
+                initialState: AppCategoryPickerFeature.State(
+                    authorizationStatus: authorizationStatus,
+                    selection: selection
+                )
+            ) { AppCategoryPickerFeature() }
         }
-        defaults.removePersistentDomain(forName: suiteName)
-
-        let state = SelectedAppsState(defaults: defaults)
-        state.updateMetadata(SelectedAppsMetadata(
-            categoryCount: categoryCount,
-            appCount: appCount,
-            lastUpdated: Date()
-        ))
-        return state
     }
 
     func test_onboardingInterruptModeView_unavailable_bodyEvaluation() {
@@ -125,149 +129,123 @@ final class TrueInterruptViewCoverageTests: XCTestCase {
     }
 
     func test_appCategoryPickerView_unavailable_bodyEvaluation() {
-        let view = AppCategoryPickerView(
-            appsState: makeSelectedAppsState(),
-            authorizationStatus: .unavailable,
-            onRequestAuthorization: {},
-            onDone: {}
-        )
+        let view = AppCategoryPickerView(store: makePickerStore(authorizationStatus: .unavailable))
         let described = String(describing: view.body)
         XCTAssertFalse(described.isEmpty)
     }
 
     func test_appCategoryPickerView_notDetermined_bodyEvaluation() {
         let view = AppCategoryPickerView(
-            appsState: makeSelectedAppsState(),
-            authorizationStatus: .notDetermined,
-            onRequestAuthorization: {},
-            onDone: {}
+            store: makePickerStore(authorizationStatus: .notDetermined)
         )
         let described = String(describing: view.body)
         XCTAssertFalse(described.isEmpty)
     }
 
     func test_appCategoryPickerView_denied_bodyEvaluation() {
-        let view = AppCategoryPickerView(
-            appsState: makeSelectedAppsState(),
-            authorizationStatus: .denied,
-            onRequestAuthorization: {},
-            onDone: {}
-        )
+        let view = AppCategoryPickerView(store: makePickerStore(authorizationStatus: .denied))
         let described = String(describing: view.body)
         XCTAssertFalse(described.isEmpty)
     }
 
     func test_appCategoryPickerView_approvedEmptySelection_bodyEvaluation() {
-        let view = AppCategoryPickerView(
-            appsState: makeSelectedAppsState(),
-            authorizationStatus: .approved,
-            onRequestAuthorization: {},
-            onDone: {}
-        )
+        let view = AppCategoryPickerView(store: makePickerStore(authorizationStatus: .approved))
         let described = String(describing: view.body)
         XCTAssertFalse(described.isEmpty)
     }
 
     func test_appCategoryPickerView_approvedSelectedApps_bodyEvaluation() {
-        let view = AppCategoryPickerView(
-            appsState: makeSelectedAppsState(appCount: 2, categoryCount: 1),
+        let store = makePickerStore(
             authorizationStatus: .approved,
-            onRequestAuthorization: {},
-            onDone: {}
+            selection: AppGroupSelectionSnapshot(categoryCount: 1, appCount: 2, lastUpdated: Date())
         )
+        let view = AppCategoryPickerView(store: store)
         let described = String(describing: view.body)
         XCTAssertFalse(described.isEmpty)
     }
 
-    func test_appCategoryPickerView_callbacksAreInvocable() {
-        var authorizationRequested = false
-        var doneCalled = false
-        let view = AppCategoryPickerView(
-            appsState: makeSelectedAppsState(),
-            authorizationStatus: .notDetermined,
-            onRequestAuthorization: { authorizationRequested = true },
-            onDone: { doneCalled = true }
-        )
-
-        view.onRequestAuthorization()
-        view.onDone()
-
-        XCTAssertTrue(authorizationRequested)
-        XCTAssertTrue(doneCalled)
-    }
-
-    func test_appCategoryPickerView_deniedPrimaryAction_opensSettingsOnly() {
-        var authorizationRequested = false
-        var settingsOpened = false
-        let view = AppCategoryPickerView(
-            appsState: makeSelectedAppsState(),
-            authorizationStatus: .denied,
-            onRequestAuthorization: { authorizationRequested = true },
-            onOpenSettings: { settingsOpened = true },
-            onDone: {}
-        )
-
-        view.performPrimaryAction()
-
-        XCTAssertFalse(authorizationRequested)
-        XCTAssertTrue(settingsOpened)
-    }
-
-    func test_appCategoryPickerView_notDeterminedPrimaryAction_requestsAuthorizationOnly() {
-        var authorizationRequested = false
-        var settingsOpened = false
-        let view = AppCategoryPickerView(
-            appsState: makeSelectedAppsState(),
-            authorizationStatus: .notDetermined,
-            onRequestAuthorization: { authorizationRequested = true },
-            onOpenSettings: { settingsOpened = true },
-            onDone: {}
-        )
-
-        view.performPrimaryAction()
-
-        XCTAssertTrue(authorizationRequested)
-        XCTAssertFalse(settingsOpened)
-    }
-
-    func test_appCategoryPickerView_approvedPrimaryAction_selectsAppsOnly() {
-        var authorizationRequested = false
-        var settingsOpened = false
+    func test_appCategoryPickerView_onSelectAppsCallback_isInvocable() {
         var selectAppsCalled = false
         let view = AppCategoryPickerView(
-            appsState: makeSelectedAppsState(),
-            authorizationStatus: .approved,
-            onRequestAuthorization: { authorizationRequested = true },
-            onOpenSettings: { settingsOpened = true },
-            onSelectApps: { selectAppsCalled = true },
-            onDone: {}
+            store: makePickerStore(authorizationStatus: .approved),
+            onSelectApps: { selectAppsCalled = true }
         )
 
         view.performPrimaryAction()
 
-        XCTAssertFalse(authorizationRequested)
-        XCTAssertFalse(settingsOpened)
-        XCTAssertTrue(selectAppsCalled)
+        XCTAssertTrue(selectAppsCalled,
+                      "Approved-state primary action must invoke parent-injected onSelectApps")
+    }
+
+    func test_appCategoryPickerView_deniedPrimaryAction_dispatchesOpenSettings() async {
+        let opened = LockIsolated<[URL]>([])
+        let store = withDependencies {
+            $0.screenTimeAuthorizationClient = ScreenTimeAuthorizationClient(
+                status: { .denied },
+                statusChanges: { .finished },
+                requestAuthorization: { .denied }
+            )
+            $0.openURL = OpenURLEffect { url in
+                opened.withValue { $0.append(url) }
+                return true
+            }
+        } operation: {
+            Store(initialState: AppCategoryPickerFeature.State(authorizationStatus: .denied)) {
+                AppCategoryPickerFeature()
+            }
+        }
+        let view = AppCategoryPickerView(store: store)
+
+        view.performPrimaryAction()
+        // Allow the .openSettingsTapped effect to drain.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        opened.withValue { urls in
+            XCTAssertEqual(urls.count, 1,
+                           "Denied-state primary action must route exactly one URL via openURL")
+        }
+    }
+
+    func test_appCategoryPickerView_notDeterminedPrimaryAction_routesAuthorizationRequest() async {
+        let requestCount = LockIsolated(0)
+        let store = withDependencies {
+            $0.screenTimeAuthorizationClient = ScreenTimeAuthorizationClient(
+                status: { .notDetermined },
+                statusChanges: { .finished },
+                requestAuthorization: {
+                    requestCount.withValue { $0 += 1 }
+                    return .approved
+                }
+            )
+        } operation: {
+            Store(
+                initialState: AppCategoryPickerFeature.State(authorizationStatus: .notDetermined)
+            ) { AppCategoryPickerFeature() }
+        }
+        let view = AppCategoryPickerView(store: store)
+
+        view.performPrimaryAction()
+        // Allow the .requestAuthorizationTapped effect to drain.
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(requestCount.value, 1,
+                       "Not-determined primary action must hit the authorization client exactly once")
     }
 
     func test_appCategoryPickerView_unavailablePrimaryAction_isNoOp() {
-        var authorizationRequested = false
-        var settingsOpened = false
         var selectAppsCalled = false
+        let store = makePickerStore(authorizationStatus: .unavailable)
         let view = AppCategoryPickerView(
-            appsState: makeSelectedAppsState(),
-            authorizationStatus: .unavailable,
-            onRequestAuthorization: { authorizationRequested = true },
-            onOpenSettings: { settingsOpened = true },
-            onSelectApps: { selectAppsCalled = true },
-            onDone: {}
+            store: store,
+            onSelectApps: { selectAppsCalled = true }
         )
 
         view.performPrimaryAction()
 
-        XCTAssertFalse(authorizationRequested)
-        XCTAssertFalse(settingsOpened)
-        XCTAssertFalse(selectAppsCalled)
+        XCTAssertFalse(selectAppsCalled,
+                       "Unavailable primary action must not invoke onSelectApps")
+        XCTAssertEqual(store.authorizationStatus, .unavailable,
+                       "Unavailable primary action must not mutate authorization status")
     }
 
     // MARK: - Accessibility Hint Body Tests
@@ -303,12 +281,7 @@ final class TrueInterruptViewCoverageTests: XCTestCase {
     func test_appCategoryPickerView_allStatuses_bodyContainsDoneButtonHint() {
         let expectedDoneHintKey: LocalizedStringKey = "appCategoryPicker.doneButton.hint"
         for status in ScreenTimeAuthorizationStatus.allCases {
-            let view = AppCategoryPickerView(
-                appsState: makeSelectedAppsState(),
-                authorizationStatus: status,
-                onRequestAuthorization: {},
-                onDone: {}
-            )
+            let view = AppCategoryPickerView(store: makePickerStore(authorizationStatus: status))
             let described = String(describing: view.body)
             XCTAssertFalse(
                 described.isEmpty,
@@ -319,12 +292,14 @@ final class TrueInterruptViewCoverageTests: XCTestCase {
 
     func test_appCategoryPickerView_allStatuses_render() {
         for status in ScreenTimeAuthorizationStatus.allCases {
-            render(AppCategoryPickerView(
-                appsState: makeSelectedAppsState(appCount: 1, categoryCount: 1),
+            render(AppCategoryPickerView(store: makePickerStore(
                 authorizationStatus: status,
-                onRequestAuthorization: {},
-                onDone: {}
-            ))
+                selection: AppGroupSelectionSnapshot(
+                    categoryCount: 1,
+                    appCount: 1,
+                    lastUpdated: Date()
+                )
+            )))
         }
     }
 


### PR DESCRIPTION
## Summary

Phase 6 of #702 (`p0-tca-14c`): wire `AppCategoryPickerView` to its TCA Phase-1 reducer (`AppCategoryPickerFeature`), eroding the legacy MVVM view boundary while keeping the picker's runtime UX byte-equivalent for the entitlement-pending / not-determined / denied / approved-empty states.

## What this PR does

### View
- `AppCategoryPickerView` now takes `store: StoreOf<AppCategoryPickerFeature>` (`@Perception.Bindable`); drops `appsState`, `authorizationStatus`, `onRequestAuthorization`, `onOpenSettings`, `onDone` parameters.
- Body wrapped in `WithPerceptionTracking { … }` per existing TCA-bound views (`RootView`, `ContentView`).
- Done dispatches `store.send(.doneTapped)` and dismisses via `@Environment(\.dismiss)` — env-driven dismiss is **transitional** until Phase 7 of #702 wires `RootView` as the destination owner and the parent reducer clears `state.destination` on `.doneTapped`.
- `.onAppear { store.send(.onAppear) }` so the screen-time auth client refreshes status reactively.
- Kept `onSelectApps` as an injected closure: `FamilyActivityPicker` invocation isn't modeled in the Phase-1 reducer (do_not_touch list forbids extending it; #678 will fold it in alongside the IPC-client surface extension).

### Call sites (transitional wrappers)
- `SettingsTrueInterruptSection` and `OnboardingView` each present the picker via a tiny private `AppCategoryPickerSheet` / `OnboardingAppCategoryPickerSheet` that owns a local `Store(initialState: .init()) { AppCategoryPickerFeature() }`. Both wrappers vanish in Phase 7 once `RootView` owns destination scoping.
- Removed the now-unused `@StateObject private var selectedAppsState = SelectedAppsState()` from both call sites.

### Tests
- `TrueInterruptViewCoverageTests` rewritten to construct the view with a real `Store` (seeded via `withDependencies`-stubbed `ScreenTimeAuthorizationClient` so `.onAppear`'s auth probe doesn't race teardown).
- Behavioural assertions for `.denied` / `.notDetermined` now verify the dependency clients via `LockIsolated` recorders rather than closure flags.
- `.approved` still drives `onSelectApps` callback.
- Net delta: **2175 → 2174 (−1)**. Removed the now-redundant `onDone` / `onRequestAuthorization` closure-invocation tests; the `doneTapped` / `requestAuthorizationTapped` reducer paths are exhaustively covered by `AppCategoryPickerFeatureTests`.

## Known regression (intentional, deferred to #678)
The Phase-1 reducer's `.onAppear` sets `state.selection = .empty` pending #678 (IPC client surface extension):
```swift
case .onAppear:
    state.isLoadingSelection = true
    // Selection persistence to App Group is owned by p0-tca-15 (#678) —
    // IPCClient surface is intentionally not extended here.
    state.selection = .empty
    …
```
The approved-state `ApprovedCard` therefore shows the empty placeholder summary even when the user previously configured apps, until #678 lands. This matches the reducer's **documented intent** and recovers as soon as #678 ships.

## Scope discipline
- ❌ **No** Phase-1 reducer file modified (do_not_touch).
- ❌ `SelectedAppsState`'s `@Published` / `: ObservableObject` conformance **NOT** stripped — that's Phase 1 of #702, gated on Phase 4 / 5 / 7 view migrations completing first.
- ❌ `SettingsView.swift` / `OnboardingView.swift` bodies **NOT** migrated to TCA stores — only their picker-presentation slot is.
- ✅ Build green: `./scripts/build.sh all` — 2174 tests, lint + build + test.

## Refs
- Refs #702 (Phase 6 only — Phases 1, 2, 3, 4, 5, 7, 8 still outstanding)
- Companion: #678 will restore the approved-state selection summary
- Parent epic: #662