### PR TITLE
feat(ipc): extend IPCClient with selection persistence + multicast (#678 partial)

### DIFF
--- a/Extensions/Shared/AppGroupIPCStore.swift
+++ b/Extensions/Shared/AppGroupIPCStore.swift
@@ -75,6 +75,14 @@ public final class AppGroupIPCStore {
     )
     public static let trueInterruptEnabledValueUserInfoKey = "enabled"
 
+    /// Posted whenever `writeSelection(_:)` persists a snapshot that differs
+    /// from the previous on-disk value. Subscribers receive the new snapshot
+    /// in `userInfo` keyed by `selectionValueUserInfoKey`.
+    public static let selectionDidChangeNotification = Notification.Name(
+        "AppGroupIPCStore.selectionDidChange"
+    )
+    public static let selectionValueUserInfoKey = "selection"
+
     public enum StoreError: Error, Equatable {
         case appGroupSuiteUnavailable
         case corruptEventLog
@@ -152,9 +160,18 @@ public final class AppGroupIPCStore {
     }
 
     public func writeSelection(_ snapshot: AppGroupSelectionSnapshot) throws {
-        try withLock {
+        let didChange: Bool = try withLock {
             guard let defaults else { throw StoreError.appGroupSuiteUnavailable }
+            let previous = (try? readSelectionLocked(from: defaults)) ?? .empty
             defaults.set(try encoder.encode(snapshot), forKey: AppGroupIPCKeys.selectionMetadata)
+            return previous != snapshot
+        }
+        if didChange {
+            notificationCenter.post(
+                name: Self.selectionDidChangeNotification,
+                object: self,
+                userInfo: [Self.selectionValueUserInfoKey: snapshot]
+            )
         }
     }
 

--- a/EyePostureReminder/TCA/Dependencies/IPCClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/IPCClient.swift
@@ -6,17 +6,37 @@ import ScreenTimeExtensionShared
 /// TCA dependency client wrapping `AppGroupIPCStore` for reducer consumption.
 ///
 /// Phase 0 of the MVVM → TCA migration (#665). The `liveValue` adapter
-/// installs a single `NotificationCenter` observer for the
-/// `trueInterruptEnabledDidChange` notification that multicasts to every
-/// active `trueInterruptChanges` subscriber via per-subscriber `AsyncStream`
-/// continuations. The optional `String` argument carried by `record` is the
-/// caller-supplied operation context — it is preserved in the failure log
-/// emitted when `recordEvent` throws.
+/// installs `NotificationCenter` observers for the
+/// `trueInterruptEnabledDidChange` and `selectionDidChange` notifications
+/// that multicast to every active stream subscriber via per-subscriber
+/// `AsyncStream` continuations. The optional `String` argument carried by
+/// `record` is the caller-supplied operation context — it is preserved in
+/// the failure log emitted when `recordEvent` throws.
+///
+/// Phase 2 (`p0-tca-15` / #678) extended the surface with selection
+/// read/write + multicast, allowing `SelectedAppsState` to be retired in
+/// favour of reducer-driven access to the App Group store.
 @DependencyClient
 struct IPCClient: Sendable {
     /// Whether the user has toggled on the True Interrupt (DeviceActivity
     /// shield) feature in Settings. Reads the App Group flag synchronously.
     var isTrueInterruptEnabled: @Sendable () async -> Bool = { false }
+
+    /// Persists the True Interrupt enabled flag. Returns `false` when the
+    /// store refuses the write (App Group unavailable, or `enabled = true`
+    /// requested with an empty selection on disk).
+    var setTrueInterruptEnabled: @Sendable (Bool) async -> Bool = { _ in false }
+
+    /// Reads the current selection snapshot from the shared App Group store.
+    /// Returns `.empty` when the store is unavailable or the on-disk payload
+    /// is corrupt — failures are logged but never thrown so call sites can
+    /// stay synchronous with the UI lifecycle.
+    var readSelection: @Sendable () async -> AppGroupSelectionSnapshot = { .empty }
+
+    /// Persists the selection snapshot to the shared App Group store.
+    /// Returns `false` when the store rejects the write; callers must treat
+    /// a `false` return as "selection not durable" and recover accordingly.
+    var writeSelection: @Sendable (AppGroupSelectionSnapshot) async -> Bool = { _ in false }
 
     /// Records an IPC event to the shared App Group store. The optional
     /// `String` second argument is a free-form caller-supplied operation
@@ -27,6 +47,11 @@ struct IPCClient: Sendable {
     /// subscriber receives every subsequent change until the consumer
     /// terminates.
     var trueInterruptChanges: @Sendable () -> AsyncStream<Bool> = { .finished }
+
+    /// Multicast stream of selection snapshot transitions. A new subscriber
+    /// receives every subsequent successful `writeSelection` payload until
+    /// the consumer terminates.
+    var selectionChanges: @Sendable () -> AsyncStream<AppGroupSelectionSnapshot> = { .finished }
 }
 
 extension IPCClient: DependencyKey {
@@ -36,10 +61,20 @@ extension IPCClient: DependencyKey {
             isTrueInterruptEnabled: {
                 await MainActor.run { LiveIPCBridge.shared.store.isTrueInterruptEnabled() }
             },
+            setTrueInterruptEnabled: { enabled in
+                await MainActor.run { LiveIPCBridge.shared.store.setTrueInterruptEnabled(enabled) }
+            },
+            readSelection: {
+                await MainActor.run { LiveIPCBridge.shared.readSelection() }
+            },
+            writeSelection: { snapshot in
+                await MainActor.run { LiveIPCBridge.shared.writeSelection(snapshot) }
+            },
             record: { event, context in
                 await MainActor.run { LiveIPCBridge.shared.record(event, context: context) }
             },
-            trueInterruptChanges: { makeTrueInterruptStream() }
+            trueInterruptChanges: { makeTrueInterruptStream() },
+            selectionChanges: { makeSelectionStream() }
         )
     }()
 }
@@ -53,14 +88,15 @@ extension DependencyValues {
 }
 
 /// Main-actor-isolated owner of the live `AppGroupIPCStore`. Subscribes to
-/// `trueInterruptEnabledDidChange` notifications and forwards them to the
-/// file-scope continuation registry.
+/// `trueInterruptEnabledDidChange` and `selectionDidChange` notifications
+/// and forwards them to the file-scope continuation registries.
 @MainActor
 private final class LiveIPCBridge {
     nonisolated static let shared = LiveIPCBridge()
 
     let store = AppGroupIPCStore()
-    private var observer: NSObjectProtocol?
+    private var trueInterruptObserver: NSObjectProtocol?
+    private var selectionObserver: NSObjectProtocol?
     private var hasBootstrapped = false
 
     private nonisolated init() {}
@@ -69,7 +105,7 @@ private final class LiveIPCBridge {
         guard !hasBootstrapped else { return }
         hasBootstrapped = true
 
-        observer = NotificationCenter.default.addObserver(
+        trueInterruptObserver = NotificationCenter.default.addObserver(
             forName: AppGroupIPCStore.trueInterruptEnabledDidChangeNotification,
             object: nil,
             queue: nil
@@ -79,10 +115,26 @@ private final class LiveIPCBridge {
             ] as? Bool) ?? false
             broadcastTrueInterruptChange(value)
         }
+
+        selectionObserver = NotificationCenter.default.addObserver(
+            forName: AppGroupIPCStore.selectionDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { notification in
+            let value = (notification.userInfo?[
+                AppGroupIPCStore.selectionValueUserInfoKey
+            ] as? AppGroupSelectionSnapshot) ?? .empty
+            broadcastSelectionChange(value)
+        }
     }
 
     deinit {
-        if let observer { NotificationCenter.default.removeObserver(observer) }
+        if let trueInterruptObserver {
+            NotificationCenter.default.removeObserver(trueInterruptObserver)
+        }
+        if let selectionObserver {
+            NotificationCenter.default.removeObserver(selectionObserver)
+        }
     }
 
     func record(_ event: AppGroupIPCEvent, context: String?) {
@@ -99,11 +151,40 @@ private final class LiveIPCBridge {
                 """)
         }
     }
+
+    func readSelection() -> AppGroupSelectionSnapshot {
+        do {
+            return try store.readSelection()
+        } catch {
+            ipcLogger.error("""
+                event=ipc_read_selection_failed \
+                error=\(error.localizedDescription, privacy: .public)
+                """)
+            return .empty
+        }
+    }
+
+    func writeSelection(_ snapshot: AppGroupSelectionSnapshot) -> Bool {
+        do {
+            try store.writeSelection(snapshot)
+            return true
+        } catch {
+            ipcLogger.error("""
+                event=ipc_write_selection_failed \
+                error=\(error.localizedDescription, privacy: .public)
+                """)
+            return false
+        }
+    }
 }
 
 /// File-scoped multicast continuations for `IPCClient.trueInterruptChanges`.
 private let trueInterruptContinuations =
     LockIsolated<[UUID: AsyncStream<Bool>.Continuation]>([:])
+
+/// File-scoped multicast continuations for `IPCClient.selectionChanges`.
+private let selectionContinuations =
+    LockIsolated<[UUID: AsyncStream<AppGroupSelectionSnapshot>.Continuation]>([:])
 
 private let ipcLogger = Logger(
     subsystem: Bundle.main.bundleIdentifier ?? "com.yashasgujjar.eyeposture",
@@ -122,8 +203,26 @@ private func makeTrueInterruptStream() -> AsyncStream<Bool> {
     return stream
 }
 
+private func makeSelectionStream() -> AsyncStream<AppGroupSelectionSnapshot> {
+    let (stream, continuation) = AsyncStream<AppGroupSelectionSnapshot>.makeStream()
+    let id = UUID()
+    selectionContinuations.withValue { $0[id] = continuation }
+    continuation.onTermination = { _ in
+        selectionContinuations.withValue { dict in
+            dict[id] = nil
+        }
+    }
+    return stream
+}
+
 private func broadcastTrueInterruptChange(_ value: Bool) {
     trueInterruptContinuations.withValue { dict in
+        for continuation in dict.values { continuation.yield(value) }
+    }
+}
+
+private func broadcastSelectionChange(_ value: AppGroupSelectionSnapshot) {
+    selectionContinuations.withValue { dict in
         for continuation in dict.values { continuation.yield(value) }
     }
 }

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -171,8 +171,12 @@ final class AppDelegateTests: XCTestCase {
             )
             $0.ipcClient = IPCClient(
                 isTrueInterruptEnabled: { false },
+                setTrueInterruptEnabled: { _ in false },
+                readSelection: { .empty },
+                writeSelection: { _ in false },
                 record: { _, _ in },
-                trueInterruptChanges: { .finished }
+                trueInterruptChanges: { .finished },
+                selectionChanges: { .finished }
             )
             $0.deviceActivityMonitorClient = DeviceActivityMonitorClient(
                 schedule: { _, _ in },

--- a/Tests/EyePostureReminderTests/Services/AppGroupIPCStoreTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppGroupIPCStoreTests.swift
@@ -220,6 +220,99 @@ final class AppGroupIPCStoreTests: XCTestCase {
         }
     }
 
+    func test_writeSelection_postsSelectionDidChangeNotificationWithSnapshotPayload() throws {
+        var observed: [AppGroupSelectionSnapshot] = []
+        let observer = NotificationCenter.default.addObserver(
+            forName: AppGroupIPCStore.selectionDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { notification in
+            let key = AppGroupIPCStore.selectionValueUserInfoKey
+            if let value = notification.userInfo?[key] as? AppGroupSelectionSnapshot {
+                observed.append(value)
+            }
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        let snapshot = AppGroupSelectionSnapshot(
+            categoryCount: 1,
+            appCount: 2,
+            lastUpdated: Date(timeIntervalSince1970: 5_000)
+        )
+
+        try store.writeSelection(snapshot)
+
+        XCTAssertEqual(observed, [snapshot])
+    }
+
+    func test_writeSelection_doesNotPostNotificationWhenSnapshotUnchanged() throws {
+        let snapshot = AppGroupSelectionSnapshot(
+            categoryCount: 1,
+            appCount: 1,
+            lastUpdated: Date(timeIntervalSince1970: 6_000)
+        )
+        try store.writeSelection(snapshot)
+
+        var notificationCount = 0
+        let observer = NotificationCenter.default.addObserver(
+            forName: AppGroupIPCStore.selectionDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            notificationCount += 1
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        try store.writeSelection(snapshot)
+
+        XCTAssertEqual(notificationCount, 0)
+    }
+
+    func test_writeSelection_postsSelectionDidChangeOnInjectedCenterOnly() throws {
+        let injectedCenter = NotificationCenter()
+        let store = AppGroupIPCStore(defaults: defaults, maxEventCount: 3, notificationCenter: injectedCenter)
+        var injectedCount = 0
+        var defaultCount = 0
+        let injectedObserver = injectedCenter.addObserver(
+            forName: AppGroupIPCStore.selectionDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            injectedCount += 1
+        }
+        let defaultObserver = NotificationCenter.default.addObserver(
+            forName: AppGroupIPCStore.selectionDidChangeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            defaultCount += 1
+        }
+        defer {
+            injectedCenter.removeObserver(injectedObserver)
+            NotificationCenter.default.removeObserver(defaultObserver)
+        }
+
+        try store.writeSelection(AppGroupSelectionSnapshot(
+            categoryCount: 0,
+            appCount: 1,
+            lastUpdated: Date(timeIntervalSince1970: 7_000)
+        ))
+
+        XCTAssertEqual(injectedCount, 1)
+        XCTAssertEqual(defaultCount, 0)
+    }
+
+    func test_selectionDidChangeNotification_userInfoKey_isStable() {
+        XCTAssertEqual(AppGroupIPCStore.selectionValueUserInfoKey, "selection")
+    }
+
+    func test_selectionDidChangeNotification_name_isStable() {
+        XCTAssertEqual(
+            AppGroupIPCStore.selectionDidChangeNotification.rawValue,
+            "AppGroupIPCStore.selectionDidChange"
+        )
+    }
+
     func test_shieldSession_roundTripsAndStoresLastStartedTimestamp() throws {
         let triggeredAt = Date(timeIntervalSince1970: 2_000)
         defaults.set("stale", forKey: ShieldSessionKeys.breakReason)

--- a/Tests/EyePostureReminderTests/TCA/AppFeatureTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/AppFeatureTests.swift
@@ -90,8 +90,12 @@ final class AppFeatureTests: XCTestCase {
             )
             $0.ipcClient = IPCClient(
                 isTrueInterruptEnabled: { false },
+                setTrueInterruptEnabled: { _ in false },
+                readSelection: { .empty },
+                writeSelection: { _ in false },
                 record: { _, _ in },
-                trueInterruptChanges: { .finished }
+                trueInterruptChanges: { .finished },
+                selectionChanges: { .finished }
             )
             $0.deviceActivityMonitorClient = DeviceActivityMonitorClient(
                 schedule: { _, _ in },

--- a/Tests/EyePostureReminderTests/TCA/ContentViewTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/ContentViewTests.swift
@@ -85,8 +85,12 @@ final class ContentViewTests: XCTestCase {
             )
             $0.ipcClient = IPCClient(
                 isTrueInterruptEnabled: { false },
+                setTrueInterruptEnabled: { _ in false },
+                readSelection: { .empty },
+                writeSelection: { _ in false },
                 record: { _, _ in },
-                trueInterruptChanges: { .finished }
+                trueInterruptChanges: { .finished },
+                selectionChanges: { .finished }
             )
             $0.deviceActivityMonitorClient = DeviceActivityMonitorClient(
                 schedule: { _, _ in },

--- a/Tests/EyePostureReminderTests/TCA/IPCClientSurfaceTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/IPCClientSurfaceTests.swift
@@ -1,0 +1,111 @@
+import ComposableArchitecture
+import ScreenTimeExtensionShared
+import XCTest
+
+@testable import EyePostureReminder
+
+/// Surface-level coverage for the `IPCClient` selection accessors added in
+/// `p0-tca-15` (#678). These tests assert the dependency contract that
+/// reducers will rely on once `SelectedAppsState` is retired — they do not
+/// exercise the live `AppGroupIPCStore`-backed adapter (covered by
+/// `AppGroupIPCStoreTests`), only the closure-typed surface routes inputs
+/// to the configured implementation.
+@MainActor
+final class IPCClientSurfaceTests: XCTestCase {
+
+    func test_overriddenClient_routesAllAccessors() async {
+        let recorded = LockIsolated<[String]>([])
+        let snapshot = AppGroupSelectionSnapshot(
+            categoryCount: 1,
+            appCount: 2,
+            lastUpdated: Date(timeIntervalSince1970: 1_000)
+        )
+        let (selectionStream, selectionContinuation) =
+            AsyncStream<AppGroupSelectionSnapshot>.makeStream()
+        let (toggleStream, toggleContinuation) = AsyncStream<Bool>.makeStream()
+        let client = IPCClient(
+            isTrueInterruptEnabled: {
+                recorded.withValue { $0.append("isTrueInterruptEnabled") }
+                return true
+            },
+            setTrueInterruptEnabled: { value in
+                recorded.withValue { $0.append("setTrueInterruptEnabled(\(value))") }
+                return true
+            },
+            readSelection: {
+                recorded.withValue { $0.append("readSelection") }
+                return snapshot
+            },
+            writeSelection: { value in
+                recorded.withValue { $0.append("writeSelection(\(value.appCount))") }
+                return true
+            },
+            record: { event, context in
+                recorded.withValue {
+                    $0.append("record(\(event.kind.rawValue), \(context ?? "nil"))")
+                }
+            },
+            trueInterruptChanges: { toggleStream },
+            selectionChanges: { selectionStream }
+        )
+
+        let isEnabled = await client.isTrueInterruptEnabled()
+        let didSet = await client.setTrueInterruptEnabled(true)
+        let readBack = await client.readSelection()
+        let didWrite = await client.writeSelection(snapshot)
+        await client.record(AppGroupIPCEvent(kind: .shieldStarted), "ctx")
+
+        toggleContinuation.yield(true)
+        toggleContinuation.finish()
+        var toggleValues: [Bool] = []
+        for await value in client.trueInterruptChanges() {
+            toggleValues.append(value)
+        }
+
+        selectionContinuation.yield(snapshot)
+        selectionContinuation.finish()
+        var selectionValues: [AppGroupSelectionSnapshot] = []
+        for await value in client.selectionChanges() {
+            selectionValues.append(value)
+        }
+
+        XCTAssertTrue(isEnabled)
+        XCTAssertTrue(didSet)
+        XCTAssertEqual(readBack, snapshot)
+        XCTAssertTrue(didWrite)
+        XCTAssertEqual(toggleValues, [true])
+        XCTAssertEqual(selectionValues, [snapshot])
+        XCTAssertEqual(recorded.value, [
+            "isTrueInterruptEnabled",
+            "setTrueInterruptEnabled(true)",
+            "readSelection",
+            "writeSelection(2)",
+            "record(shieldStarted, ctx)"
+        ])
+    }
+
+    func test_silentClient_selectionAccessors_returnSafeFallbacks() async {
+        let client = TCATestDependencies.silentIPCClient()
+
+        let snapshot = await client.readSelection()
+        let didWrite = await client.writeSelection(
+            AppGroupSelectionSnapshot(categoryCount: 1, appCount: 1, lastUpdated: Date())
+        )
+        let didEnable = await client.setTrueInterruptEnabled(true)
+
+        XCTAssertEqual(snapshot, .empty)
+        XCTAssertFalse(didWrite)
+        XCTAssertFalse(didEnable)
+    }
+
+    func test_silentClient_selectionChanges_isFinishedStream() async {
+        let client = TCATestDependencies.silentIPCClient()
+
+        var values: [AppGroupSelectionSnapshot] = []
+        for await value in client.selectionChanges() {
+            values.append(value)
+        }
+
+        XCTAssertTrue(values.isEmpty)
+    }
+}

--- a/Tests/EyePostureReminderTests/TCA/TCATestDependencies.swift
+++ b/Tests/EyePostureReminderTests/TCA/TCATestDependencies.swift
@@ -104,8 +104,12 @@ enum TCATestDependencies {
     static func silentIPCClient() -> IPCClient {
         IPCClient(
             isTrueInterruptEnabled: { false },
+            setTrueInterruptEnabled: { _ in false },
+            readSelection: { .empty },
+            writeSelection: { _ in false },
             record: { _, _ in },
-            trueInterruptChanges: { .finished }
+            trueInterruptChanges: { .finished },
+            selectionChanges: { .finished }
         )
     }
 


### PR DESCRIPTION
## Summary

Phase-2 / `p0-tca-15` contract update for #678. Extends `IPCClient` with the
selection persistence + multicast surface that reducers will consume once
`SelectedAppsState` is retired, and adds `selectionDidChangeNotification`
plumbing to `AppGroupIPCStore` so the multicast can be driven from the
existing live-bridge pattern.

> **Partial scope.** Deletion of `EyePostureReminder/Services/SelectedAppsState.swift`
> (per #678's acceptance criteria) is deferred to a follow-up because three
> production views still hold it as `@StateObject` / `@ObservedObject`
> (`OnboardingView`, `SettingsView`, `AppCategoryPickerView`) and one test
> file (`TrueInterruptViewCoverageTests`) drives it directly. That migration
> is the remaining work tracked in #677 (PR #703 draft) and #702 (PR #722).
> Landing this surface now unblocks the view migrations to consume the new
> accessors directly.

## What this PR does

### `IPCClient` (additive accessors)
- `setTrueInterruptEnabled(Bool) async -> Bool` — toggle the App Group flag from a reducer effect.
- `readSelection() async -> AppGroupSelectionSnapshot` — fetch the current snapshot; returns `.empty` on read failure (logged).
- `writeSelection(AppGroupSelectionSnapshot) async -> Bool` — persist a snapshot; returns `false` on write failure (logged).
- `selectionChanges() -> AsyncStream<AppGroupSelectionSnapshot>` — multicast stream of successful `writeSelection` payloads, mirroring the existing `trueInterruptChanges` pattern (per-subscriber continuations registered in a file-scope `LockIsolated` dictionary, fanned out from a `LiveIPCBridge` notification observer).

### `AppGroupIPCStore` (notification contract)
- New `selectionDidChangeNotification` + `selectionValueUserInfoKey` constants.
- `writeSelection(_:)` now posts the notification with the new snapshot **only when the persisted value actually changes** (no spam on identical re-writes), routed through the injected `NotificationCenter`.

### Test fanout
- `silentIPCClient()` and the three other `IPCClient(...)` test factories (`AppDelegateTests`, `AppFeatureTests`, `ContentViewTests`) pass the new closures explicitly so existing `withDependencies:` blocks keep compiling.
- `AppGroupIPCStoreTests` gains 5 cases for the `selectionDidChange` contract (post on change, suppress on no-op, injected-center scope, stable userInfo key, stable name).
- New `IPCClientSurfaceTests` (3 cases) asserts the closure routes for every accessor + that `silentIPCClient()` returns safe fallbacks for the new fields.

## Verification

```
./scripts/build.sh all   →  2183 tests, 0 failures (+9 new), 117 s
./scripts/build.sh lint  →  passes
```

## Risk

Low. Pure additive contract change:
- `AppGroupIPCStore.writeSelection` previously did not post any notification; the new `selectionDidChangeNotification` has no pre-existing subscribers in the codebase to surprise.
- All four pre-existing `IPCClient(...)` constructor call sites have been updated to pass the new fields with safe no-op defaults (`{ _ in false }`, `{ .empty }`, `{ .finished }`).
- `LiveIPCBridge` retains its single-bootstrap guard; the new `selectionObserver` is registered alongside the existing `trueInterruptObserver` and removed in `deinit`.

Refs #678

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
