### PR TITLE
test(tca): SchedulingFeature TestStore parity for AppCoordinator (#680)

### DIFF
--- a/Tests/EyePostureReminderTests/TCA/SchedulingFeature_ForegroundTransitionTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/SchedulingFeature_ForegroundTransitionTests.swift
@@ -1,0 +1,205 @@
+import ComposableArchitecture
+import UserNotifications
+import XCTest
+
+@testable import EyePostureReminder
+
+/// `TestStore` parity coverage for `SchedulingFeature.foregroundTransition`
+/// — Phase 3 issue `p0-tca-17` (#680). Mirrors the foreground branches of
+/// the legacy `AppCoordinatorTests`.
+@MainActor
+final class SchedulingForegroundTransitionTests: XCTestCase {
+
+    // MARK: - No snooze, unchanged auth status
+
+    /// `.foregroundTransition` with no snooze and unchanged auth status must
+    /// only refresh the cached auth status — no reschedule should fire.
+    func test_foregroundTransition_noSnooze_sameAuthStatus_refreshesAuthOnly() async {
+        var initial = SchedulingFeature.State()
+        initial.notificationAuthStatus = .denied
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.notificationClient = TCATestDependencies.silentNotificationClient(
+                authorizationStatus: .denied
+            )
+        }
+
+        await store.send(.foregroundTransition)
+        await store.receive(.internalAction(.authStatusRefreshed(.denied)))
+        await store.finish()
+    }
+
+    // MARK: - No snooze, auth status changed
+
+    /// When the cached auth status differs from the live one, the reducer
+    /// must re-run `.scheduleReminders` so newly-granted authorisation gets
+    /// picked up immediately, mirroring `handleForegroundTransition`
+    /// lines 587-606.
+    func test_foregroundTransition_noSnooze_authChanged_runsScheduleReminders() async {
+        var initial = SchedulingFeature.State()
+        initial.notificationAuthStatus = .notDetermined
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.notificationClient = TCATestDependencies.silentNotificationClient(
+                authorizationStatus: .authorized
+            )
+        }
+
+        await store.send(.foregroundTransition)
+        await store.receive(.internalAction(.authStatusRefreshed(.authorized))) {
+            $0.notificationAuthStatus = .authorized
+        }
+        await store.receive(\.scheduleReminders)
+        await store.receive(.internalAction(.authStatusRefreshed(.authorized)))
+        await store.receive(.internalAction(.cancelSnoozeWake))
+        await store.finish()
+    }
+
+    // MARK: - Future snooze, authorized
+
+    /// Future snooze + authorized notifications: reducer arms the wake task
+    /// and posts the silent snooze-wake notification, but never re-runs
+    /// `.scheduleReminders`. Direct port of `handleForegroundTransition`
+    /// lines 588-595.
+    func test_foregroundTransition_futureSnooze_authorized_armsWakeAndPostsSilentNotification() async {
+        // Snooze branch in `foregroundTransitionEffect` compares `until <=
+        // Date()` (system wall-clock), so use `Date.distantFuture` to keep
+        // the test reproducible.
+        let wake = Date.distantFuture
+        let scheduledNotifications = LockIsolated<[String]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.snoozedUntil = wake
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            // `.scheduleSnoozeWake` arms a clock.sleep effect that needs both
+            // a date dep and a `ContinuousClock`; without these it trips the
+            // unimplemented defaults when `.stop` cancels the wake task.
+            $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+            $0.continuousClock = TestClock()
+            $0.notificationClient = NotificationClient(
+                requestAuthorization: { _ in false },
+                authorizationStatus: { .authorized },
+                add: { request in
+                    scheduledNotifications.withValue { $0.append(request.identifier) }
+                },
+                removePending: { _ in },
+                removeAllPending: {},
+                pendingRequests: { [] },
+                deliveredNotifications: { [] }
+            )
+        }
+
+        await store.send(.foregroundTransition)
+        await store.receive(.internalAction(.authStatusRefreshed(.authorized))) {
+            $0.notificationAuthStatus = .authorized
+        }
+        await store.receive(.internalAction(.scheduleSnoozeWake(wake)))
+
+        await store.send(.stop)
+
+        XCTAssertEqual(scheduledNotifications.value,
+                       [SchedulingFeature.snoozeWakeCategory])
+    }
+
+    // MARK: - Future snooze, unauthorized
+
+    /// Future snooze + denied notifications: reducer arms the wake task but
+    /// must NOT post the silent notification (UNUserNotificationCenter would
+    /// silently drop it anyway).
+    func test_foregroundTransition_futureSnooze_unauthorized_skipsSilentNotification() async {
+        let snoozedUntil = Date.distantFuture
+        let scheduledNotifications = LockIsolated<[String]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.snoozedUntil = snoozedUntil
+        initial.notificationAuthStatus = .denied
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+            $0.continuousClock = TestClock()
+            $0.notificationClient = NotificationClient(
+                requestAuthorization: { _ in false },
+                authorizationStatus: { .denied },
+                add: { request in
+                    scheduledNotifications.withValue { $0.append(request.identifier) }
+                },
+                removePending: { _ in },
+                removeAllPending: {},
+                pendingRequests: { [] },
+                deliveredNotifications: { [] }
+            )
+        }
+
+        await store.send(.foregroundTransition)
+        await store.receive(.internalAction(.authStatusRefreshed(.denied)))
+        await store.receive(.internalAction(.scheduleSnoozeWake(snoozedUntil)))
+
+        await store.send(.stop)
+
+        XCTAssertTrue(scheduledNotifications.value.isEmpty)
+    }
+
+    // MARK: - Expired snooze on foreground
+
+    /// Returning to foreground after a snooze expired must clear state and
+    /// re-run scheduling — `handleForegroundTransition` lines 596-605.
+    func test_foregroundTransition_expiredSnooze_clearsAndReschedules() async {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let setUntilCalls = LockIsolated<[Date?]>([])
+        let setCountCalls = LockIsolated<[Int]>([])
+        let loggedEvents = LockIsolated<[String]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.snoozedUntil = now.addingTimeInterval(-30)
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.date = .constant(now)
+            $0.notificationClient = TCATestDependencies.silentNotificationClient(
+                authorizationStatus: .authorized
+            )
+            var settings = TCATestDependencies.silentSettingsClient()
+            settings.setSnoozedUntil = { value in
+                setUntilCalls.withValue { $0.append(value) }
+            }
+            settings.setSnoozeCount = { value in
+                setCountCalls.withValue { $0.append(value) }
+            }
+            $0.settingsClient = settings
+            $0.analyticsClient = AnalyticsClient(log: { event in
+                loggedEvents.withValue { $0.append(String(describing: event)) }
+            })
+        }
+
+        await store.send(.foregroundTransition)
+        await store.receive(.internalAction(.authStatusRefreshed(.authorized))) {
+            $0.notificationAuthStatus = .authorized
+        }
+        await store.receive(.internalAction(.snoozeStateCleared)) {
+            $0.snoozedUntil = nil
+        }
+        await store.receive(\.scheduleReminders)
+        await store.receive(.internalAction(.authStatusRefreshed(.authorized)))
+        await store.receive(.internalAction(.cancelSnoozeWake))
+        await store.finish()
+
+        XCTAssertEqual(setUntilCalls.value, [nil])
+        XCTAssertEqual(setCountCalls.value, [0])
+        XCTAssertTrue(loggedEvents.value.contains(where: { $0.contains("snoozeExpired") }))
+    }
+}

--- a/Tests/EyePostureReminderTests/TCA/SchedulingFeature_NotificationRoutingTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/SchedulingFeature_NotificationRoutingTests.swift
@@ -1,0 +1,338 @@
+import ComposableArchitecture
+import ScreenTimeExtensionShared
+import UserNotifications
+import XCTest
+
+@testable import EyePostureReminder
+
+/// `TestStore` parity coverage for `SchedulingFeature`'s notification
+/// routing + threshold-reached paths — Phase 3 issue `p0-tca-17` (#680).
+/// Mirrors `AppCoordinatorNotificationFallbackTests` and the
+/// `handleNotification` / `thresholdReached` branches of
+/// `AppCoordinatorTests`.
+@MainActor
+final class SchedulingNotificationRoutingTests: XCTestCase {
+
+    // MARK: - .notificationRouted(.reminder(.eyes))
+
+    /// `.notificationRouted(.reminder(.eyes))` fires the notification-fallback
+    /// pipeline: clears the snooze counter, records an IPC fallback event,
+    /// emits `.reminderTriggered(.notificationFallback)`, presents the
+    /// overlay, and resets the in-app tracker so it doesn't double-fire.
+    /// Direct port of `AppCoordinator.handleNotification` lines 510-555.
+    func test_notificationRouted_reminderEyes_runsFallbackPipeline() async {
+        let setSnoozeCounts = LockIsolated<[Int]>([])
+        let recordedEvents = LockIsolated<[AppGroupIPCEvent]>([])
+        let loggedEvents = LockIsolated<[String]>([])
+        let shownOverlays = LockIsolated<[(ReminderType, TimeInterval)]>([])
+        let resetTypes = LockIsolated<[ReminderType]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.settings = ReminderSettings(interval: 1200, breakDuration: 20)
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            var settings = TCATestDependencies.silentSettingsClient()
+            settings.setSnoozeCount = { value in
+                setSnoozeCounts.withValue { $0.append(value) }
+            }
+            $0.settingsClient = settings
+            $0.ipcClient = IPCClient(
+                isTrueInterruptEnabled: { false },
+                record: { event, _ in recordedEvents.withValue { $0.append(event) } },
+                trueInterruptChanges: { .finished }
+            )
+            $0.overlayClient = OverlayClient(
+                show: { type, duration, _, _ in
+                    shownOverlays.withValue { $0.append((type, duration)) }
+                },
+                dismiss: {},
+                clearQueue: {},
+                clearQueueForType: { _ in },
+                isVisible: { false },
+                lifecycleEvents: { .finished }
+            )
+            $0.screenTimeTrackerClient = ScreenTimeTrackerClient(
+                setThreshold: { _, _ in },
+                enableTracking: { _ in },
+                disableTracking: { _ in },
+                pauseAll: {},
+                resumeAll: {},
+                reset: { type in resetTypes.withValue { $0.append(type) } },
+                thresholdReached: { .finished }
+            )
+            $0.analyticsClient = AnalyticsClient(log: { event in
+                loggedEvents.withValue { $0.append(String(describing: event)) }
+            })
+        }
+
+        await store.send(.notificationRouted(.reminder(.eyes)))
+        await store.finish()
+
+        XCTAssertEqual(setSnoozeCounts.value, [0],
+                       "Reminder notification must reset the snooze counter")
+        XCTAssertEqual(recordedEvents.value.count, 1)
+        XCTAssertEqual(recordedEvents.value.first?.kind,
+                       .notificationFallbackDelivered,
+                       "Reminder notification must record a fallback-delivered IPC event")
+        XCTAssertEqual(recordedEvents.value.first?.reasonRaw,
+                       ReminderType.eyes.shieldReason.rawValue)
+        XCTAssertEqual(shownOverlays.value.count, 1)
+        XCTAssertEqual(shownOverlays.value.first?.0, .eyes)
+        XCTAssertEqual(shownOverlays.value.first?.1, 20)
+        XCTAssertEqual(resetTypes.value, [.eyes],
+                       "Reminder notification must reset the in-app tracker for that type")
+        XCTAssertTrue(loggedEvents.value.contains(where: {
+            $0.contains("reminderTriggered") && $0.contains("notificationFallback")
+        }))
+    }
+
+    // MARK: - .notificationRouted while snoozed
+
+    /// While a snooze is active, an arriving reminder notification must be
+    /// ignored — port of `handleNotification` line 514 snooze guard.
+    func test_notificationRouted_reminderDuringActiveSnooze_isNoOp() async {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let recordedEvents = LockIsolated<[AppGroupIPCEvent]>([])
+        let shownOverlays = LockIsolated<[ReminderType]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.snoozedUntil = now.addingTimeInterval(60 * 60)
+        initial.settings = ReminderSettings(interval: 1200, breakDuration: 20)
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.date = .constant(now)
+            $0.ipcClient = IPCClient(
+                isTrueInterruptEnabled: { false },
+                record: { event, _ in recordedEvents.withValue { $0.append(event) } },
+                trueInterruptChanges: { .finished }
+            )
+            $0.overlayClient = OverlayClient(
+                show: { type, _, _, _ in shownOverlays.withValue { $0.append(type) } },
+                dismiss: {},
+                clearQueue: {},
+                clearQueueForType: { _ in },
+                isVisible: { false },
+                lifecycleEvents: { .finished }
+            )
+        }
+
+        await store.send(.notificationRouted(.reminder(.posture)))
+        await store.finish()
+
+        XCTAssertTrue(recordedEvents.value.isEmpty,
+                      "Snoozed notification path must not record IPC events")
+        XCTAssertTrue(shownOverlays.value.isEmpty,
+                      "Snoozed notification path must not show overlay")
+    }
+
+    // MARK: - .notificationRouted(.snoozeWake)
+
+    /// `.snoozeWake` clears the snooze state and re-runs scheduling — port
+    /// of `handleNotification` lines 488-498.
+    func test_notificationRouted_snoozeWake_clearsAndReschedules() async {
+        var initial = SchedulingFeature.State()
+        initial.snoozedUntil = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+        }
+
+        await store.send(.notificationRouted(.snoozeWake)) {
+            $0.snoozedUntil = nil
+        }
+        await store.receive(\.scheduleReminders)
+        await store.receive(.internalAction(.authStatusRefreshed(.notDetermined)))
+        await store.receive(.internalAction(.cancelSnoozeWake))
+        await store.finish()
+    }
+
+    // MARK: - .notificationRouted(.ignore)
+
+    /// `.ignore` is the catch-all routing for unknown / system notification
+    /// categories — must be a pure no-op.
+    func test_notificationRouted_ignore_isNoOp() async {
+        let store = TestStore(initialState: SchedulingFeature.State()) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+        }
+
+        await store.send(.notificationRouted(.ignore))
+        await store.finish()
+    }
+
+    // MARK: - .thresholdReached — disabled type
+
+    /// When `state.settings.interval == 0` the type is treated as disabled
+    /// (Phase-1 SettingsClient single-value caveat) and `.thresholdReached`
+    /// must short-circuit, mirroring the `AppCoordinator` 300 ms
+    /// disable-debounce guard.
+    func test_thresholdReached_intervalZero_isNoOp() async {
+        let shownOverlays = LockIsolated<[ReminderType]>([])
+        let loggedEvents = LockIsolated<[String]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.settings = ReminderSettings(interval: 0, breakDuration: 20)
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.overlayClient = OverlayClient(
+                show: { type, _, _, _ in shownOverlays.withValue { $0.append(type) } },
+                dismiss: {},
+                clearQueue: {},
+                clearQueueForType: { _ in },
+                isVisible: { false },
+                lifecycleEvents: { .finished }
+            )
+            $0.analyticsClient = AnalyticsClient(log: { event in
+                loggedEvents.withValue { $0.append(String(describing: event)) }
+            })
+        }
+
+        await store.send(.thresholdReached(.eyes))
+        await store.finish()
+
+        XCTAssertTrue(shownOverlays.value.isEmpty)
+        XCTAssertTrue(loggedEvents.value.isEmpty)
+    }
+
+    // MARK: - .thresholdReached — enabled + authorized
+
+    /// `.thresholdReached(.eyes)` while authorized must show the overlay,
+    /// log `.reminderTriggered(.screenTimeThreshold)`, reset the snooze
+    /// counter, and reschedule the next reminder for that type.
+    func test_thresholdReached_enabledAuthorized_showsOverlayAndReschedules() async {
+        let setSnoozeCounts = LockIsolated<[Int]>([])
+        let shownOverlays = LockIsolated<[(ReminderType, TimeInterval)]>([])
+        let loggedEvents = LockIsolated<[String]>([])
+        let rescheduledTypes = LockIsolated<[ReminderType]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.settings = ReminderSettings(interval: 1200, breakDuration: 20)
+        initial.notificationAuthStatus = .authorized
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            var settings = TCATestDependencies.silentSettingsClient()
+            settings.setSnoozeCount = { value in
+                setSnoozeCounts.withValue { $0.append(value) }
+            }
+            $0.settingsClient = settings
+            $0.overlayClient = OverlayClient(
+                show: { type, duration, _, _ in
+                    shownOverlays.withValue { $0.append((type, duration)) }
+                },
+                dismiss: {},
+                clearQueue: {},
+                clearQueueForType: { _ in },
+                isVisible: { false },
+                lifecycleEvents: { .finished }
+            )
+            $0.reminderSchedulerClient = ReminderSchedulerClient(
+                scheduleReminders: { _ in },
+                rescheduleReminder: { type, _ in
+                    rescheduledTypes.withValue { $0.append(type) }
+                },
+                cancelReminder: { _ in },
+                cancelAllReminders: {}
+            )
+            $0.analyticsClient = AnalyticsClient(log: { event in
+                loggedEvents.withValue { $0.append(String(describing: event)) }
+            })
+        }
+
+        await store.send(.thresholdReached(.eyes))
+        await store.finish()
+
+        XCTAssertEqual(setSnoozeCounts.value, [0])
+        XCTAssertEqual(shownOverlays.value.count, 1)
+        XCTAssertEqual(shownOverlays.value.first?.0, .eyes)
+        XCTAssertEqual(shownOverlays.value.first?.1, 20)
+        XCTAssertEqual(rescheduledTypes.value, [.eyes])
+        XCTAssertTrue(loggedEvents.value.contains(where: {
+            $0.contains("reminderTriggered") && $0.contains("screenTimeThreshold")
+        }))
+    }
+
+    // MARK: - .thresholdReached — enabled, unauthorized
+
+    /// When notifications are denied the foreground threshold path still
+    /// presents the overlay (mirrors `AppCoordinator` line 287 callback) but
+    /// the reducer must not call `scheduler.rescheduleReminder` because there
+    /// is no notification queue to reschedule into.
+    func test_thresholdReached_enabledUnauthorized_showsOverlayButSkipsReschedule() async {
+        let shownOverlays = LockIsolated<[ReminderType]>([])
+        let rescheduledTypes = LockIsolated<[ReminderType]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.settings = ReminderSettings(interval: 1200, breakDuration: 20)
+        initial.notificationAuthStatus = .denied
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.overlayClient = OverlayClient(
+                show: { type, _, _, _ in shownOverlays.withValue { $0.append(type) } },
+                dismiss: {},
+                clearQueue: {},
+                clearQueueForType: { _ in },
+                isVisible: { false },
+                lifecycleEvents: { .finished }
+            )
+            $0.reminderSchedulerClient = ReminderSchedulerClient(
+                scheduleReminders: { _ in },
+                rescheduleReminder: { type, _ in
+                    rescheduledTypes.withValue { $0.append(type) }
+                },
+                cancelReminder: { _ in },
+                cancelAllReminders: {}
+            )
+        }
+
+        await store.send(.thresholdReached(.posture))
+        await store.finish()
+
+        XCTAssertEqual(shownOverlays.value, [.posture])
+        XCTAssertTrue(rescheduledTypes.value.isEmpty,
+                      "Denied auth must skip scheduler.rescheduleReminder")
+    }
+
+    // MARK: - .overlayDismissed
+
+    /// `.overlayDismissed` cancels every active DeviceActivity monitoring
+    /// window so a dismissed break stops accruing shield time, mirroring
+    /// `AppCoordinator.dismissOverlay`.
+    func test_overlayDismissed_cancelsAllDeviceActivitySessions() async {
+        let cancelArgs = LockIsolated<[UUID?]>([])
+
+        let store = TestStore(initialState: SchedulingFeature.State()) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.deviceActivityMonitorClient = DeviceActivityMonitorClient(
+                schedule: { _, _ in },
+                cancel: { id in cancelArgs.withValue { $0.append(id) } }
+            )
+        }
+
+        await store.send(.overlayDismissed(.eyes))
+        await store.finish()
+
+        XCTAssertEqual(cancelArgs.value.count, 1)
+        XCTAssertNil(cancelArgs.value.first ?? UUID(),
+                     "overlayDismissed must call cancel(nil) — every session, not just one")
+    }
+}

--- a/Tests/EyePostureReminderTests/TCA/SchedulingFeature_SchedulingTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/SchedulingFeature_SchedulingTests.swift
@@ -1,0 +1,378 @@
+import ComposableArchitecture
+import UserNotifications
+import XCTest
+
+@testable import EyePostureReminder
+
+/// `TestStore` parity coverage for `SchedulingFeature` — Phase 3 issue
+/// `p0-tca-17` (#680). Mirrors the scheduling and reschedule paths exercised
+/// by the legacy `AppCoordinatorTests` family
+/// (`AppCoordinatorTests`, `AppCoordinatorCancelReminderTests`,
+/// `AppCoordinatorThresholdGuardTests`).
+///
+/// Behavioural-fidelity caveats from `SchedulingFeature.swift` lines 18-31
+/// (deferred to Phase 2):
+///   * `analytics.log(.schedulePathSelected(...))` is not yet emitted by the
+///     reducer, so the matching assertion is omitted here.
+///   * Per-type interval differentiation is collapsed onto
+///     `state.settings.interval`.
+@MainActor
+final class SchedulingFeatureSchedulingTests: XCTestCase {
+
+    // MARK: - .scheduleReminders — authorized path
+
+    /// `.scheduleReminders` with `.authorized` and no active snooze must:
+    ///   * refresh the cached auth status,
+    ///   * skip the snooze-wake notification (no snooze),
+    ///   * call `cancelSnoozeWake` to evict any stale wake task,
+    ///   * forward the cached `ReminderSettings` to
+    ///     `schedulerClient.scheduleReminders`,
+    ///   * configure the tracker for both reminder types.
+    func test_scheduleReminders_authorized_callsScheduleAndConfiguresTracker() async {
+        let scheduledSnapshots = LockIsolated<[ReminderSettings]>([])
+        let cancelledAll = LockIsolated(0)
+        let setThresholds = LockIsolated<[(TimeInterval, ReminderType)]>([])
+        let enabledTypes = LockIsolated<[ReminderType]>([])
+        let resumedAll = LockIsolated(0)
+        let removedPending = LockIsolated<[[String]]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.settings = ReminderSettings(interval: 1200, breakDuration: 20)
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.notificationClient = TCATestDependencies.silentNotificationClient(
+                authorizationStatus: .authorized
+            )
+            $0.notificationClient.removePending = { ids in
+                removedPending.withValue { $0.append(ids) }
+            }
+            $0.reminderSchedulerClient = ReminderSchedulerClient(
+                scheduleReminders: { snap in
+                    scheduledSnapshots.withValue { $0.append(snap) }
+                },
+                rescheduleReminder: { _, _ in },
+                cancelReminder: { _ in },
+                cancelAllReminders: { cancelledAll.withValue { $0 += 1 } }
+            )
+            $0.screenTimeTrackerClient = ScreenTimeTrackerClient(
+                setThreshold: { interval, type in
+                    setThresholds.withValue { $0.append((interval, type)) }
+                },
+                enableTracking: { type in enabledTypes.withValue { $0.append(type) } },
+                disableTracking: { _ in },
+                pauseAll: {},
+                resumeAll: { resumedAll.withValue { $0 += 1 } },
+                reset: { _ in },
+                thresholdReached: { .finished }
+            )
+        }
+
+        await store.send(.scheduleReminders)
+        await store.receive(.internalAction(.authStatusRefreshed(.authorized))) {
+            $0.notificationAuthStatus = .authorized
+        }
+        await store.receive(.internalAction(.cancelSnoozeWake))
+
+        await store.finish()
+
+        XCTAssertEqual(scheduledSnapshots.value.count, 1,
+                       "Authorized + no snooze must invoke scheduleReminders exactly once")
+        XCTAssertEqual(scheduledSnapshots.value.first,
+                       ReminderSettings(interval: 1200, breakDuration: 20),
+                       "Scheduler must receive the cached settings snapshot")
+        XCTAssertEqual(cancelledAll.value, 0,
+                       "Authorized path must not invoke cancelAllReminders")
+        XCTAssertEqual(setThresholds.value.count, 2,
+                       "Tracker must be configured for both reminder types")
+        XCTAssertEqual(Set(enabledTypes.value), Set(ReminderType.allCases),
+                       "Both reminder types must have tracking enabled")
+        XCTAssertEqual(resumedAll.value, 1,
+                       "configureTracker must resume tracking after enabling per-type")
+        XCTAssertEqual(removedPending.value, [[SchedulingFeature.snoozeWakeCategory]],
+                       "cancelSnoozeWake must remove the snooze-wake notification id")
+    }
+
+    // MARK: - .scheduleReminders — unauthorized path
+
+    /// `.scheduleReminders` while notifications are denied must call
+    /// `cancelAllReminders` instead of scheduling, mirroring
+    /// `AppCoordinator.scheduleReminders` lines 432-447.
+    func test_scheduleReminders_unauthorized_cancelsAllReminders() async {
+        let scheduledCount = LockIsolated(0)
+        let cancelledAll = LockIsolated(0)
+
+        let store = TestStore(initialState: SchedulingFeature.State()) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.notificationClient = TCATestDependencies.silentNotificationClient(
+                authorizationStatus: .denied
+            )
+            $0.reminderSchedulerClient = ReminderSchedulerClient(
+                scheduleReminders: { _ in scheduledCount.withValue { $0 += 1 } },
+                rescheduleReminder: { _, _ in },
+                cancelReminder: { _ in },
+                cancelAllReminders: { cancelledAll.withValue { $0 += 1 } }
+            )
+        }
+
+        await store.send(.scheduleReminders)
+        await store.receive(.internalAction(.authStatusRefreshed(.denied))) {
+            $0.notificationAuthStatus = .denied
+        }
+        await store.receive(.internalAction(.cancelSnoozeWake))
+        await store.finish()
+
+        XCTAssertEqual(scheduledCount.value, 0,
+                       "Unauthorized path must not schedule")
+        XCTAssertEqual(cancelledAll.value, 1,
+                       "Unauthorized path must cancel all pending reminders")
+    }
+
+    // MARK: - .scheduleReminders — UI-test mode skips tracker reconfig
+
+    /// UI-test mode must short-circuit the foreground tracker reconfig per
+    /// `AppCoordinator.scheduleReminders` lines 452-455 — same parity carried
+    /// over to `scheduleRemindersEffect` line 222.
+    func test_scheduleReminders_uiTestMode_skipsTrackerConfig() async {
+        let setThresholdCount = LockIsolated(0)
+
+        var initial = SchedulingFeature.State()
+        initial.isUITestModeEnabled = true
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.notificationClient = TCATestDependencies.silentNotificationClient(
+                authorizationStatus: .authorized
+            )
+            $0.screenTimeTrackerClient = ScreenTimeTrackerClient(
+                setThreshold: { _, _ in setThresholdCount.withValue { $0 += 1 } },
+                enableTracking: { _ in },
+                disableTracking: { _ in },
+                pauseAll: {},
+                resumeAll: {},
+                reset: { _ in },
+                thresholdReached: { .finished }
+            )
+        }
+
+        await store.send(.scheduleReminders)
+        await store.receive(.internalAction(.authStatusRefreshed(.authorized))) {
+            $0.notificationAuthStatus = .authorized
+        }
+        await store.receive(.internalAction(.cancelSnoozeWake))
+        await store.finish()
+
+        XCTAssertEqual(setThresholdCount.value, 0,
+                       "UI-test mode must not reconfigure the foreground tracker")
+    }
+
+    // MARK: - .rescheduleType — debounce
+
+    /// Two rapid `.rescheduleType(.eyes)` calls within the 300 ms debounce
+    /// window must collapse to a single tracker / scheduler invocation, per
+    /// `rescheduleTypeEffect` line 264 (`cancelInFlight: true`).
+    func test_rescheduleType_doubleFireWithinDebounce_collapsesToSingleInvocation() async {
+        let clock = TestClock()
+        let setThresholds = LockIsolated<[ReminderType]>([])
+        let rescheduledTypes = LockIsolated<[ReminderType]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.settings = ReminderSettings(interval: 1200, breakDuration: 20)
+        initial.notificationAuthStatus = .authorized
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.continuousClock = clock
+            $0.notificationClient = TCATestDependencies.silentNotificationClient(
+                authorizationStatus: .authorized
+            )
+            $0.reminderSchedulerClient = ReminderSchedulerClient(
+                scheduleReminders: { _ in },
+                rescheduleReminder: { type, _ in
+                    rescheduledTypes.withValue { $0.append(type) }
+                },
+                cancelReminder: { _ in },
+                cancelAllReminders: {}
+            )
+            $0.screenTimeTrackerClient = ScreenTimeTrackerClient(
+                setThreshold: { _, type in setThresholds.withValue { $0.append(type) } },
+                enableTracking: { _ in },
+                disableTracking: { _ in },
+                pauseAll: {},
+                resumeAll: {},
+                reset: { _ in },
+                thresholdReached: { .finished }
+            )
+        }
+
+        await store.send(.rescheduleType(.eyes))
+        await store.send(.rescheduleType(.eyes))
+
+        await clock.advance(by: .milliseconds(300))
+        await store.receive(.internalAction(.authStatusRefreshed(.authorized)))
+
+        await store.finish()
+
+        XCTAssertEqual(setThresholds.value, [.eyes],
+                       "Debounce must collapse double-fire to a single tracker call")
+        XCTAssertEqual(rescheduledTypes.value, [.eyes],
+                       "Debounce must collapse double-fire to a single scheduler call")
+    }
+
+    // MARK: - .rescheduleType — interval == 0 disables tracking
+
+    /// When the per-type interval is 0 the reducer must disable tracking and
+    /// cancel scheduled reminders for that type, mirroring
+    /// `AppCoordinator.performReschedule` lines 234-249.
+    func test_rescheduleType_intervalZero_disablesAndCancels() async {
+        let clock = TestClock()
+        let disabledTypes = LockIsolated<[ReminderType]>([])
+        let cancelledTypes = LockIsolated<[ReminderType]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.settings = ReminderSettings(interval: 0, breakDuration: 20)
+        initial.notificationAuthStatus = .authorized
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.continuousClock = clock
+            $0.notificationClient = TCATestDependencies.silentNotificationClient(
+                authorizationStatus: .authorized
+            )
+            $0.reminderSchedulerClient = ReminderSchedulerClient(
+                scheduleReminders: { _ in },
+                rescheduleReminder: { _, _ in },
+                cancelReminder: { type in cancelledTypes.withValue { $0.append(type) } },
+                cancelAllReminders: {}
+            )
+            $0.screenTimeTrackerClient = ScreenTimeTrackerClient(
+                setThreshold: { _, _ in },
+                enableTracking: { _ in },
+                disableTracking: { type in disabledTypes.withValue { $0.append(type) } },
+                pauseAll: {},
+                resumeAll: {},
+                reset: { _ in },
+                thresholdReached: { .finished }
+            )
+        }
+
+        await store.send(.rescheduleType(.posture))
+        await clock.advance(by: .milliseconds(300))
+        await store.receive(.internalAction(.authStatusRefreshed(.authorized)))
+
+        await store.finish()
+
+        XCTAssertEqual(disabledTypes.value, [.posture])
+        XCTAssertEqual(cancelledTypes.value, [.posture])
+    }
+
+    // MARK: - .rescheduleType — unauthorized path
+
+    /// While notifications are denied the reducer must keep tracker enabled
+    /// (so the foreground threshold path still fires) but cancel any pending
+    /// scheduled notifications, per `rescheduleTypeEffect` lines 254-258.
+    func test_rescheduleType_unauthorized_keepsTrackerCancelsScheduler() async {
+        let clock = TestClock()
+        let cancelledTypes = LockIsolated<[ReminderType]>([])
+        let rescheduledTypes = LockIsolated<[ReminderType]>([])
+        let enabledTypes = LockIsolated<[ReminderType]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.settings = ReminderSettings(interval: 600, breakDuration: 30)
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.continuousClock = clock
+            $0.notificationClient = TCATestDependencies.silentNotificationClient(
+                authorizationStatus: .denied
+            )
+            $0.reminderSchedulerClient = ReminderSchedulerClient(
+                scheduleReminders: { _ in },
+                rescheduleReminder: { type, _ in
+                    rescheduledTypes.withValue { $0.append(type) }
+                },
+                cancelReminder: { type in cancelledTypes.withValue { $0.append(type) } },
+                cancelAllReminders: {}
+            )
+            $0.screenTimeTrackerClient = ScreenTimeTrackerClient(
+                setThreshold: { _, _ in },
+                enableTracking: { type in enabledTypes.withValue { $0.append(type) } },
+                disableTracking: { _ in },
+                pauseAll: {},
+                resumeAll: {},
+                reset: { _ in },
+                thresholdReached: { .finished }
+            )
+        }
+
+        await store.send(.rescheduleType(.eyes))
+        await clock.advance(by: .milliseconds(300))
+        await store.receive(.internalAction(.authStatusRefreshed(.denied))) {
+            $0.notificationAuthStatus = .denied
+        }
+
+        await store.finish()
+
+        XCTAssertEqual(enabledTypes.value, [.eyes],
+                       "Unauthorized path must still arm the foreground tracker")
+        XCTAssertEqual(rescheduledTypes.value, [],
+                       "Unauthorized path must skip scheduler.rescheduleReminder")
+        XCTAssertEqual(cancelledTypes.value, [.eyes],
+                       "Unauthorized path must cancel any pending scheduled reminder")
+    }
+
+    // MARK: - .settingsChanged — pure state write
+
+    /// `.settingsChanged` is a synchronous state write fed by the
+    /// settings-stream effect; it must update `state.settings` and produce no
+    /// follow-up effect.
+    func test_settingsChanged_writesStateWithoutEffect() async {
+        let store = TestStore(initialState: SchedulingFeature.State()) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+        }
+
+        let updated = ReminderSettings(interval: 1500, breakDuration: 25)
+        await store.send(.settingsChanged(updated)) {
+            $0.settings = updated
+        }
+    }
+
+    // MARK: - .backgroundTransition — emits appSessionEnd analytics
+
+    /// `.backgroundTransition` mirrors `AppCoordinator.appWillResignActive` by
+    /// emitting `.appSessionEnd` so Console.app traces show the session
+    /// boundary even after the migration.
+    func test_backgroundTransition_logsAppSessionEnd() async {
+        let loggedEvents = LockIsolated<[String]>([])
+
+        let store = TestStore(initialState: SchedulingFeature.State()) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.analyticsClient = AnalyticsClient(log: { event in
+                loggedEvents.withValue { $0.append(String(describing: event)) }
+            })
+        }
+
+        await store.send(.backgroundTransition)
+        await store.finish()
+
+        XCTAssertEqual(loggedEvents.value.count, 1)
+        XCTAssertTrue(loggedEvents.value[0].contains("appSessionEnd"),
+                      "backgroundTransition must emit appSessionEnd analytics")
+    }
+}

--- a/Tests/EyePostureReminderTests/TCA/SchedulingFeature_SnoozeTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/SchedulingFeature_SnoozeTests.swift
@@ -1,0 +1,327 @@
+import ComposableArchitecture
+import UserNotifications
+import XCTest
+
+@testable import EyePostureReminder
+
+/// `TestStore` parity coverage for `SchedulingFeature`'s snooze paths —
+/// Phase 3 issue `p0-tca-17` (#680). Mirrors `AppCoordinatorSnoozeWakeTests`
+/// and the snooze branches of `AppCoordinatorTests`.
+@MainActor
+final class SchedulingFeatureSnoozeTests: XCTestCase {
+
+    // MARK: - .scheduleReminders — active snooze branch
+
+    /// `.scheduleReminders` while a snooze window is active must:
+    ///   * pause every reminder type via the tracker,
+    ///   * cancel every pending scheduled reminder,
+    ///   * arm the snooze-wake clock task via `.scheduleSnoozeWake`,
+    ///   * schedule the silent snooze-wake notification when authorized.
+    /// Mirrors `AppCoordinator.scheduleReminders` lines 408-431.
+    func test_scheduleReminders_activeSnooze_authorized_pausesAndArmsWake() async {
+        // The active-snooze guard inside `scheduleRemindersEffect` compares
+        // against the system wall-clock (`Date()`), not `@Dependency(\.date)`,
+        // so we have to pick a wall-clock-future timestamp. Using
+        // `Date.distantFuture` keeps the test deterministic across machines.
+        let snoozedUntil = Date.distantFuture
+        let pausedAll = LockIsolated(0)
+        let cancelledAll = LockIsolated(0)
+        let scheduledNotifications = LockIsolated<[String]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.snoozedUntil = snoozedUntil
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            // `.scheduleSnoozeWake` uses both `now()` and `continuousClock`
+            // to arm a clock.sleep wake task; provide test doubles so the
+            // unimplemented defaults don't trip when `.stop` cancels the task.
+            $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+            $0.continuousClock = TestClock()
+            $0.notificationClient = NotificationClient(
+                requestAuthorization: { _ in false },
+                authorizationStatus: { .authorized },
+                add: { request in
+                    scheduledNotifications.withValue { $0.append(request.identifier) }
+                },
+                removePending: { _ in },
+                removeAllPending: {},
+                pendingRequests: { [] },
+                deliveredNotifications: { [] }
+            )
+            $0.reminderSchedulerClient = ReminderSchedulerClient(
+                scheduleReminders: { _ in },
+                rescheduleReminder: { _, _ in },
+                cancelReminder: { _ in },
+                cancelAllReminders: { cancelledAll.withValue { $0 += 1 } }
+            )
+            $0.screenTimeTrackerClient = ScreenTimeTrackerClient(
+                setThreshold: { _, _ in },
+                enableTracking: { _ in },
+                disableTracking: { _ in },
+                pauseAll: { pausedAll.withValue { $0 += 1 } },
+                resumeAll: {},
+                reset: { _ in },
+                thresholdReached: { .finished }
+            )
+        }
+
+        await store.send(.scheduleReminders)
+        await store.receive(.internalAction(.authStatusRefreshed(.authorized))) {
+            $0.notificationAuthStatus = .authorized
+        }
+        await store.receive(.internalAction(.scheduleSnoozeWake(snoozedUntil)))
+
+        // The snooze-wake task is a long-running clock.sleep effect; cancel it
+        // so `store.finish()` doesn't trip on outstanding effects.
+        await store.send(.stop)
+
+        XCTAssertEqual(pausedAll.value, 1, "Active snooze must pause every type")
+        XCTAssertEqual(cancelledAll.value, 1,
+                       "Active snooze must cancel every pending reminder")
+        XCTAssertEqual(scheduledNotifications.value,
+                       [SchedulingFeature.snoozeWakeCategory],
+                       "Authorized + active snooze must schedule a silent wake notification")
+    }
+
+    /// `.scheduleReminders` with an active snooze but no notification
+    /// authorisation must skip the silent-wake notification but still arm
+    /// the in-process snooze-wake task — matches the
+    /// `AppCoordinator.scheduleSnoozeWakeNotification` guard.
+    func test_scheduleReminders_activeSnooze_unauthorized_skipsSilentNotification() async {
+        let snoozedUntil = Date.distantFuture
+        let scheduledNotifications = LockIsolated<[String]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.snoozedUntil = snoozedUntil
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+            $0.continuousClock = TestClock()
+            $0.notificationClient = NotificationClient(
+                requestAuthorization: { _ in false },
+                authorizationStatus: { .denied },
+                add: { request in
+                    scheduledNotifications.withValue { $0.append(request.identifier) }
+                },
+                removePending: { _ in },
+                removeAllPending: {},
+                pendingRequests: { [] },
+                deliveredNotifications: { [] }
+            )
+        }
+
+        await store.send(.scheduleReminders)
+        await store.receive(.internalAction(.authStatusRefreshed(.denied))) {
+            $0.notificationAuthStatus = .denied
+        }
+        await store.receive(.internalAction(.scheduleSnoozeWake(snoozedUntil)))
+
+        await store.send(.stop)
+
+        XCTAssertTrue(scheduledNotifications.value.isEmpty,
+                      "Denied notifications must skip the silent snooze-wake post")
+    }
+
+    // MARK: - .scheduleReminders — expired snooze branch
+
+    /// An expired snooze must be cleared before the regular schedule path
+    /// runs, mirroring `AppCoordinator.scheduleReminders` lines 421-431.
+    func test_scheduleReminders_expiredSnooze_clearsThenSchedules() async {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let snoozedUntil = now.addingTimeInterval(-60)  // expired one minute ago
+        let setUntilCalls = LockIsolated<[Date?]>([])
+        let setCountCalls = LockIsolated<[Int]>([])
+        let loggedEvents = LockIsolated<[String]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.snoozedUntil = snoozedUntil
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.date = .constant(now)
+            $0.notificationClient = TCATestDependencies.silentNotificationClient(
+                authorizationStatus: .authorized
+            )
+            var settings = TCATestDependencies.silentSettingsClient()
+            settings.setSnoozedUntil = { value in
+                setUntilCalls.withValue { $0.append(value) }
+            }
+            settings.setSnoozeCount = { value in
+                setCountCalls.withValue { $0.append(value) }
+            }
+            $0.settingsClient = settings
+            $0.analyticsClient = AnalyticsClient(log: { event in
+                loggedEvents.withValue { $0.append(String(describing: event)) }
+            })
+        }
+
+        await store.send(.scheduleReminders)
+        await store.receive(.internalAction(.authStatusRefreshed(.authorized))) {
+            $0.notificationAuthStatus = .authorized
+        }
+        await store.receive(.internalAction(.snoozeStateCleared)) {
+            $0.snoozedUntil = nil
+        }
+        await store.receive(.internalAction(.cancelSnoozeWake))
+        await store.finish()
+
+        XCTAssertEqual(setUntilCalls.value, [nil],
+                       "Expired snooze must clear settingsClient.snoozedUntil")
+        XCTAssertEqual(setCountCalls.value, [0],
+                       "Expired snooze must reset settingsClient.snoozeCount")
+        XCTAssertEqual(loggedEvents.value.count, 1)
+        XCTAssertTrue(loggedEvents.value[0].contains("snoozeExpired"),
+                      "Expired snooze must emit .snoozeExpired analytics")
+    }
+
+    // MARK: - .clearExpiredSnoozeIfNeeded
+
+    /// A future snooze remains untouched.
+    func test_clearExpiredSnoozeIfNeeded_futureSnooze_isNoOp() async {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        var initial = SchedulingFeature.State()
+        initial.snoozedUntil = now.addingTimeInterval(60 * 60)
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.date = .constant(now)
+        }
+
+        await store.send(.clearExpiredSnoozeIfNeeded)
+        await store.finish()
+    }
+
+    /// A `nil` snooze remains a no-op.
+    func test_clearExpiredSnoozeIfNeeded_noSnooze_isNoOp() async {
+        let store = TestStore(initialState: SchedulingFeature.State()) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+        }
+
+        await store.send(.clearExpiredSnoozeIfNeeded)
+        await store.finish()
+    }
+
+    /// An expired snooze must be cleared from state, persisted via the
+    /// settings client, and emit `.snoozeExpired` analytics — port of
+    /// `AppCoordinator.clearExpiredSnoozeIfNeeded`.
+    func test_clearExpiredSnoozeIfNeeded_expiredSnooze_clearsState() async {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let setUntilCalls = LockIsolated<[Date?]>([])
+        let setCountCalls = LockIsolated<[Int]>([])
+        let loggedEvents = LockIsolated<[String]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.snoozedUntil = now.addingTimeInterval(-30)
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.date = .constant(now)
+            var settings = TCATestDependencies.silentSettingsClient()
+            settings.setSnoozedUntil = { value in
+                setUntilCalls.withValue { $0.append(value) }
+            }
+            settings.setSnoozeCount = { value in
+                setCountCalls.withValue { $0.append(value) }
+            }
+            $0.settingsClient = settings
+            $0.analyticsClient = AnalyticsClient(log: { event in
+                loggedEvents.withValue { $0.append(String(describing: event)) }
+            })
+        }
+
+        await store.send(.clearExpiredSnoozeIfNeeded) {
+            $0.snoozedUntil = nil
+        }
+        await store.finish()
+
+        XCTAssertEqual(setUntilCalls.value, [nil])
+        XCTAssertEqual(setCountCalls.value, [0])
+        XCTAssertEqual(loggedEvents.value.count, 1)
+        XCTAssertTrue(loggedEvents.value[0].contains("snoozeExpired"))
+    }
+
+    // MARK: - .snoozeWakeFired
+
+    /// `.snoozeWakeFired` clears state, persists, logs analytics, and
+    /// re-runs `.scheduleReminders` so the regular schedule resumes — direct
+    /// analogue of `AppCoordinator.handleNotification(.snoozeWake)`.
+    func test_snoozeWakeFired_clearsStateAndReschedules() async {
+        let setUntilCalls = LockIsolated<[Date?]>([])
+        let setCountCalls = LockIsolated<[Int]>([])
+        let loggedEvents = LockIsolated<[String]>([])
+
+        var initial = SchedulingFeature.State()
+        initial.snoozedUntil = Date(timeIntervalSince1970: 1_700_000_000)
+
+        let store = TestStore(initialState: initial) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            var settings = TCATestDependencies.silentSettingsClient()
+            settings.setSnoozedUntil = { value in
+                setUntilCalls.withValue { $0.append(value) }
+            }
+            settings.setSnoozeCount = { value in
+                setCountCalls.withValue { $0.append(value) }
+            }
+            $0.settingsClient = settings
+            $0.analyticsClient = AnalyticsClient(log: { event in
+                loggedEvents.withValue { $0.append(String(describing: event)) }
+            })
+        }
+
+        await store.send(.snoozeWakeFired) {
+            $0.snoozedUntil = nil
+        }
+        await store.receive(\.scheduleReminders)
+        await store.receive(.internalAction(.authStatusRefreshed(.notDetermined)))
+        await store.receive(.internalAction(.cancelSnoozeWake))
+        await store.finish()
+
+        XCTAssertEqual(setUntilCalls.value, [nil])
+        XCTAssertEqual(setCountCalls.value, [0])
+        XCTAssertTrue(loggedEvents.value.contains(where: { $0.contains("snoozeExpired") }))
+    }
+
+    // MARK: - reduceInternal(.scheduleSnoozeWake)
+
+    /// `.scheduleSnoozeWake(date)` arms a `clock.sleep` task that fires
+    /// `.snoozeWakeFired` once the wall-clock date passes.
+    func test_scheduleSnoozeWake_firesAfterClockAdvances() async {
+        let clock = TestClock()
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let wake = now.addingTimeInterval(120)
+
+        let store = TestStore(initialState: SchedulingFeature.State()) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.continuousClock = clock
+            $0.date = .constant(now)
+        }
+
+        await store.send(.internalAction(.scheduleSnoozeWake(wake)))
+
+        await clock.advance(by: .seconds(120))
+        await store.receive(\.snoozeWakeFired)
+        await store.receive(\.scheduleReminders)
+        await store.receive(.internalAction(.authStatusRefreshed(.notDetermined)))
+        await store.receive(.internalAction(.cancelSnoozeWake))
+
+        await store.finish()
+    }
+}

--- a/Tests/EyePostureReminderTests/TCA/SchedulingFeature_WatchdogRecoveryTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/SchedulingFeature_WatchdogRecoveryTests.swift
@@ -1,0 +1,137 @@
+import ComposableArchitecture
+import UserNotifications
+import XCTest
+
+@testable import EyePostureReminder
+
+/// Watchdog-recovery TestStore coverage for `SchedulingFeature` —
+/// Phase 3 issue `p0-tca-17` (#680).
+///
+/// The legacy `AppCoordinator.runWatchdogRecoveryIfNeeded(at:)` family
+/// (`AppCoordinatorWatchdogHeartbeatTests`) reads the App Group IPC log,
+/// detects a stale heartbeat, then cancels every reminder and restarts the
+/// schedule. The TCA `SchedulingFeature` reducer (this file's PR is the
+/// Phase-3 test rewrite, not the Phase-2 wiring) does not yet expose a
+/// watchdog-recovery action because the dependency-client surface required
+/// for it (an `IPCClient.recentEvents`-style accessor + a heartbeat clock
+/// adapter) has not been added — see the explicit deferral comment in
+/// `EyePostureReminder/TCA/Features/SchedulingFeature.swift` lines 24-28:
+///
+///     "Watchdog recovery, fallback-routing IPC reads, session-timing
+///     analytics, launch-readiness analytics, DeviceActivity scheduling on
+///     overlay present, and the OverlayClient.lifecycleEvents-driven
+///     bookkeeping all require dependency-client surface that does not yet
+///     exist; those side-effects stay on AppCoordinator until Phase 2."
+///
+/// The pause-condition + IPC stream effects defined in `startEffect()` are
+/// the closest in-scope analogues to "external trigger reschedules" so the
+/// covering tests assert those paths here. The watchdog-recovery test
+/// itself documents the deferral via `XCTSkip` so the migration ticket can
+/// re-enable it once the wider dependency surface lands.
+@MainActor
+final class SchedulingFeatureWatchdogRecoveryTests: XCTestCase {
+
+    // MARK: - Watchdog-recovery deferral
+
+    /// Records the deferral. Once Phase-2 lands the IPC-recent-events
+    /// accessor + heartbeat clock adapter, replace this `XCTSkip` with the
+    /// behavioural-parity test against the new
+    /// `.watchdogRecoveryTriggered` action.
+    func test_watchdogRecovery_deferredToPhase2() throws {
+        try XCTSkipIf(true, """
+            SchedulingFeature lacks watchdog-recovery surface in Phase 1
+            (see SchedulingFeature.swift lines 24-28). Re-enable once an
+            IPCClient.recentEvents accessor + heartbeat clock adapter ship
+            so AppCoordinatorWatchdogHeartbeatTests can be ported.
+            """)
+    }
+
+    // MARK: - IPC stream → reschedule (closest in-scope analogue)
+
+    /// `startEffect()` installs an `ipcStream` subscriber that fires
+    /// `.scheduleReminders` on every emitted true-interrupt change. This is
+    /// the closest currently-implemented analogue to a watchdog-driven
+    /// "external signal forces a reschedule" path. Verifies the contract by
+    /// driving the stream from the test body and asserting the resulting
+    /// `.scheduleReminders` action.
+    func test_ipcStream_trueInterruptChange_triggersScheduleReminders() async {
+        let (stream, continuation) = AsyncStream<Bool>.makeStream()
+
+        let store = TestStore(initialState: SchedulingFeature.State()) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.ipcClient = IPCClient(
+                isTrueInterruptEnabled: { false },
+                record: { _, _ in },
+                trueInterruptChanges: { stream }
+            )
+        }
+        store.exhaustivity = .off
+
+        await store.send(.start)
+
+        continuation.yield(true)
+        await store.receive(\.scheduleReminders)
+
+        // Tear down the long-lived streams so `store.finish()` doesn't trip.
+        continuation.finish()
+        await store.send(.stop)
+    }
+
+    // MARK: - Pause stream → pauseConditionChanged (closest in-scope analogue)
+
+    /// `startEffect()` also installs a `pauseStream` subscriber that maps
+    /// every emitted `Bool` onto `.pauseConditionChanged`. This is the
+    /// in-scope analogue to the "external resume / pause condition forces
+    /// a state transition" guard rail. Verifies the routing by yielding
+    /// from the test body.
+    func test_pauseStream_pauseConditionChange_routesToReducer() async {
+        let (stream, continuation) = AsyncStream<Bool>.makeStream()
+        let pausedAll = LockIsolated(0)
+
+        let store = TestStore(initialState: SchedulingFeature.State()) {
+            SchedulingFeature()
+        } withDependencies: {
+            TCATestDependencies.applyAllSilentClients(&$0)
+            $0.date = .constant(Date(timeIntervalSince1970: 1_700_000_000))
+            $0.pauseConditionClient = PauseConditionClient(
+                isPaused: { false },
+                pauseChanges: { stream },
+                startMonitoring: {},
+                stopMonitoring: {}
+            )
+            $0.screenTimeTrackerClient = ScreenTimeTrackerClient(
+                setThreshold: { _, _ in },
+                enableTracking: { _ in },
+                disableTracking: { _ in },
+                pauseAll: { pausedAll.withValue { $0 += 1 } },
+                resumeAll: {},
+                reset: { _ in },
+                thresholdReached: { .finished }
+            )
+            $0.overlayClient = OverlayClient(
+                show: { _, _, _, _ in },
+                dismiss: {},
+                clearQueue: {},
+                clearQueueForType: { _ in },
+                isVisible: { false },
+                lifecycleEvents: { .finished }
+            )
+        }
+        store.exhaustivity = .off
+
+        await store.send(.start)
+
+        continuation.yield(true)
+        await store.receive(\.pauseConditionChanged) {
+            $0.isPausedByConditions = true
+        }
+
+        continuation.finish()
+        await store.send(.stop)
+
+        XCTAssertEqual(pausedAll.value, 1,
+                       "pauseConditionChanged(true) must call trackerClient.pauseAll")
+    }
+}


### PR DESCRIPTION
## Summary

Adds the five Phase-3 TestStore files required by p0-tca-17 (#680) so `SchedulingFeature` has direct behavioural-parity coverage independent of the legacy `AppCoordinator` test harness.

## Files added (test-only — no production code modified)

| File | Coverage |
|------|----------|
| `Tests/EyePostureReminderTests/TCA/SchedulingFeature_SchedulingTests.swift` | `.scheduleReminders` (authorized / unauthorized / UI-test mode) and `.rescheduleType` (debounce, interval=0, unauthorized, settingsChanged, backgroundTransition) |
| `Tests/EyePostureReminderTests/TCA/SchedulingFeature_SnoozeTests.swift` | active-snooze branch, expired-snooze, `clearExpiredSnoozeIfNeeded`, `.snoozeWakeFired`, `.scheduleSnoozeWake` clock test |
| `Tests/EyePostureReminderTests/TCA/SchedulingFeature_ForegroundTransitionTests.swift` | foreground-transition branch matrix (auth-status delta, future snooze, expired snooze) |
| `Tests/EyePostureReminderTests/TCA/SchedulingFeature_NotificationRoutingTests.swift` | `.notificationRouted(.reminder/.snoozeWake/.ignore)`, `.thresholdReached`, `.overlayDismissed` |
| `Tests/EyePostureReminderTests/TCA/SchedulingFeature_WatchdogRecoveryTests.swift` | XCTSkip stub for the literal watchdog test + IPC-stream and pause-stream in-scope analogues |

## Watchdog deferral note

The literal `runWatchdogRecoveryIfNeeded`-equivalent test stays as `XCTSkip` because the reducer still defers that surface to `AppCoordinator` per the explicit comment at `EyePostureReminder/TCA/Features/SchedulingFeature.swift` lines 24-28:

> Watchdog recovery, fallback-routing IPC reads, session-timing analytics, launch-readiness analytics, DeviceActivity scheduling on overlay present, and the OverlayClient.lifecycleEvents-driven bookkeeping all require dependency-client surface that does not yet exist; those side-effects stay on AppCoordinator until Phase 2.

Once Phase-2 lands the IPC-recent-events accessor and heartbeat clock adapter, the skip can be replaced with the parity test against the new `.watchdogRecoveryTriggered` action.

## Verification

`./scripts/build.sh all` (build + lint + test) → **2207 tests, 1 skipped, 0 failures** locally.

## Closes

Closes #680
