### PR TITLE
test: extend overlay-window tearDown terminate to DarkModeUITests (#726)

### DIFF
--- a/Tests/EyePostureReminderUITests/DarkModeUITests.swift
+++ b/Tests/EyePostureReminderUITests/DarkModeUITests.swift
@@ -41,6 +41,13 @@ final class DarkModeUITests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        // Force-terminate so the overlay's `UIWindow` (at `.alert + 1`) is
+        // released and SpringBoard can complete its background assertion before
+        // the next test boots a fresh process. Without this, the dark-mode
+        // overlay tests inherit a zombie process and `waitForOverlayPresented()`
+        // never resolves — same root cause as the Overlays-shard cascade fixed
+        // for `OverlayPresentationTests` / `OverlayPostureTests` in #714 (#726).
+        app?.terminateAndWaitForExit()
         app = nil
     }
 


### PR DESCRIPTION
## Summary

Mirrors the `OverlayPresentationTests` / `OverlayPostureTests` `tearDown` fix from #714 into `DarkModeUITests`, which presents the same alert-level overlay `UIWindow` but currently only sets `app = nil` between tests.

## Why this is needed

`DarkModeUITests` exercises three overlay-presenting tests (`test_darkMode_overlay_doneButton_dismissesOverlay`, `test_darkMode_overlay_essentialElementsVisible`, `test_darkMode_postureOverlay_essentialElementsVisible`) plus 4 non-overlay tests in a single `XCTestCase`. Without an explicit `terminate()` while XCTest still holds a stable process assertion, `UIApplication.willTerminateNotification` does not fire reliably between successive overlay launches on a loaded simulator. The `OverlayManager` observer added in #714 then never gets a chance to release the alert-level `UIWindow`, SpringBoard can't reap the prior process, and the next `launchWithEyeOverlay()` boots into the zombie's session — `overlay.doneButton` never becomes hittable within the 8s `waitForOverlayPresented()` window.

This is the **same root cause** as #714, just in the Dark Mode shard rather than the Overlays shard.

## Evidence

PR #703 (refactor: decommission legacy MVVM types) — `UI Tests / Dark Mode` failure run https://github.com/yashasg/fantastic-octo-fortnight/actions/runs/25892071641:

- 1st pass: 3 dark-mode overlay tests time out at `XCTAssertTrue(app.waitForOverlayPresented(), …)` (`Tests/EyePostureReminderUITests/DarkModeUITests.swift:30, 36`).
- 2nd pass (auto-retry): 1 follow-on failure with `Application 'com.yashasg.eyeposturereminder' does not have a process ID` — the exact zombie pattern from #714's root-cause analysis.

PR #703's only diff is removing `coordinator` from a `#Preview` block — it does not touch overlay code, so the Dark Mode flake is environmental, not regression.

## Change

`Tests/EyePostureReminderUITests/DarkModeUITests.swift::tearDownWithError` now calls the `terminateAndWaitForExit()` helper introduced in #714 before clearing `app`. For non-overlay dark-mode tests (`launches`, `settingsButtonIsHittable`, `settings_canBeOpened`, `onboarding_welcomeScreenLaunches`) the explicit terminate is a small per-test cost (≤5s timeout, returns immediately when state is already `.notRunning`).

## Branch base

This PR is **stacked on top of #715** (`users/squad/issue-714-overlay-window-termination-cleanup`) because the `terminateAndWaitForExit(timeout:)` helper and the `OverlayManager.willTerminateNotification` observer it relies on are introduced there. After #715 squash-merges into main, this PR should be rebased onto main — the diff stays a 7-line addition.

## Verification

```
./scripts/build.sh lint   →  passes
./scripts/build.sh build  →  ** BUILD SUCCEEDED **
```

The Dark Mode shard cannot be reproduced locally without the loaded-CI simulator, but the change is a direct application of the proven #714 pattern to the affected XCTestCase.

## Risk

Low. Test-only change (no production code modified), additive `tearDown` path that simply force-quits the app between tests — the same pattern PR #715 already applies to `OverlayPresentationTests` / `OverlayPostureTests`.

Closes #726

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
