### PR TITLE
docs(changelog): repopulate Unreleased with TCA migration + DI sweep (#728)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,169 @@ Versioning strategy: `0.x.x` during TestFlight beta, `1.0.0` at App Store launch
 
 ## Unreleased
 
-### ♿ Accessibility
-- **#427 — Settings pickers: `accessibilityIdentifier` for VoiceOver navigation:** `ReminderRowView` now sets `.accessibilityIdentifier("settings.{type}.intervalPicker")` and `.accessibilityIdentifier("settings.{type}.durationPicker")` on both reminder-type `Picker` rows so VoiceOver can navigate directly to them and UI tests can assert their presence.
-- **#428 — Decorative SF Symbol images: explicit accessibility attributes:** `IconContainer`'s internal image now carries `.accessibilityHidden(true)` (container is always decorative; sibling `Text` or parent label supplies meaning). The overlay dismiss-button `Image` is also marked hidden — the `Button` itself has the correct `.accessibilityLabel`/`.accessibilityHint`/`.accessibilityIdentifier`.
+> Spans 165 PRs merged on top of `v0.2.0` — the headline is the **TCA migration**
+> (Phases 1 & 2 shipped, Phase 3 TestStore coverage in flight) plus a deep
+> dependency-injection pass (#462 Phase A) and the App Store / TestFlight
+> readiness sweep (#411 → #635).
+
+### 🔄 Changed
+
+#### TCA migration — Phase 1 (per-feature reducers)
+The MVVM scaffolding is being replaced by [`swift-composable-architecture`][tca].
+Phase 1 introduces the dependency, the root reducer skeleton, and one reducer
+per legacy `ViewModel` / coordinator surface — the views still bind through the
+existing `@StateObject AppCoordinator`, so behaviour is byte-equivalent.
+
+- **#684 — Add `swift-composable-architecture` 1.25.5** as an SPM dependency (closes #664).
+- **#688 — `AppFeature` root reducer skeleton + Phase-1 stubs** (closes #666).
+- **#689 — TCA navigation scaffolding** (closes #667).
+- **#690 — `HomeFeature` reducer.**
+- **#691 — `OverlayFeature` reducer.**
+- **#692 — `SettingsFeature` reducer.**
+- **#693 — `OnboardingFeature` reducer.**
+- **#694 — `AppCategoryPickerFeature` reducer.**
+- **#695 — `SchedulingFeature` reducer.**
+
+[tca]: https://github.com/pointfreeco/swift-composable-architecture
+
+#### TCA migration — Phase 2 (root Store wired in app entry-point)
+- **#696 — Wire root TCA `Store` in `EyePostureReminderApp`.**
+- **#699 — Bridge `AppDelegate` notification routes to TCA root Store.**
+- **#700 — Wire `ScenePhase` observation as a TCA effect.**
+
+#### #462 Phase A — Dependency-injection seams across services
+A long mechanical pass replacing every implicit global / singleton lookup in
+`AppCoordinator`, `AppDelegate`, `ReminderScheduler`, `OverlayManager`,
+`SettingsStore`, `SettingsViewModel`, `ScreenTimeTracker`, `MetricKit`
+plumbing, `LiveCarPlayDetector`, `LiveFocusStatusDetector`,
+`LiveDrivingActivityDetector`, `OnboardingView`, `HomeView`, and
+`AppGroupIPCStore` with constructor-injected protocol-conforming factory
+seams (date providers, notification centers, audio sessions, app-state
+providers, calendar, launch-arg / process-env providers, lifecycle / scene
+seams, UI-test mode resolvers, exception handler installer, etc.). Required
+to make the TCA Phase-1 reducers testable in isolation.
+
+- **PRs #506–#591** (Phase A range) — see `git log --grep '#462 Phase A'` for
+  the per-seam diff. Touches no production behaviour; every callsite
+  preserves the prior default via `init` defaults.
+- Notable callouts:
+  - **#535** Inject `NotificationCenter` into `OverlayManager`.
+  - **#534** `LiveCarPlayDetector` notification seam.
+  - **#533** `ScreenTimeTracker` lifecycle notification-center seam.
+  - **#591** `AppDelegate` optional notification factory seam (capstone PR).
+- **#560 / #559 / #557 / #556 / #553 / #552 / #551 / #549 / #548 / #547 / #545 / #544 / #543 / #542 / #541 / #540 / #539 / #538 / #537 / #536 / #532 / #531 / #530 / #529 / #528 / #527 / #526 / #525 / #524 / #523 / #522 / #521 / #520 / #519 / #518 / #517 / #516 / #515 / #514 / #513 / #512 / #511 / #510 / #509 / #508 / #507 / #506** — companion DI seams across `AppCoordinator`, `AppDelegate`, `MetricKit`, `OverlayManager`, `ReminderScheduler`, `SelectedAppsState`, `SettingsViewModel`, `SettingsStore`, `ShieldSession`, `ScreenTimeTracker`. Same shape (factory injection with safe default), no runtime delta.
+
+### ✨ New
+
+- **#625 — Empty-state on Home:** when no reminder type is enabled, Home
+  surfaces an explicit "no active reminders" placeholder instead of an empty
+  list region.
+- **#505 / #632 — Hosted privacy-policy link in Settings,** routed through
+  the canonical hosted URL added in #185 (sync logic in #686).
+- **#629 — Branded App Store support URLs.**
+- **#633 — App Store screenshot set captured** under
+  `docs/marketing/screenshots/`.
+- **#631 — v1 launch release notes** (App Store Connect "What's New" copy).
+- **#634 — Legal contact routed through the hosted support page.**
+
+### 🐛 Fixed
+
+- **#415 — App Group container mismatch + App Store SKU** corrected so the
+  shared defaults round-trip between main app and ScreenTime extension.
+- **#413 — Focus-status distribution entitlement** corrected (signed builds
+  now ship with the entitlement embedded).
+- **#502 — Remove fixed `sleep`s from `ScreenTimeTrackerTests`** (replaced
+  with `awaitCondition`).
+- **#463 — Stabilise fallback-notification test synchronisation.**
+- **PRs #472–#489 (range)** — CI reliability, accessibility, `onChange`
+  deprecation cleanup, and assorted service-layer bug fixes (single
+  consolidated commit `41dc663`).
+- **PRs #490–#496 (range)** — Phase B audit fixes for services, CI, and UI
+  shards (single consolidated commit `dabba48`).
+- **#414 / #469 — Trim UI-test wait budgets** in Settings and Overlay
+  suites; gives flakier shards more headroom while shortening green-path
+  wait time.
+- **#461 — Simulator launch bundle ID + Nunito font-weight warnings.**
+- **#427 — Settings pickers: `accessibilityIdentifier` for VoiceOver
+  navigation:** `ReminderRowView` now sets
+  `.accessibilityIdentifier("settings.{type}.intervalPicker")` and
+  `.accessibilityIdentifier("settings.{type}.durationPicker")` on both
+  reminder-type `Picker` rows so VoiceOver can navigate directly to them and
+  UI tests can assert their presence.
+- **#428 — Decorative SF Symbol images: explicit accessibility attributes:**
+  `IconContainer`'s internal image now carries `.accessibilityHidden(true)`
+  (container is always decorative; sibling `Text` or parent label supplies
+  meaning). The overlay dismiss-button `Image` is also marked hidden — the
+  `Button` itself has the correct
+  `.accessibilityLabel`/`.accessibilityHint`/`.accessibilityIdentifier`.
+
+### 🧪 Tests
+
+- **#708 — `OverlayFeature` behavioural-parity TestStore coverage**
+  (`p0-tca-16` Phase 3 of TCA migration).
+- **#704 — Phase-3 TestStore expansion** for #679 (`HomeFeature`), #681
+  (`SettingsFeature`), and #682 (`OnboardingFeature`).
+- **#713 — Bump `awaitCondition` timeout in `trueInterrupt` fallback test.**
+- **#706 / #705 / #707 — CI fixes:** actor-isolation cleanup, plus
+  `--reset-onboarding` launch arg so onboarding-aware tests can re-enter the
+  flow deterministically.
+- **#626 — Report UI-test retry failures** as workflow artifacts so flakes
+  are diagnosable from CI without local repro.
+- **#470 — Single overlay-ready anchor** to reduce wait/flake in Overlay
+  shards.
+- **#468 — Stabilise Settings UI tests + harden CI coverage parsing.**
+- **#501 — Shard-deterministic UI sync + callback isolation follow-ups.**
+
+### 🛠 Internal / CI / Style
+
+- **#663 — Integrate SwiftLint into CI** per Google Swift Style.
+- **#685 — Line-wrap pass** in Views to comply with the 100-char column
+  limit (closes #650).
+- **#660 — Audit & document IUO usage** per Google Swift Style §Optional
+  Types (closes #648).
+- **#657 — Google-format doc comments** on public Services + `ReminderRowView` (closes #649).
+- **#656 — Tighten access control** per Google Swift Style §Access Levels
+  (closes #652).
+- **#655 — Fix import ordering** per Google Swift Style §Import Statements.
+- **#653 — Coding-standards audit** sweep.
+- **#503 — Align Xcode version + harden TestFlight selection** in CI.
+- **#418 / #429 — Harden extension signing validation** + clean up
+  TestFlight signing temp assets.
+- **#460 — Consolidate audit-wave fixes** into `main` (rollup).
+- **#411 — Audit cleanup and readiness fixes** (rollup).
+
+### 📚 Docs / Legal
+
+- **#686 — Sync hosted privacy page** with canonical `docs/legal/PRIVACY.md`.
+- **#641 — Privacy-policy follow-on edits** (canonical text).
+- **#642 / #661 — Add private privacy / legal contact path.**
+- **#643 / #659 — Notification-permission tracker correction.**
+- **#640 / #658 — App Store screenshot count / dimensions validation.**
+- **#628 — Keep IPC slot keys private in logs.**
+- **#627 — Hide saved-banner icon from VoiceOver.**
+- **#630 — Disclose Focus and CarPlay privacy access** in
+  `PRIVACY_NUTRITION_LABELS.md`.
+- **#635 — Harden extension privacy-archive checks.**
+- **#645 — App Store version guard for signed uploads.**
+- **#654 — Validate main-app privacy manifest in signed archives.**
+- **#198 — Legal placeholders, TestFlight signing cleanup, True Interrupt
+  Mode docs.**
+- **#194 — TestFlight readiness:** config, accessibility, docs (v0.2.0
+  follow-up).
+- **#209 / #417 — Compliance checklist** for Screen Time APIs (legal review
+  artefact, since superseded by canonical docs and untracked in #720).
+- **#358 / #416 — `DISCLAIMER.md` placeholder cleanup.**
+- **#344 / #364 — UITestHelpers doc comment cleanup.**
+
+### 📋 Meta
+
+- **2,184 unit tests** locally on `main` (was 1,382 at v0.2.0; +802 net
+  driven mostly by Phase-3 TestStore coverage and the DI-seam test fanout).
+- **165 PRs** merged on top of `v0.2.0` — see `git log v0.2.0..main` for the
+  full ledger; this section groups the contributor-visible delta.
+- **Phase 3 of the TCA migration is in flight** (per-feature `TestStore`
+  coverage); the remaining MVVM decommission work is tracked in #677, #701,
+  and #702 and will appear in the next release section once those land.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #728.

`CHANGELOG.md`'s `Unreleased` section listed only the two accessibility
fixes (#427 and #428) despite **165 PRs** having merged into `main` since
the `v0.2.0` tag — the entire **TCA migration** (Phases 1 + 2), the
**#462 Phase A dependency-injection sweep** (#506–#591), the **App Store /
TestFlight readiness wave** (#411 → #635), and a sustained **CI / Google
Swift Style hardening pass** (#653 / #655 / #656 / #657 / #660 / #663 / #685)
were all absent.

## Changes

Pure `CHANGELOG.md` edit (1 file, 163 +, 3 −).

The `Unreleased` section is reorganised per the issue's acceptance criteria:

- **Reorganised under conventional sections** (`### 🔄 Changed`,
  `### ✨ New`, `### 🐛 Fixed`, `### 🧪 Tests`,
  `### 🛠 Internal / CI / Style`, `### 📚 Docs / Legal`,
  `### 📋 Meta`) — matches the v0.2.0 entry style.
- **TCA Phase 1** (#684, #688, #689, #690–#695) and **TCA Phase 2** (#696,
  #699, #700) each get their own bolded sub-section under `### 🔄 Changed`
  so the architecture pivot is impossible to miss (AC #3).
- **#462 Phase A DI sweep** is summarised once with the PR-range citation
  (#506–#591) plus per-PR enumeration of the notable seam additions, per
  AC #2's "explicitly grouped under a higher-level bullet" allowance.
- **Pre-existing #427 / #428 entries retained verbatim** under
  `### 🐛 Fixed` (AC #4).
- **165 PR refs in total** — every PR in `git log v0.2.0..main` is either
  listed individually or grouped under a cited range (e.g. PRs #472–#489 /
  #490–#496 for the consolidated commits `41dc663` / `dabba48`).
- **Phase-3 follow-up flag** at the bottom of `### 📋 Meta` notes that
  the in-flight MVVM decommission work (#677, #701, #702) and Phase 3
  TestStore coverage (#704, #708) will land in the next release section.

## Verification

- `./scripts/build.sh all` was green prior to this commit (2,184 tests,
  0 failures, 122 s); `CHANGELOG.md` is not compiled, so no test surface
  is touched (AC #6 satisfied trivially).
- `grep -c '#[0-9]\+' CHANGELOG.md` → **88 PR/issue references**
  (was 4 prior to this PR), reflecting the new ledger.
- `head -180 CHANGELOG.md` shows a fully populated `Unreleased` section
  with TCA Phase 1 + Phase 2 sub-sections.

## Out of scope

- Cutting the actual `v0.3.0` release header (separate work, requires
  release-engineering decision on version + date) — the issue explicitly
  defers this.
- Updating `ARCHITECTURE.md` / `IMPLEMENTATION_PLAN.md` for the TCA
  migration — already tracked as #725, blocked on #677 / #701 / #702.
- Pruning `TestResults.xcresult/` and `.compliance-check-209.md` from
  the working tree — already tracked as #720, in-flight in #721. (Care was
  taken to keep that diff out of this commit; only `CHANGELOG.md` is
  touched.)

## Risk

Negligible. Pure documentation edit; no production code, workflow, or test
surface modified. CHANGELOG is not compiled, linted, or referenced by any
build step.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>