### PR TITLE
chore: route 2 regressed .onChange callsites through onChangeCompat (#730)

### DIFF
--- a/EyePostureReminder/App/EyePostureReminderApp.swift
+++ b/EyePostureReminder/App/EyePostureReminderApp.swift
@@ -70,7 +70,7 @@ struct EyePostureReminderApp: App {
                 .task {
                     await store.send(.scheduling(.start)).finish()
                 }
-                .onChange(of: scenePhase) { phase in
+                .onChangeCompat(of: scenePhase) { phase in
                     if phase == .active {
                         presentUITestOverlayIfNeeded()
                     }

--- a/EyePostureReminder/Views/ContentView.swift
+++ b/EyePostureReminder/Views/ContentView.swift
@@ -31,7 +31,7 @@ struct ContentView: View {
                 reduceMotion ? nil : AppAnimation.onboardingTransition,
                 value: store.hasSeenOnboarding
             )
-            .onChange(of: persistedHasSeenOnboarding) { newValue in
+            .onChangeCompat(of: persistedHasSeenOnboarding) { newValue in
                 if store.hasSeenOnboarding != newValue {
                     store.send(.hasSeenOnboardingChanged(newValue))
                 }


### PR DESCRIPTION
## Summary

Closes #730.

[#494](https://github.com/yashasg/fantastic-octo-fortnight/pull/494) closed with a sweep that replaced **22** deprecated single-arg `.onChange(of:perform:)` closures with the `onChangeCompat` wrapper (`EyePostureReminder/Views/View+OnChange.swift`) so the codebase stays warning-free against the iOS 17+ SDK while preserving iOS 16 deployment-target compatibility. Two callsites had since regressed past that cleanup:

- `EyePostureReminder/App/EyePostureReminderApp.swift:73` — pre-dates #494, slipped through the original sweep.
- `EyePostureReminder/Views/ContentView.swift:34` — added by #696 (TCA Phase 2 — wire root TCA Store) on 2026-05-14.

## Changes

```diff
-                .onChange(of: scenePhase) { phase in
+                .onChangeCompat(of: scenePhase) { phase in
                     if phase == .active {
                         presentUITestOverlayIfNeeded()
                     }
                     store.send(.scenePhaseChanged(phase))
                 }
```

```diff
-            .onChange(of: persistedHasSeenOnboarding) { newValue in
+            .onChangeCompat(of: persistedHasSeenOnboarding) { newValue in
                 if store.hasSeenOnboarding != newValue {
                     store.send(.hasSeenOnboardingChanged(newValue))
                 }
             }
```

Closure bodies are byte-equivalent; no behaviour delta — `onChangeCompat` just chooses the iOS-17 two-arg overload at the `#available(iOS 17, *)` boundary and falls back to the single-arg form on iOS 16.

## Verification

```text
$ rg "\.onChange\(of:[^,]+\)\s*\{" EyePostureReminder Extensions
# → 0 matches outside Views/View+OnChange.swift (intentional iOS-16 fallback inside the wrapper)

$ ./scripts/build.sh all
# → ** TEST SUCCEEDED ** — 2,184 tests, 0 failures, 109s wall clock
```

No tests added — pure mechanical wrapper substitution; no production behaviour to regression-test that the existing 2,184-test suite does not already cover (`scenePhase` routing exercised by `AppCoordinatorTests` + `AppFeatureTests`; `hasSeenOnboarding` change exercised by `OnboardingFeatureTests` + `ContentViewGateTests`).

## Acceptance criteria coverage

| AC | Status |
|----|--------|
| Switch the 2 callsites to `.onChangeCompat(of:)` | ✅ |
| `rg` returns 0 matches outside `Views/View+OnChange.swift` | ✅ |
| `./scripts/build.sh all` stays green | ✅ (2,184 tests, 0 failures) |
| No production behaviour change | ✅ (closure bodies byte-equivalent) |

## Out of scope

- The wrapper itself (`Views/View+OnChange.swift:18` — `onChange(of: value) { _, newValue in action(newValue) }`) is the iOS-17 two-arg form behind a `#available(iOS 17, *)` gate, intentionally not deprecated.