### PR TITLE
ci: bump remaining Node-20 GHA pins (download-artifact, github-script) to Node 24 (#732)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,7 @@ jobs:
           xcrun simctl list devices available | grep -i iphone | head -5
 
       - name: Download UI prebuilt artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: ui-prebuilt-${{ github.run_id }}
           path: ${{ env.DERIVED_DATA_PATH }}/Build/Products

--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Ralph — Apply triage decisions
         if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const fs = require('fs');
@@ -108,7 +108,7 @@ jobs:
       # Copilot auto-assign step (uses PAT if available)
       - name: Ralph — Assign @copilot issues
         if: success()
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Identify assigned member and trigger work
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const fs = require('fs');
@@ -120,7 +120,7 @@ jobs:
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
         if: github.event.label.name == 'squad:copilot'
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Triage issue via Lead agent
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Parse roster and sync labels
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## Summary

Closes #732.

PR #710 (closes #709) bumped `actions/checkout`, `actions/cache`, and `actions/upload-artifact` to Node 24 majors but **two more pinned actions were left on Node 20** majors and continue to emit the same deprecation warning #709 was filed to silence:

| Action | Before | After |
| --- | --- | --- |
| `actions/download-artifact` | v4 (`d3f86a1...`) | **v8.0.1** (`3e5f45b...`) |
| `actions/github-script` | v7.0.1 (`60a0d83...`) | **v8.0.0** (`ed59741...`) |

`v8.0.0` of `github-script` is chosen over `v9.0.0`: v9 removes `require('@actions/github')` (breaking). Our scripts only `require('fs')` (Node built-in, unaffected) — verified with `grep -rn 'require(' .github/workflows/`. v8.0.x is API-compatible with our existing `script:` blocks.

`v8.0.x` of `download-artifact` is API-compatible with our `name`/`path` usage on the single UI prebuilt artifact download.

## Files touched

- `.github/workflows/ci.yml` (1 ref — `download-artifact` line 359)
- `.github/workflows/squad-heartbeat.yml` (2 refs)
- `.github/workflows/squad-issue-assign.yml` (2 refs)
- `.github/workflows/squad-triage.yml` (1 ref)
- `.github/workflows/sync-squad-labels.yml` (1 ref)

```
5 files changed, 7 insertions(+), 7 deletions(-)
```

## Why this isn't folded into PR #710

#710 ships the bumps it scoped (checkout/cache/upload-artifact) and is currently in a green-Build-Test / flaky-Dark-Mode state. Folding more changes in would re-trigger its long-running UI-test matrix unnecessarily and risk merge-window slip. This branch touches different lines (`download-artifact` + `github-script` callsites that #710 leaves alone), so both can land independently with no conflict.

## Verification

- `python3 -c 'import yaml; yaml.safe_load(open(...))'` passes for every modified workflow.
- `grep -nE 'actions/(download-artifact|github-script)' .github/workflows/*.yml` shows only the new SHAs.
- Local build/test unaffected (workflow YAML only — no Swift code touched).
- The CI run on this PR is the real verification — expectation is **0 Node 20 deprecation warnings** in any UI-test job log on this branch.

## Risk

Low. Workflow-only change, no overlap with any in-flight PR (#710 covers a disjoint set of action callsites). Trivially revertible by reverting the single commit.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
