### PR TITLE
test: extend overlay-window tearDown terminate to DarkModeUITests (#726)

### DIFF
--- a/Tests/EyePostureReminderUITests/DarkModeUITests.swift
+++ b/Tests/EyePostureReminderUITests/DarkModeUITests.swift
@@ -41,6 +41,13 @@ final class DarkModeUITests: XCTestCase {
     }
 
     override func tearDownWithError() throws {
+        // Force-terminate so the overlay's `UIWindow` (at `.alert + 1`) is
+        // released and SpringBoard can complete its background assertion before
+        // the next test boots a fresh process. Without this, the dark-mode
+        // overlay tests inherit a zombie process and `waitForOverlayPresented()`
+        // never resolves — same root cause as the Overlays-shard cascade fixed
+        // for `OverlayPresentationTests` / `OverlayPostureTests` in #714 (#726).
+        app?.terminateAndWaitForExit()
         app = nil
     }
 


### PR DESCRIPTION
Re-open of #727 (auto-closed when base branch `users/squad/issue-714-overlay-window-termination-cleanup` was deleted on the squash-merge of #715).

## Summary

DarkModeUITests was missed by #714 / #715 — the dark-mode shard was hitting the same SpringBoard background-assertion timeout cascade fixed for OverlayPresentationTests / OverlayPostureTests. This extends the same `terminateAndWaitForExit()` tearDown to DarkModeUITests so the overlay's `UIWindow` (at `.alert + 1`) is released before the next test boots a fresh process.

## Changes

- `Tests/EyePostureReminderUITests/DarkModeUITests.swift` — add `app?.terminateAndWaitForExit()` in `tearDownWithError()` with a comment explaining the root cause.

Closes #726

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>