### PR TITLE
refactor(tca): split OverlayFeature dismiss into two phases (#738)

### DIFF
--- a/EyePostureReminder/TCA/AppFeature.swift
+++ b/EyePostureReminder/TCA/AppFeature.swift
@@ -75,6 +75,17 @@ struct AppFeature {
                 return .none
             case let .notificationRouted(route):
                 return .send(.scheduling(.notificationRouted(route)))
+            case .overlay(.presented(.dismissed)):
+                // Two-phase dismiss (#738): once `OverlayFeature` finishes
+                // its `dismissAnimationCompleted` → `overlayClient.dismiss`
+                // → `dismissed` chain, the presentation slot in the root
+                // store must be cleared so `RootView`'s
+                // `.fullScreenCover(item: $store.scope(state: \.$overlay, …))`
+                // tears down the cover. The `@Presents` machinery does not
+                // auto-clear on a child action; the parent reducer owns the
+                // nil write.
+                state.overlay = nil
+                return .none
             case .home, .settings, .onboarding, .scheduling, .overlay, .destination:
                 return .none
             }

--- a/EyePostureReminder/TCA/Features/OverlayFeature.swift
+++ b/EyePostureReminder/TCA/Features/OverlayFeature.swift
@@ -8,6 +8,26 @@ import Foundation
 /// Lifecycle events from `OverlayClient.lifecycleEvents` are intentionally
 /// consumed by `SchedulingFeature` (`p0-tca-10`), not here, so this reducer
 /// stays focused on a single presentation instance.
+///
+/// ## Two-phase dismiss (issue #738)
+///
+/// `.dismissTapped` and `.timerExpired` no longer call `overlayClient.dismiss`
+/// directly. Instead they:
+/// 1. flip `state.isDismissing = true` (so the view can react and start
+///    its slide-up + fade exit animation),
+/// 2. emit the corresponding analytics event,
+/// 3. cancel the running timer effect.
+///
+/// The view (or test) must then dispatch `.dismissAnimationCompleted` once
+/// its exit transition has finished. That second action owns the
+/// `overlayClient.dismiss()` side effect (which tears down the
+/// `OverlayManager` `UIWindow` synchronously) and emits `.dismissed`.
+///
+/// This split is required by `#702` Phase 2 (wire `OverlayView` to the
+/// store): without it, the reducer would tear the `UIWindow` down before
+/// `OverlayView`'s ~0.4 s `AppAnimation.overlayDismiss` /
+/// `AppAnimation.overlayAutoDismiss` transition could play, regressing
+/// overlay UX to a hard cut.
 @Reducer
 struct OverlayFeature {
     @ObservableState
@@ -18,7 +38,17 @@ struct OverlayFeature {
         let hapticsEnabled: Bool
         let pauseMediaEnabled: Bool
         var secondsRemaining: Int
+        /// Set as soon as a dismiss path (`.dismissTapped` or
+        /// `.timerExpired`) is acknowledged. The view observes this to drive
+        /// its exit animation; the reducer uses it to suppress duplicate
+        /// dismiss attempts.
         var isDismissing: Bool = false
+        /// Set after `.dismissAnimationCompleted` has triggered the
+        /// `overlayClient.dismiss` effect. Guards against re-entrant
+        /// completion callbacks (e.g. SwiftUI firing `.onCompletion` more
+        /// than once across animation interrupts) double-tearing the
+        /// underlying `UIWindow`.
+        var isFinalized: Bool = false
 
         init(
             id: UUID = UUID(),
@@ -42,6 +72,11 @@ struct OverlayFeature {
         case dismissTapped
         case settingsTapped
         case timerExpired
+        /// Dispatched by the view (or a test driver) once the overlay's
+        /// exit animation has finished. Owns the `overlayClient.dismiss()`
+        /// side effect that tears down the underlying `UIWindow`. Idempotent
+        /// — guarded by `state.isFinalized`.
+        case dismissAnimationCompleted
         case dismissed
     }
 
@@ -82,13 +117,11 @@ struct OverlayFeature {
                 analyticsClient.log(
                     .overlayDismissed(type: type, method: .button, elapsedS: elapsed)
                 )
-                return .merge(
-                    .cancel(id: CancelID.timer),
-                    .run { [overlayClient] send in
-                        await overlayClient.dismiss()
-                        await send(.dismissed)
-                    }
-                )
+                // Two-phase dismiss (#738): cancel the running timer + flip
+                // `isDismissing` so the view animates the exit transition.
+                // The actual `overlayClient.dismiss()` side effect runs once
+                // the view dispatches `.dismissAnimationCompleted`.
+                return .cancel(id: CancelID.timer)
 
             case .settingsTapped:
                 let elapsed = elapsed(in: state)
@@ -107,13 +140,26 @@ struct OverlayFeature {
                 analyticsClient.log(
                     .overlayAutoDismissed(type: state.type, durationS: state.duration)
                 )
-                return .merge(
-                    .cancel(id: CancelID.timer),
-                    .run { [overlayClient] send in
-                        await overlayClient.dismiss()
-                        await send(.dismissed)
-                    }
-                )
+                // Two-phase dismiss (#738): same as `.dismissTapped`. The
+                // auto-dismiss exit animation runs in the view; the
+                // `overlayClient.dismiss()` side effect waits for
+                // `.dismissAnimationCompleted`.
+                return .cancel(id: CancelID.timer)
+
+            case .dismissAnimationCompleted:
+                // Idempotent — multiple completion callbacks (e.g. SwiftUI
+                // animation interrupts) must not tear the overlay window
+                // down twice. Also tolerate arrival in unexpected order
+                // (e.g. before any dismiss path has fired) by gating on
+                // `isDismissing`.
+                guard state.isDismissing, !state.isFinalized else {
+                    return .none
+                }
+                state.isFinalized = true
+                return .run { [overlayClient] send in
+                    await overlayClient.dismiss()
+                    await send(.dismissed)
+                }
 
             case .dismissed:
                 return .cancel(id: CancelID.timer)

--- a/Tests/EyePostureReminderTests/TCA/AppFeatureTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/AppFeatureTests.swift
@@ -226,6 +226,48 @@ final class AppFeatureTests: XCTestCase {
         await store.receive(\.scheduling.notificationRouted)
     }
 
+    // MARK: - Overlay presentation cleanup (#738 — two-phase dismiss completion)
+
+    /// AppFeature owns the `@Presents var overlay` slot. When the child
+    /// `OverlayFeature` finishes its two-phase dismiss chain (issue #738) by
+    /// emitting `.dismissed`, the parent reducer must clear
+    /// `state.overlay = nil` so `RootView`'s
+    /// `.fullScreenCover(item: $store.scope(state: \.$overlay, …))` tears
+    /// down the cover. Without this nil write the cover would stay on screen
+    /// until something else clobbers the slot.
+    func test_overlayPresentedDismissed_clearsOverlayState() async {
+        var initial = AppFeature.State()
+        initial.overlay = OverlayFeature.State(type: .eyes, duration: 10)
+        let store = makeStore(initialState: initial)
+        store.exhaustivity = .off
+
+        await store.send(.overlay(.presented(.dismissed))) {
+            $0.overlay = nil
+        }
+    }
+
+    /// Defence-in-depth: a child action that is *not* `.dismissed` must
+    /// leave the overlay slot intact so the cover stays on screen while the
+    /// reducer handles intermediate phases (`.dismissTapped`,
+    /// `.dismissAnimationCompleted`).
+    func test_overlayPresentedDismissTapped_doesNotClearOverlayState() async {
+        var initial = AppFeature.State()
+        initial.overlay = OverlayFeature.State(type: .eyes, duration: 10)
+        let store = makeStore(initialState: initial)
+        store.exhaustivity = .off
+
+        // The child reducer flips `isDismissing`; the parent leaves the
+        // slot untouched so the overlay window stays alive while the view
+        // animates the exit transition.
+        await store.send(.overlay(.presented(.dismissTapped))) {
+            $0.overlay?.isDismissing = true
+        }
+        XCTAssertNotNil(
+            store.state.overlay,
+            "AppFeature must not clear overlay state until .dismissed arrives"
+        )
+    }
+
     // MARK: - Destination state Equatable conformance
 
     /// `AppFeature.Destination.State` synthesised `Equatable` is required by

--- a/Tests/EyePostureReminderTests/TCA/OverlayFeatureBehaviorTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/OverlayFeatureBehaviorTests.swift
@@ -78,6 +78,7 @@ final class OverlayFeatureBehaviorTests: XCTestCase {
         await clock.advance(by: .seconds(1))
         await store.receive(\.timerTick) { $0.secondsRemaining = 0 }
         await store.receive(\.timerExpired) { $0.isDismissing = true }
+        await store.send(.dismissAnimationCompleted) { $0.isFinalized = true }
         await store.receive(\.dismissed)
 
         XCTAssertEqual(spies.dismissCalls.value, 1,
@@ -101,6 +102,7 @@ final class OverlayFeatureBehaviorTests: XCTestCase {
         await store.receive(\.timerTick) { $0.secondsRemaining = 9 }
 
         await store.send(.dismissTapped) { $0.isDismissing = true }
+        await store.send(.dismissAnimationCompleted) { $0.isFinalized = true }
         await store.receive(\.dismissed)
 
         // Advance well past the original duration: tick effect must be
@@ -118,6 +120,12 @@ final class OverlayFeatureBehaviorTests: XCTestCase {
         )
 
         await store.send(.dismissTapped) { $0.isDismissing = true }
+        // Two-phase dismiss (#738): `overlayClient.dismiss` must NOT have
+        // fired yet — only the animation-completion phase owns that side
+        // effect.
+        XCTAssertEqual(spies.dismissCalls.value, 0,
+                       "overlayClient.dismiss must not fire on dismissTapped alone (two-phase dismiss)")
+        await store.send(.dismissAnimationCompleted) { $0.isFinalized = true }
         await store.receive(\.dismissed)
 
         XCTAssertEqual(spies.dismissCalls.value, 1,
@@ -134,6 +142,7 @@ final class OverlayFeatureBehaviorTests: XCTestCase {
         )
 
         await store.send(.dismissTapped) { $0.isDismissing = true }
+        await store.send(.dismissAnimationCompleted) { $0.isFinalized = true }
         await store.receive(\.dismissed)
 
         let events = spies.analytics.value
@@ -166,6 +175,7 @@ final class OverlayFeatureBehaviorTests: XCTestCase {
         }
 
         await store.send(.dismissTapped) { $0.isDismissing = true }
+        await store.send(.dismissAnimationCompleted) { $0.isFinalized = true }
         await store.receive(\.dismissed)
 
         let events = spies.analytics.value
@@ -192,6 +202,82 @@ final class OverlayFeatureBehaviorTests: XCTestCase {
                        "Re-entrant dismissTapped must not double-log analytics")
         XCTAssertEqual(spies.dismissCalls.value, 0,
                        "Re-entrant dismissTapped must not call overlay.dismiss again")
+    }
+
+    // MARK: - Two-phase dismiss ordering (#738)
+
+    /// Asserts the strict happens-before ordering required by #702 Phase 2:
+    /// **analytics → animation-pending → animation-completed → overlay
+    /// client dismiss → dismissed.** The `overlayClient.dismiss` call is
+    /// gated entirely on `.dismissAnimationCompleted` arriving — it never
+    /// fires off `.dismissTapped` alone.
+    func test_twoPhaseDismiss_dismissTapped_ordering() async {
+        let clock = TestClock()
+        let spies = makeSpies()
+        let store = makeStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 30),
+            clock: clock,
+            spies: spies
+        )
+
+        // Phase 1: tap → analytics + isDismissing flip; no dismiss yet.
+        await store.send(.dismissTapped) { $0.isDismissing = true }
+        XCTAssertEqual(spies.analytics.value.count, 1,
+                       "Analytics emits on dismissTapped, not on completion")
+        XCTAssertEqual(spies.dismissCalls.value, 0,
+                       "overlayClient.dismiss must wait for animation completion")
+
+        // Phase 2: animation completes → overlayClient.dismiss + dismissed.
+        await store.send(.dismissAnimationCompleted) { $0.isFinalized = true }
+        await store.receive(\.dismissed)
+        XCTAssertEqual(spies.dismissCalls.value, 1,
+                       "overlayClient.dismiss must fire exactly once after completion")
+    }
+
+    /// Same ordering contract applied to the auto-dismiss path so the view
+    /// can play `AppAnimation.overlayAutoDismiss` before the underlying
+    /// `UIWindow` is torn down.
+    func test_twoPhaseDismiss_timerExpired_ordering() async {
+        let clock = TestClock()
+        let spies = makeSpies()
+        let store = makeStore(
+            initialState: OverlayFeature.State(type: .posture, duration: 10),
+            clock: clock,
+            spies: spies
+        )
+
+        await store.send(.timerExpired) { $0.isDismissing = true }
+        XCTAssertEqual(spies.analytics.value.count, 1,
+                       "Analytics emits on timerExpired, not on completion")
+        XCTAssertEqual(spies.dismissCalls.value, 0,
+                       "overlayClient.dismiss must wait for animation completion")
+
+        await store.send(.dismissAnimationCompleted) { $0.isFinalized = true }
+        await store.receive(\.dismissed)
+        XCTAssertEqual(spies.dismissCalls.value, 1,
+                       "overlayClient.dismiss must fire exactly once after completion")
+    }
+
+    /// Defence-in-depth: a re-entrant `.dismissAnimationCompleted` (e.g.
+    /// SwiftUI animation interrupt firing the completion callback twice)
+    /// must not call `overlayClient.dismiss` a second time.
+    func test_dismissAnimationCompleted_reentrant_doesNotCallOverlayDismissTwice() async {
+        let clock = TestClock()
+        let spies = makeSpies()
+        let store = makeStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 10),
+            clock: clock,
+            spies: spies
+        )
+
+        await store.send(.dismissTapped) { $0.isDismissing = true }
+        await store.send(.dismissAnimationCompleted) { $0.isFinalized = true }
+        await store.receive(\.dismissed)
+        XCTAssertEqual(spies.dismissCalls.value, 1)
+
+        await store.send(.dismissAnimationCompleted)
+        XCTAssertEqual(spies.dismissCalls.value, 1,
+                       "Re-entrant .dismissAnimationCompleted must not fire overlay.dismiss again")
     }
 
     // MARK: - .settingsTapped: analytics-only side effect
@@ -265,6 +351,7 @@ final class OverlayFeatureBehaviorTests: XCTestCase {
         )
 
         await store.send(.timerExpired) { $0.isDismissing = true }
+        await store.send(.dismissAnimationCompleted) { $0.isFinalized = true }
         await store.receive(\.dismissed)
 
         let events = spies.analytics.value
@@ -288,6 +375,11 @@ final class OverlayFeatureBehaviorTests: XCTestCase {
         )
 
         await store.send(.timerExpired) { $0.isDismissing = true }
+        // Two-phase dismiss (#738): the side-effect doesn't fire until the
+        // view (or this test) sends `.dismissAnimationCompleted`.
+        XCTAssertEqual(spies.dismissCalls.value, 0,
+                       "overlayClient.dismiss must not fire on timerExpired alone (two-phase dismiss)")
+        await store.send(.dismissAnimationCompleted) { $0.isFinalized = true }
         await store.receive(\.dismissed)
 
         XCTAssertEqual(spies.dismissCalls.value, 1)

--- a/Tests/EyePostureReminderTests/TCA/OverlayFeatureTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/OverlayFeatureTests.swift
@@ -50,6 +50,7 @@ final class OverlayFeatureTests: XCTestCase {
         XCTAssertTrue(state.hapticsEnabled, "hapticsEnabled defaults to true")
         XCTAssertFalse(state.pauseMediaEnabled, "pauseMediaEnabled defaults to false")
         XCTAssertFalse(state.isDismissing, "isDismissing defaults to false")
+        XCTAssertFalse(state.isFinalized, "isFinalized defaults to false")
         XCTAssertEqual(state.secondsRemaining, 10)
     }
 
@@ -63,8 +64,15 @@ final class OverlayFeatureTests: XCTestCase {
         } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
 
         await store.send(.onAppear)
+        // Two-phase dismiss (#738): `.timerExpired` flips `isDismissing`
+        // and emits analytics, but the actual `overlayClient.dismiss()`
+        // side effect is deferred until the view (or this test) sends
+        // `.dismissAnimationCompleted`.
         await store.receive(\.timerExpired) {
             $0.isDismissing = true
+        }
+        await store.send(.dismissAnimationCompleted) {
+            $0.isFinalized = true
         }
         await store.receive(\.dismissed)
     }
@@ -96,6 +104,9 @@ final class OverlayFeatureTests: XCTestCase {
         await store.receive(\.timerExpired) {
             $0.isDismissing = true
         }
+        await store.send(.dismissAnimationCompleted) {
+            $0.isFinalized = true
+        }
         await store.receive(\.dismissed)
     }
 
@@ -111,22 +122,26 @@ final class OverlayFeatureTests: XCTestCase {
         await store.receive(\.timerExpired) {
             $0.isDismissing = true
         }
+        await store.send(.dismissAnimationCompleted) {
+            $0.isFinalized = true
+        }
         await store.receive(\.dismissed)
     }
 
     // MARK: - .dismissTapped
 
-    func test_dismissTapped_setsIsDismissingAndDismisses() async {
+    func test_dismissTapped_setsIsDismissingButDoesNotEmitDismissed() async {
         let store = TestStore(
             initialState: OverlayFeature.State(type: .eyes, duration: 10)
         ) {
             OverlayFeature()
         } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
 
+        // Phase 1: tap flips `isDismissing` only — no `.dismissed` follow-up
+        // because the view still has to play its exit animation. (#738)
         await store.send(.dismissTapped) {
             $0.isDismissing = true
         }
-        await store.receive(\.dismissed)
     }
 
     func test_dismissTapped_whileAlreadyDismissing_isNoOp() async {
@@ -153,17 +168,19 @@ final class OverlayFeatureTests: XCTestCase {
 
     // MARK: - .timerExpired
 
-    func test_timerExpired_setsIsDismissingAndDismisses() async {
+    func test_timerExpired_setsIsDismissingButDoesNotEmitDismissed() async {
         let store = TestStore(
             initialState: OverlayFeature.State(type: .posture, duration: 5)
         ) {
             OverlayFeature()
         } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
 
+        // Phase 1: auto-expiry flips `isDismissing` only — no `.dismissed`
+        // follow-up because the view still has to play its exit animation.
+        // (#738)
         await store.send(.timerExpired) {
             $0.isDismissing = true
         }
-        await store.receive(\.dismissed)
     }
 
     func test_timerExpired_whileAlreadyDismissing_isNoOp() async {
@@ -174,6 +191,81 @@ final class OverlayFeatureTests: XCTestCase {
         } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
 
         await store.send(.timerExpired)
+    }
+
+    // MARK: - .dismissAnimationCompleted (#738 — two-phase dismiss completion)
+
+    /// `.dismissAnimationCompleted` after `.dismissTapped` flips
+    /// `isFinalized` and triggers the actual dismiss side-effect chain.
+    func test_dismissAnimationCompleted_afterDismissTapped_dispatchesDismissed() async {
+        let store = TestStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 10)
+        ) {
+            OverlayFeature()
+        } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
+
+        await store.send(.dismissTapped) {
+            $0.isDismissing = true
+        }
+        await store.send(.dismissAnimationCompleted) {
+            $0.isFinalized = true
+        }
+        await store.receive(\.dismissed)
+    }
+
+    /// `.dismissAnimationCompleted` after `.timerExpired` flips
+    /// `isFinalized` and triggers the actual dismiss side-effect chain.
+    func test_dismissAnimationCompleted_afterTimerExpired_dispatchesDismissed() async {
+        let store = TestStore(
+            initialState: OverlayFeature.State(type: .posture, duration: 5)
+        ) {
+            OverlayFeature()
+        } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
+
+        await store.send(.timerExpired) {
+            $0.isDismissing = true
+        }
+        await store.send(.dismissAnimationCompleted) {
+            $0.isFinalized = true
+        }
+        await store.receive(\.dismissed)
+    }
+
+    /// Idempotency guard: re-arrival of `.dismissAnimationCompleted` (e.g.
+    /// SwiftUI animation interrupt firing the completion callback twice)
+    /// must not dispatch `.dismissed` a second time, which would otherwise
+    /// double-tear the underlying `UIWindow` via `overlayClient.dismiss`.
+    func test_dismissAnimationCompleted_reentrant_isNoOp() async {
+        let store = TestStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 10)
+        ) {
+            OverlayFeature()
+        } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
+
+        await store.send(.dismissTapped) {
+            $0.isDismissing = true
+        }
+        await store.send(.dismissAnimationCompleted) {
+            $0.isFinalized = true
+        }
+        await store.receive(\.dismissed)
+
+        // Second arrival is a pure no-op — no state delta, no follow-up.
+        await store.send(.dismissAnimationCompleted)
+    }
+
+    /// Out-of-order arrival: a stray `.dismissAnimationCompleted` before any
+    /// dismiss path has fired must not flip `isFinalized` or trigger the
+    /// dismiss side effect — the reducer would be free to interpret it as
+    /// "dismiss now" otherwise, breaking the `isDismissing` precondition.
+    func test_dismissAnimationCompleted_beforeAnyDismissPath_isNoOp() async {
+        let store = TestStore(
+            initialState: OverlayFeature.State(type: .eyes, duration: 10)
+        ) {
+            OverlayFeature()
+        } withDependencies: { TCATestDependencies.applyAllSilentClients(&$0) }
+
+        await store.send(.dismissAnimationCompleted)
     }
 
     // MARK: - .dismissed


### PR DESCRIPTION
## Summary

Closes #738.

Splits `OverlayFeature.dismissTapped` / `.timerExpired` so they no longer call `overlayClient.dismiss()` synchronously. Adds `.dismissAnimationCompleted` which owns the dismiss side-effect after the view's exit animation finishes. Required by #702 Phase 2 (wire `OverlayView` to the store) so SwiftUI's `AppAnimation.overlayDismiss` / `.overlayAutoDismiss` transition can play before `OverlayManager`'s `UIWindow` is torn down.

## Changes

### `EyePostureReminder/TCA/Features/OverlayFeature.swift`
- `State` gains `isFinalized: Bool` (defaults `false`) — guards against re-entrant completion callbacks double-tearing the underlying `UIWindow`.
- `Action` gains `.dismissAnimationCompleted`.
- `.dismissTapped` / `.timerExpired` now emit analytics + cancel timer + flip `isDismissing` only — no `overlayClient.dismiss()`, no `.dismissed`.
- Doc comment on the type explains the two-phase contract and why it matters for #702 Phase 2.

### `EyePostureReminder/TCA/AppFeature.swift`
- New case `.overlay(.presented(.dismissed))` clears `state.overlay = nil` so `RootView`'s `.fullScreenCover(item: $store.scope(state: \\.$overlay, …))` tears down cleanly. The `@Presents` machinery does not auto-clear on a child action — the parent reducer owns the nil write.

### Tests

- `OverlayFeatureTests` / `OverlayFeatureBehaviorTests` updated to drive the two-phase chain (every `.dismissTapped` / `.timerExpired` flow now follows up with `.dismissAnimationCompleted` before `.dismissed`).
- New tests:
  - **Ordering** (`test_twoPhaseDismiss_dismissTapped_ordering`, `…_timerExpired_ordering`): asserts analytics → animation-pending → completion → `overlayClient.dismiss` → `.dismissed`. `overlayClient.dismiss` count is verified to be 0 between phase 1 and phase 2.
  - **Idempotent re-entry** (`test_dismissAnimationCompleted_reentrant_isNoOp`, `…_doesNotCallOverlayDismissTwice`): a second `.dismissAnimationCompleted` does not fire `overlayClient.dismiss` again.
  - **Out-of-order arrival** (`test_dismissAnimationCompleted_beforeAnyDismissPath_isNoOp`): stray `.dismissAnimationCompleted` before any dismiss path is a pure no-op.
  - **AppFeature wiring** (`test_overlayPresentedDismissed_clearsOverlayState`, `…dismissTapped_doesNotClearOverlayState`): parent clears the slot only on `.dismissed`, leaving it intact during intermediate child actions.

## Verification

```text
$ ./scripts/build.sh all
✓ Build succeeded
✓ Lint passed
✓ Tests passed (2199 tests, 0 failures, 113 s)
```

Diff: 5 files changed, 301 insertions(+), 18 deletions(-).

## Acceptance criteria coverage

| AC | Status |
|----|--------|
| 1. New `.dismissAnimationCompleted` action owns `overlayClient.dismiss` | ✅ |
| 2. `.dismissTapped` / `.timerExpired` no longer fire dismiss directly | ✅ |
| 3. `AppFeature` clears `state.overlay = nil` on `.dismissed` | ✅ |
| 4. New tests assert the two-phase ordering | ✅ |
| 5. Existing tests continue to pass; `./scripts/build.sh all` green | ✅ |

## Out of scope (unchanged)

- Re-wiring `OverlayView` / `OverlayManager` to dispatch `.dismissAnimationCompleted` after their existing exit animation completion handlers — that is #702 Phase 2 itself; this PR delivers only the reducer surface needed to make Phase 2 non-regressing.

## Risk

Low. The new completion phase is required to surface the dismiss side effect, and existing TestStore tests would have caught any silent behaviour change. The only observable production-side change today is that `AppFeature` now nils out the overlay slot on `.dismissed` — nothing currently presents the overlay through `AppFeature`, so there is no live caller to regress before #702 Phase 2 wires it.

---
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>