### PR TITLE
fix(tca): seed SchedulingFeature.settings synchronously to close UI-test backdoor race (#737)

### DIFF
--- a/EyePostureReminder/App/EyePostureReminderApp.swift
+++ b/EyePostureReminder/App/EyePostureReminderApp.swift
@@ -24,11 +24,26 @@ struct EyePostureReminderApp: App {
         // the stale `true` value left in UserDefaults from the previous test
         // launch and onboarding tests landed on Home (#707).
         Self.preSeedHasSeenOnboardingFromLaunchArgsIfNeeded()
+        // Mirror overlay-affecting launch args into UserDefaults BEFORE the
+        // settings seed below reads them, for the same UIApplicationMain
+        // ordering reason. Without this, `--show-overlay-eyes` /
+        // `--show-overlay-posture` would leave `state.scheduling.settings`
+        // stuck on the previous test launch's value (or `defaultEyes`) and
+        // `reminderNotificationEffect` would race with the
+        // `SettingsClient.stream` first emission, intermittently showing
+        // overlays at `breakDuration: 0` (#737).
+        Self.preSeedReminderSettingsFromLaunchArgsIfNeeded()
 #endif
         var initialState = AppFeature.State()
         initialState.hasSeenOnboarding = UserDefaults.standard.bool(
             forKey: AppStorageKey.hasSeenOnboarding
         )
+        // Seed scheduling.settings synchronously from UserDefaults so the TCA
+        // root state observes the persisted (or `--show-overlay-*`-inflated)
+        // `breakDuration` immediately, before `SchedulingFeature.start`
+        // installs the `SettingsClient` stream subscription. Closes the
+        // settings-load race documented in #737.
+        initialState.scheduling.settings = SettingsStore.eyesSnapshotFromUserDefaults()
         self.store = Store(initialState: initialState) { AppFeature() }
     }
 
@@ -60,6 +75,40 @@ struct EyePostureReminderApp: App {
             UserDefaults.standard.set(true, forKey: AppStorageKey.hasSeenOnboarding)
         }
     }
+
+    /// Mirrors the `--show-overlay-eyes` / `--show-overlay-posture` launch
+    /// arguments into the `kshana.eyes.breakDuration` /
+    /// `kshana.posture.breakDuration` UserDefaults keys before
+    /// `SettingsStore.eyesSnapshotFromUserDefaults()` reads them in `init()`.
+    ///
+    /// Mirrors the inflation that `AppDelegate.applyUITestLaunchArguments`
+    /// applies via `SettingsStore.eyesBreakDuration = uiTestOverlayBreakDuration`,
+    /// but runs synchronously in `App.init` so the seed picks it up — the
+    /// `AppDelegate` pass runs from `didFinishLaunchingWithOptions`, after
+    /// `App.init` has already returned. Without this guard the TCA root
+    /// `state.scheduling.settings.breakDuration` would race with
+    /// `SettingsClient.stream`'s first emission and the UI-test overlay
+    /// backdoor (now dispatched through `store.send(.notificationRouted)`)
+    /// would intermittently show 0-second overlays that auto-dismiss before
+    /// `OverlayUITests` can interact with them (#737).
+    ///
+    /// `#if DEBUG` keeps the launch-arg backdoor out of Release/TestFlight
+    /// builds (re: #350/#405).
+    private static func preSeedReminderSettingsFromLaunchArgsIfNeeded() {
+        let args = CommandLine.arguments
+        let inflateForOverlayLaunchArg =
+            args.contains("--show-overlay-eyes") ||
+            args.contains("--show-overlay-posture")
+        guard inflateForOverlayLaunchArg else { return }
+        UserDefaults.standard.set(
+            AppDelegate.uiTestOverlayBreakDuration,
+            forKey: SettingsStore.Keys.eyesBreakDuration
+        )
+        UserDefaults.standard.set(
+            AppDelegate.uiTestOverlayBreakDuration,
+            forKey: SettingsStore.Keys.postureBreakDuration
+        )
+    }
 #endif
 
     var body: some Scene {
@@ -86,13 +135,24 @@ struct EyePostureReminderApp: App {
 #if DEBUG
     /// UI test mode: if a specific overlay type was requested via launch
     /// arguments, trigger it after SwiftUI has attached/activated the window.
+    ///
+    /// Routes through `store.send(.notificationRouted(.reminder(type)))` —
+    /// the same path UNUserNotificationCenter delivery takes via
+    /// `AppDelegate.dispatchNotificationRoute` — so the backdoor exercises
+    /// production reducer code instead of the deprecated
+    /// `AppCoordinator.handleNotification` shim that #677 / #702 are
+    /// dismantling. The synchronous `state.scheduling.settings` seed in
+    /// `init()` plus the `--show-overlay-*` UserDefaults inflation guarantees
+    /// the reducer reads the inflated `breakDuration` immediately, without
+    /// racing the `SettingsClient.stream` first emission (#737).
+    ///
     /// `#if DEBUG` ensures this backdoor is compiled out of Release builds
     /// (re: #350/#405).
     private func presentUITestOverlayIfNeeded() {
         Task { @MainActor in
             await Task.yield()
             if let type = appDelegate.consumeUITestOverlayType() {
-                coordinator.handleNotification(for: type)
+                store.send(.notificationRouted(.reminder(type)))
             }
         }
     }

--- a/EyePostureReminder/Models/SettingsStore.swift
+++ b/EyePostureReminder/Models/SettingsStore.swift
@@ -320,7 +320,12 @@ final class SettingsStore: ObservableObject {
 
 // MARK: - Keys
 
-private extension SettingsStore {
+extension SettingsStore {
+    /// `UserDefaults` key namespace for every persisted `SettingsStore`
+    /// property. Exposed at module scope (not `private`) so non-`@MainActor`
+    /// callers — for example the `EyePostureReminderApp.init` synchronous
+    /// settings seed (#737) — can read the same canonical keys without
+    /// duplicating string literals that would silently drift on rename.
     enum Keys {
         static let globalEnabled          = "kshana.globalEnabled"
         static let eyesEnabled            = "kshana.eyes.enabled"
@@ -336,6 +341,41 @@ private extension SettingsStore {
         static let pauseDuringFocus       = "kshana.pauseDuringFocus"
         static let pauseWhileDriving      = "kshana.pauseWhileDriving"
         static let notificationFallbackEnabled = "kshana.notificationFallbackEnabled"
+    }
+}
+
+// MARK: - Synchronous Seed (#737)
+
+extension SettingsStore {
+    /// Synchronous, non-actor-isolated read of the persisted eyes-side
+    /// `ReminderSettings` directly from the supplied `UserDefaults`.
+    ///
+    /// `EyePostureReminderApp.init()` calls this to seed the TCA root
+    /// `state.scheduling.settings` *before* `SchedulingFeature.start` runs,
+    /// closing the settings-load race that previously left
+    /// `reminderNotificationEffect` reading `breakDuration: 0` and showing
+    /// auto-dismissing overlays during the UI-test backdoor (#737).
+    ///
+    /// Falls back to `ReminderSettings.defaultEyes` for any key not yet
+    /// persisted (first cold launch after install). Per the docstring at the
+    /// top of `SchedulingFeature` the eyes-side snapshot is shared by both
+    /// reminder types until per-type settings land.
+    ///
+    /// Follow-up (#737): retire this helper once `SettingsClient.liveValue`
+    /// exposes a synchronous initial-value accessor that the AppFeature root
+    /// reducer can read at construction time without bouncing to the main
+    /// actor.
+    nonisolated static func eyesSnapshotFromUserDefaults(
+        _ defaults: UserDefaults = .standard
+    ) -> ReminderSettings {
+        let fallback = ReminderSettings.defaultEyes
+        let interval = defaults.object(forKey: Keys.eyesInterval) != nil
+            ? defaults.double(forKey: Keys.eyesInterval)
+            : fallback.interval
+        let breakDuration = defaults.object(forKey: Keys.eyesBreakDuration) != nil
+            ? defaults.double(forKey: Keys.eyesBreakDuration)
+            : fallback.breakDuration
+        return ReminderSettings(interval: interval, breakDuration: breakDuration)
     }
 }
 

--- a/Tests/EyePostureReminderTests/Models/SettingsStoreSeedTests.swift
+++ b/Tests/EyePostureReminderTests/Models/SettingsStoreSeedTests.swift
@@ -1,0 +1,119 @@
+import XCTest
+
+@testable import EyePostureReminder
+
+/// Coverage for `SettingsStore.eyesSnapshotFromUserDefaults` — the
+/// non-actor-isolated synchronous read used by `EyePostureReminderApp.init`
+/// to seed the TCA root `state.scheduling.settings` before the
+/// `SettingsClient.stream` first emission lands. Closes the settings-load
+/// race that previously left `reminderNotificationEffect` reading
+/// `breakDuration: 0` and showing auto-dismissing overlays during the
+/// UI-test backdoor (#737).
+final class SettingsStoreSeedTests: XCTestCase {
+
+    private var defaults: UserDefaults!
+    private let suiteName = "SettingsStoreSeedTests.\(UUID().uuidString)"
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    // MARK: - Empty-store fallback
+
+    func test_eyesSnapshot_emptyDefaults_fallsBackToDefaultEyes() {
+        let snapshot = SettingsStore.eyesSnapshotFromUserDefaults(defaults)
+        XCTAssertEqual(
+            snapshot, ReminderSettings.defaultEyes,
+            "First-cold-launch seed must fall back to ReminderSettings.defaultEyes"
+        )
+    }
+
+    func test_eyesSnapshot_emptyDefaults_breakDurationIsNonZero() {
+        let snapshot = SettingsStore.eyesSnapshotFromUserDefaults(defaults)
+        XCTAssertGreaterThan(
+            snapshot.breakDuration, 0,
+            "Seed must never produce breakDuration: 0 — that is the exact race "
+            + "#737 closes (overlay would auto-dismiss before UITests interact)"
+        )
+    }
+
+    func test_eyesSnapshot_emptyDefaults_intervalIsNonZero() {
+        let snapshot = SettingsStore.eyesSnapshotFromUserDefaults(defaults)
+        XCTAssertGreaterThan(
+            snapshot.interval, 0,
+            "Seed must never produce interval: 0 — thresholdReachedEffect "
+            + "guards on `interval > 0` and would silently no-op"
+        )
+    }
+
+    // MARK: - Persisted-value reads
+
+    func test_eyesSnapshot_persistedInterval_isReturned() {
+        defaults.set(900.0, forKey: SettingsStore.Keys.eyesInterval)
+        let snapshot = SettingsStore.eyesSnapshotFromUserDefaults(defaults)
+        XCTAssertEqual(snapshot.interval, 900)
+    }
+
+    func test_eyesSnapshot_persistedBreakDuration_isReturned() {
+        defaults.set(45.0, forKey: SettingsStore.Keys.eyesBreakDuration)
+        let snapshot = SettingsStore.eyesSnapshotFromUserDefaults(defaults)
+        XCTAssertEqual(snapshot.breakDuration, 45)
+    }
+
+    func test_eyesSnapshot_bothKeysPersisted_returnsExactValues() {
+        defaults.set(1500.0, forKey: SettingsStore.Keys.eyesInterval)
+        defaults.set(30.0, forKey: SettingsStore.Keys.eyesBreakDuration)
+        let snapshot = SettingsStore.eyesSnapshotFromUserDefaults(defaults)
+        XCTAssertEqual(snapshot, ReminderSettings(interval: 1500, breakDuration: 30))
+    }
+
+    // MARK: - UI-test inflation parity
+
+    /// Mirrors the `--show-overlay-eyes` / `--show-overlay-posture` pre-seed
+    /// in `EyePostureReminderApp.preSeedReminderSettingsFromLaunchArgsIfNeeded`:
+    /// once the inflated 600 s value lands in UserDefaults, the seed must
+    /// surface it so the TCA `reminderNotificationEffect` reads
+    /// `breakDuration: 600` immediately, with no race against the
+    /// `SettingsClient.stream` first emission.
+    func test_eyesSnapshot_uiTestOverlayInflation_isHonoured() {
+#if DEBUG
+        defaults.set(
+            AppDelegate.uiTestOverlayBreakDuration,
+            forKey: SettingsStore.Keys.eyesBreakDuration
+        )
+        let snapshot = SettingsStore.eyesSnapshotFromUserDefaults(defaults)
+        XCTAssertEqual(
+            snapshot.breakDuration,
+            AppDelegate.uiTestOverlayBreakDuration,
+            "Seed must reflect the --show-overlay-* inflation written by "
+            + "EyePostureReminderApp.preSeedReminderSettingsFromLaunchArgsIfNeeded"
+        )
+#else
+        throw XCTSkip("uiTestOverlayBreakDuration is DEBUG-only")
+#endif
+    }
+
+    // MARK: - Partial-key persistence
+
+    func test_eyesSnapshot_onlyIntervalPersisted_breakDurationFallsBack() {
+        defaults.set(800.0, forKey: SettingsStore.Keys.eyesInterval)
+        let snapshot = SettingsStore.eyesSnapshotFromUserDefaults(defaults)
+        XCTAssertEqual(snapshot.interval, 800)
+        XCTAssertEqual(snapshot.breakDuration, ReminderSettings.defaultEyes.breakDuration)
+    }
+
+    func test_eyesSnapshot_onlyBreakDurationPersisted_intervalFallsBack() {
+        defaults.set(15.0, forKey: SettingsStore.Keys.eyesBreakDuration)
+        let snapshot = SettingsStore.eyesSnapshotFromUserDefaults(defaults)
+        XCTAssertEqual(snapshot.interval, ReminderSettings.defaultEyes.interval)
+        XCTAssertEqual(snapshot.breakDuration, 15)
+    }
+}

--- a/Tests/EyePostureReminderTests/TCA/AppFeatureTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/AppFeatureTests.swift
@@ -226,6 +226,37 @@ final class AppFeatureTests: XCTestCase {
         await store.receive(\.scheduling.notificationRouted)
     }
 
+    /// #737: When `state.scheduling.settings` is seeded with a non-zero
+    /// `breakDuration` (mirroring `EyePostureReminderApp.init()`'s synchronous
+    /// `SettingsStore.eyesSnapshotFromUserDefaults` read), the seeded value
+    /// must survive `.notificationRouted(.reminder(.eyes))` reduction so
+    /// `SchedulingFeature.reminderNotificationEffect` calls
+    /// `overlayClient.show` with the correct duration. Pre-#737 the seed was
+    /// always `(interval: 0, breakDuration: 0)` regardless of UserDefaults,
+    /// so the UI-test backdoor would intermittently fire `overlayClient.show(
+    /// type, 0, …)` and the overlay would auto-dismiss before any UITest
+    /// could interact with it.
+    func test_notificationRouted_preservesSeededSchedulingSettings() async {
+        var initial = AppFeature.State()
+        initial.scheduling.settings = ReminderSettings(interval: 1200, breakDuration: 600)
+        let store = makeStore(initialState: initial)
+        store.exhaustivity = .off
+
+        XCTAssertEqual(store.state.scheduling.settings.breakDuration, 600,
+                       "Seed must be observable on the initial state before any action runs")
+
+        await store.send(.notificationRouted(.reminder(.eyes)))
+        await store.receive(\.scheduling.notificationRouted)
+
+        XCTAssertEqual(store.state.scheduling.settings.breakDuration, 600,
+                       "Seeded breakDuration must survive the action chain — this is the "
+                       + "value SchedulingFeature.reminderNotificationEffect feeds into "
+                       + "overlayClient.show(type, duration, _, _).")
+        XCTAssertEqual(store.state.scheduling.settings.interval, 1200,
+                       "Seeded interval must also survive — thresholdReachedEffect guards "
+                       + "on `interval > 0` and would silently no-op otherwise.")
+    }
+
     // MARK: - Overlay presentation cleanup (#738 — two-phase dismiss completion)
 
     /// AppFeature owns the `@Presents var overlay` slot. When the child


### PR DESCRIPTION
Closes #737

## Summary

Eliminates the settings-load race that left `state.scheduling.settings` at `(interval: 0, breakDuration: 0)` when the UI-test overlay backdoor dispatched `.notificationRouted`, causing `reminderNotificationEffect` to call `overlayClient.show(type, 0, _, _)` and the overlay to auto-dismiss before `OverlayUITests` could interact with it.

## Approach (Option A from #737)

Synchronous seed in `EyePostureReminderApp.init`, mirroring the existing `hasSeenOnboarding` pre-seed (#707):

1. **`SettingsStore.eyesSnapshotFromUserDefaults`** (new, `nonisolated static`) reads `kshana.eyes.{interval,breakDuration}` synchronously, falling back to `ReminderSettings.defaultEyes` when keys are absent.
2. **`EyePostureReminderApp.init`** seeds `initialState.scheduling.settings` with that snapshot before constructing the `Store`.
3. **`preSeedReminderSettingsFromLaunchArgsIfNeeded`** (`#if DEBUG`) mirrors `--show-overlay-eyes` / `--show-overlay-posture` into UserDefaults via the inflated `AppDelegate.uiTestOverlayBreakDuration` so the seed picks the inflated value up. `AppDelegate.applyUITestLaunchArguments` runs from `didFinishLaunchingWithOptions`, which UIApplicationMain dispatches AFTER `App.init` returns — same UIKit ordering rationale as #707.
4. **`presentUITestOverlayIfNeeded`** now dispatches `store.send(.notificationRouted(.reminder(type)))` instead of `coordinator.handleNotification(for: type)`, exercising production TCA reducer code and removing one more `AppCoordinator` hold blocking #677 / #702 phase 7-8.

`SettingsStore.Keys` is internalised (was `private`) so the seed and tests reference the canonical key constants instead of duplicating string literals.

## Acceptance criteria (from #737)

- [x] `presentUITestOverlayIfNeeded` dispatches `store.send(.notificationRouted(.reminder(type)))`.
- [x] With `--show-overlay-eyes` / `--show-overlay-posture`, the inflated `breakDuration` is in `state.scheduling.settings` by the time the backdoor dispatches.
- [x] `AppCoordinator` reference removed from `presentUITestOverlayIfNeeded`'s body.
- [x] `./scripts/build.sh all` green (2208 tests, 0 failures, 115 s).

## Tests

- **`SettingsStoreSeedTests`** (9 cases): empty-defaults fallback, non-zero-on-empty invariants, persisted reads, partial-key persistence, UI-test inflation parity.
- **`AppFeatureTests.test_notificationRouted_preservesSeededSchedulingSettings`**: confirms a non-zero seeded `breakDuration` survives `.notificationRouted(.reminder(.eyes))` reduction so `reminderNotificationEffect` feeds the correct duration into `overlayClient.show`.

## Risk

Low — additive seed + helper. The TCA dispatch swap matches the path UNUserNotificationCenter delivery already uses via `AppDelegate.dispatchNotificationRoute`, and the existing `AppFeatureTests.test_notificationRouted_reminder_forwardsToScheduling` covers the wiring contract.

## Out of scope

- Wiring `OverlayView` to `OverlayFeature` (#702 Phase 2).
- `coordinator: AppCoordinator` `@StateObject` removal from the App struct (#702 Phase 7).

## Pairs with

- #717 (`#711` overlay-flake fix — AppCoordinator-side pre-seed in `AppDelegate.preSeedUITestDefaults`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>