### PR TITLE
ci: purge SDK-bound ModuleCache.noindex to fix SwiftShims mtime drift (#745)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,33 @@ jobs:
           restore-keys: |
             spm-sourcepackages-${{ runner.os }}-xcode${{ env.XCODE_VERSION }}-
 
+      # ── Purge SDK-bound caches (#745) ────────────────────────────────────────
+      # The cached DerivedData restored above contains ModuleCache.noindex with
+      # precompiled `.pcm` module files (notably `SwiftShims-*.pcm`) that record
+      # the mtime of the SDK's `usr/lib/swift/shims/module.modulemap` they were
+      # built against. macos-15 runners and Xcode_16.4 patches across runs can
+      # have differing SDK file mtimes (cold-image refreshes, SDK shims relinked
+      # by Xcode), so the cached pcm refuses to load on the next run with:
+      #   error: file '.../SwiftShims-*.pcm' has been modified since the module
+      #   file '...' was built: mtime changed (was X, now Y)
+      # That trips xcodebuild with `exit 65` *before* tests run, so no
+      # `TestResults.xcresult` is produced — making the failure look like a
+      # source/test-compile bug (#746, #747) when the real cause is the SDK
+      # mtime drift documented in #745. Discarding both caches forces the
+      # compiler to rebuild them against the current runner's SDK while still
+      # keeping the much larger `Build/` intermediates (.swiftmodule, object
+      # files) around for incremental reuse — so the speedup from caching is
+      # preserved without the false failures.
+      - name: Purge SDK-bound module caches (avoid SwiftShims mtime drift)
+        run: |
+          for SUBDIR in ModuleCache.noindex SDKStatCaches.noindex; do
+            CACHE_PATH="${{ env.DERIVED_DATA_PATH }}/${SUBDIR}"
+            if [[ -d "$CACHE_PATH" ]]; then
+              echo "Removing stale ${SUBDIR} (would otherwise trigger SwiftShims mtime mismatch — see #745)"
+              rm -rf "$CACHE_PATH"
+            fi
+          done
+
       # ── Homebrew package cache ───────────────────────────────────────────────
       - name: Cache Homebrew packages
         id: brew-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,17 @@ to make the TCA Phase-1 reducers testable in isolation.
 
 ### 🛠 Internal / CI / Style
 
+- **#745 — Purge SDK-bound `ModuleCache.noindex` / `SDKStatCaches.noindex`
+  before each CI build.** The cached `DerivedData` restored across runs
+  contained precompiled `SwiftShims-*.pcm` files that recorded an SDK
+  `module.modulemap` mtime which drifts between macos-15 runner refreshes,
+  causing `xcodebuild` to fail with `error: file '.../SwiftShims-*.pcm'
+  has been modified since the module file '...' was built: mtime changed`
+  and `exit 65` *before* tests ran (no `TestResults.xcresult` produced).
+  Wiping just those two SDK-bound subdirectories preserves the much larger
+  `Build/` intermediates for incremental reuse while removing the false
+  failure surface that was being mis-attributed to source-compile bugs in
+  #746 / #747.
 - **#663 — Integrate SwiftLint into CI** per Google Swift Style.
 - **#685 — Line-wrap pass** in Views to comply with the 100-char column
   limit (closes #650).


### PR DESCRIPTION
## Summary

Closes #745.

`scripts/build.sh build` (run by the `Build & Test` job before tests) was
failing on PR runs with the SwiftShims module-cache `mtime` mismatch error
documented in #745:

```
<unknown>:0: error: file '/Applications/Xcode_16.4.app/.../usr/lib/swift/shims/module.modulemap'
has been modified since the module file
'.../DerivedData/ModuleCache.noindex/2ORBC4L18CUBQ/SwiftShims-*.pcm' was built:
mtime changed (was 1778476540, now 1777267324)
```

Repeated 23× then `Process completed with exit code 65` — *before* tests
ran, so no `TestResults.xcresult` was uploaded. Confirmed on the latest
failed run for PR #724 (run [25905852039](https://github.com/yashasg/fantastic-octo-fortnight/actions/runs/25905852039)).

## Root cause

The `Build & Test` job restores a per-branch DerivedData cache:

```yaml
- name: Cache DerivedData
  uses: actions/cache@…
  with:
    path: ${{ env.DERIVED_DATA_PATH }}
    key: derived-data-branch-…-${{ hashFiles('Package.swift', 'Package.resolved', 'scripts/build.sh', '.github/workflows/ci.yml') }}
```

That cache contains `ModuleCache.noindex/`, which holds precompiled
`SwiftShims-*.pcm` files. Each `.pcm` records the **mtime** of the SDK
`module.modulemap` it was built against. macos-15 runners share the same
Xcode 16.4 build, but the SDK file `mtime` drifts across runner
images (cold-image refresh, SDK shim relink). When the next run loads
the cached pcm, the compiler refuses it because the recorded mtime
no longer matches.

This was being mis-attributed to source-compile bugs in #746 / #747,
but the same root cause was hitting #703, #716, #717, #723, #724, #733
intermittently.

## Fix

Drop **only** `ModuleCache.noindex/` and `SDKStatCaches.noindex/` right
after the cache restore step, before any `xcodebuild` invocation. Both
rebuild in seconds against the current runner's SDK; the much larger
`Build/` intermediates (`.swiftmodule`, `.o` files) stay cached so
incremental build speed is unchanged.

```yaml
- name: Purge SDK-bound module caches (avoid SwiftShims mtime drift)
  run: |
    for SUBDIR in ModuleCache.noindex SDKStatCaches.noindex; do
      CACHE_PATH="${{ env.DERIVED_DATA_PATH }}/${SUBDIR}"
      if [[ -d "$CACHE_PATH" ]]; then
        echo "Removing stale ${SUBDIR} (would otherwise trigger SwiftShims mtime mismatch — see #745)"
        rm -rf "$CACHE_PATH"
      fi
    done
```

The cache key already invalidates when `.github/workflows/ci.yml` changes,
so this commit also forces a fresh DerivedData cache for the next run —
which doubles as a one-time cleanup of any other stale entries.

## Validation

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — OK
- `./scripts/build.sh lint` — OK
- `./scripts/build.sh all` (locally on `main`) — 2208 tests passed in 160s
- This PR's own CI run will be the live validation; if green, the same fix
  unblocks rebases of #703, #716, #717, #723, #724, #733.

## Risk / rollback

- Risk: very low. Removes two small derived-cache subdirectories before
  any build step; nothing else uses them across jobs.
- Rollback: revert this commit. The only behavioural delta is that
  `ModuleCache.noindex` / `SDKStatCaches.noindex` will be rebuilt on
  every run instead of being restored — adds a few seconds at most.

## Out of scope

- The artifact-service "HTML instead of JSON" upstream flake hitting #717 /
  #733 (separate GitHub Actions infra issue; resolves on rerun).
- The `IPCClient.selectionChanges()` test-hang hypothesis tracked in #747
  is independent — once this CI fix lands, #723 will get a clean Build &
  Test pass *or* surface the real timeout (whichever is true).
