### PR TITLE
fix(tests): backfill IPCClient args in SchedulingFeature_*Tests after #723/#724 cross-merge (#749)

### DIFF
--- a/Tests/EyePostureReminderTests/TCA/SchedulingFeature_NotificationRoutingTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/SchedulingFeature_NotificationRoutingTests.swift
@@ -41,8 +41,12 @@ final class SchedulingNotificationRoutingTests: XCTestCase {
             $0.settingsClient = settings
             $0.ipcClient = IPCClient(
                 isTrueInterruptEnabled: { false },
+                setTrueInterruptEnabled: { _ in false },
+                readSelection: { .empty },
+                writeSelection: { _ in false },
                 record: { event, _ in recordedEvents.withValue { $0.append(event) } },
-                trueInterruptChanges: { .finished }
+                trueInterruptChanges: { .finished },
+                selectionChanges: { .finished }
             )
             $0.overlayClient = OverlayClient(
                 show: { type, duration, _, _ in
@@ -109,8 +113,12 @@ final class SchedulingNotificationRoutingTests: XCTestCase {
             $0.date = .constant(now)
             $0.ipcClient = IPCClient(
                 isTrueInterruptEnabled: { false },
+                setTrueInterruptEnabled: { _ in false },
+                readSelection: { .empty },
+                writeSelection: { _ in false },
                 record: { event, _ in recordedEvents.withValue { $0.append(event) } },
-                trueInterruptChanges: { .finished }
+                trueInterruptChanges: { .finished },
+                selectionChanges: { .finished }
             )
             $0.overlayClient = OverlayClient(
                 show: { type, _, _, _ in shownOverlays.withValue { $0.append(type) } },

--- a/Tests/EyePostureReminderTests/TCA/SchedulingFeature_WatchdogRecoveryTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/SchedulingFeature_WatchdogRecoveryTests.swift
@@ -63,8 +63,12 @@ final class SchedulingFeatureWatchdogRecoveryTests: XCTestCase {
             TCATestDependencies.applyAllSilentClients(&$0)
             $0.ipcClient = IPCClient(
                 isTrueInterruptEnabled: { false },
+                setTrueInterruptEnabled: { _ in false },
+                readSelection: { .empty },
+                writeSelection: { _ in false },
                 record: { _, _ in },
-                trueInterruptChanges: { stream }
+                trueInterruptChanges: { stream },
+                selectionChanges: { .finished }
             )
         }
         store.exhaustivity = .off


### PR DESCRIPTION
## Summary

Closes **#749**.

`./scripts/build.sh all` is broken on `main` at `3c4294a` after the back-to-back merge of #723 (extends `IPCClient` with 4 new `@DependencyClient` accessors) and #724 (adds 5 new `SchedulingFeature_*Tests.swift` files). Both PRs were green in isolation; their textual merge is conflict-free, but three inline `IPCClient(...)` constructions in #724's new test files only specify the pre-#723 four-argument shape and now fail to compile:

```
Tests/EyePostureReminderTests/TCA/SchedulingFeature_NotificationRoutingTests.swift:42
Tests/EyePostureReminderTests/TCA/SchedulingFeature_NotificationRoutingTests.swift:110
Tests/EyePostureReminderTests/TCA/SchedulingFeature_WatchdogRecoveryTests.swift:64
```

## Fix

Backfills the four missing arguments on each call site with the same silent stubs PR #723 wired into `silentIPCClient` / `AppFeatureTests` / `ContentViewTests` / `AppDelegateTests`:

```diff
 $0.ipcClient = IPCClient(
     isTrueInterruptEnabled: { false },
+    setTrueInterruptEnabled: { _ in false },
+    readSelection: { .empty },
+    writeSelection: { _ in false },
     record: { ... },
-    trueInterruptChanges: { ... }
+    trueInterruptChanges: { ... },
+    selectionChanges: { .finished }
 )
```

Net diff: +15 −3 across two test files. No production code touched.

## Verification

- ✅ `./scripts/build.sh all` → **2264 tests, 0 failures, 1 skipped** in 77 s; `** TEST SUCCEEDED **`; `✓ All steps passed in 104s`.
- ✅ Pre-merge baseline was 2208; PR #723 + #724 added net +56 tests; this fix re-enables the 56-test compile so the post-merge count is preserved.
- ✅ No compile-side cascade of the original "Cannot infer contextual base in reference to member 'notificationRouted'" / 'reminder' / 'eyes' errors after the three sites compile.

## Process note

Filing follow-up note in #749 — `gh pr merge --auto --squash` does not re-run CI on a green PR after `main` advances unless protected branch settings require an up-to-date status check. Squad cycles merging more than one PR back-to-back should either enable that branch protection or merge serially with one CI cycle between merges.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
