### PR TITLE
refactor(AppDelegate): switch snoozeWakeCategory ref to SchedulingFeature (#702 Phase 8 prep)

### DIFF
--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -309,7 +309,7 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         if let type = ReminderType(categoryIdentifier: categoryID) {
             return .reminder(type)
         }
-        if categoryID == AppCoordinator.snoozeWakeCategory {
+        if categoryID == SchedulingFeature.snoozeWakeCategory {
             return .snoozeWake
         }
         return .ignore

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -719,7 +719,7 @@ final class AppDelegateTests: XCTestCase {
     }
 
     func test_notificationRoute_snoozeWake_routesToSnoozeWake() {
-        let route = delegate.notificationRoute(for: AppCoordinator.snoozeWakeCategory)
+        let route = delegate.notificationRoute(for: SchedulingFeature.snoozeWakeCategory)
 
         XCTAssertEqual(route, .snoozeWake)
     }


### PR DESCRIPTION
## Summary

Tiny, surgical Phase-8 prep step for the MVVM-decommission tracker
(#702). Repoints `AppDelegate`'s snooze-wake routing from
`AppCoordinator.snoozeWakeCategory` to the equivalent constant on the
TCA reducer (`SchedulingFeature.snoozeWakeCategory`), removing one of
the few remaining hard references the delegate holds on the legacy
`AppCoordinator` type.

## What changed

- `EyePostureReminder/App/AppDelegate.swift` (1 line) — `notificationRoute(for:)`
  reads the snooze-wake category identifier from `SchedulingFeature`
  instead of `AppCoordinator`.
- `Tests/EyePostureReminderTests/Services/AppDelegateTests.swift` (1 line) —
  `test_notificationRoute_snoozeWake_routesToSnoozeWake` exercises the
  same call site through the new symbol so the contract remains
  reducer-anchored after `AppCoordinator.swift` is eventually deleted.

## Why safe

- Both constants resolve to the **identical** string
  `"com.yashasgujjar.kshana.snooze-wake"`
  (`AppCoordinator.swift` L49 ↔ `SchedulingFeature.swift` L40).
- `SchedulingFeature` is the new authority for snooze-wake scheduling
  (it writes the matching `UNNotificationRequest` via
  `notificationClient.add` in `scheduleSnoozeWake` — see
  `SchedulingFeature.swift` L564, L570). Other call sites
  (`Tests/EyePostureReminderTests/TCA/SchedulingFeature_*Tests.swift`)
  already consume `SchedulingFeature.snoozeWakeCategory` directly.
- No `do_not_touch` files modified — `SchedulingFeature.swift` is read-only
  here, only its public constant is referenced.

## Build status

`./scripts/build.sh all` →  ✓ `Executed 2264 tests, with 1 test skipped and 0 failures`
(unchanged vs. `main` baseline `fce05d6`; same 2264 tests).

## Scope

Refs #702 (Phase 8 — Delete AppCoordinator stack + tests). **Does not
close** #702 — the actual file deletions and broader view migrations
(Phases 2–7) remain pending. This PR is intentionally limited to the
single-line indirection so it can land cleanly in isolation while the
larger view-migration work continues in parallel.

`AppCoordinator.snoozeWakeCategory` is intentionally left in place;
`AppCoordinator+Helpers.swift` (L62, L81, L85) still consumes it and
will be removed together with the rest of the AppCoordinator stack
under Phase 8.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>