### PR TITLE
refactor(SelectedAppsState): drop ObservableObject + @Published (#752)

### DIFF
--- a/EyePostureReminder/Services/SelectedAppsState.swift
+++ b/EyePostureReminder/Services/SelectedAppsState.swift
@@ -16,7 +16,6 @@
 /// main app target once #201 is resolved; the extension reads it via
 /// `ManagedSettingsStore`.
 
-import Combine
 import Foundation
 import os
 import ScreenTimeExtensionShared
@@ -40,9 +39,19 @@ extension AppGroupIPCStore: SelectedAppsIPCStoring {}
 
 // MARK: - SelectedAppsState
 
-/// Observable store for the True Interrupt Mode app/category selection.
+/// App Group–backed store for the True Interrupt Mode app/category selection.
+///
+/// Previously conformed to `ObservableObject` (`@Published` on
+/// `selectionMetadata` / `isTrueInterruptEnabled`) so SwiftUI surfaces
+/// could observe selection changes directly. After `AppCategoryPickerView`
+/// migrated to `StoreOf<AppCategoryPickerFeature>` (Phase 1 reducer), no
+/// production view or test subscribes to the Combine projection any more,
+/// so the conformance + `@Published` wrappers + `import Combine` were
+/// stripped under issue #752 (residual scope of `p0-tca-14` / #677).
+/// The full file is scheduled for deletion in `p0-tca-15` (#678) once
+/// `IPCClient` absorbs read/write + change-stream responsibilities.
 @MainActor
-final class SelectedAppsState: ObservableObject {
+final class SelectedAppsState {
     typealias IPCStoreFactory = (UserDefaults?) -> any SelectedAppsIPCStoring
 
     // MARK: App Group + Persistence Keys
@@ -54,10 +63,10 @@ final class SelectedAppsState: ObservableObject {
     /// UserDefaults key for the user's True Interrupt Mode enabled intent.
     static let enabledKey = AppGroupIPCKeys.trueInterruptEnabled
 
-    // MARK: Published State
+    // MARK: State
 
-    @Published private(set) var selectionMetadata: SelectedAppsMetadata
-    @Published private(set) var isTrueInterruptEnabled: Bool
+    private(set) var selectionMetadata: SelectedAppsMetadata
+    private(set) var isTrueInterruptEnabled: Bool
 
     // MARK: Dependency
 


### PR DESCRIPTION
## Summary

Strips `: ObservableObject`, both `@Published` property wrappers, and the
now-unused `import Combine` from
`EyePostureReminder/Services/SelectedAppsState.swift`.

This lands the `SelectedAppsState` cleanup that the umbrella `p0-tca-14`
(#677) listed as residual scope — without modifying any file in #677's
`do_not_touch` list (TCA Phase-1 reducers / `TCA/Dependencies/*`).

## Why this is safe (non-blocking) now

`AppCategoryPickerView` is already wired to
`StoreOf<AppCategoryPickerFeature>`, and re-grepping the whole tree shows
**zero** consumers of the Combine projection:

```
$ rg -n 'EnvironmentObject.*SelectedAppsState|StateObject.*SelectedAppsState|ObservedObject.*SelectedAppsState' EyePostureReminder Tests Extensions
(no matches)

$ rg -n '\$selectionMetadata|\$isTrueInterruptEnabled' EyePostureReminder Tests Extensions
(no matches)

$ rg -n 'SelectedAppsState\..*objectWillChange|sink.*Selected' EyePostureReminder Tests Extensions
(no matches)
```

No SwiftUI surface, Combine sink, or test reaches into the published
projection, so removing the conformance is a pure dead-code strip.
`SelectedAppsState.swift` itself is scheduled for deletion under #678
(`p0-tca-15`) once `IPCClient` absorbs read/write + change-stream duties.

## What landed

`EyePostureReminder/Services/SelectedAppsState.swift`:

- drop `: ObservableObject`
- drop `@Published` from `selectionMetadata`
- drop `@Published` from `isTrueInterruptEnabled`
- drop `import Combine`
- refresh the type docstring to record the new contract + the #678 retire
  path

`MARK: - Published State` heading renamed to `MARK: State` to match the
new declaration.

## Build status

```
./scripts/build.sh all  →  ✓ All steps passed in 113s
                            ✓ Executed 2264 tests, 1 skipped, 0 failures
```

Test count is **identical** to the `main`@`5a2d733` baseline — no test was
deleted or rewritten, because none of them subscribed to the Combine
projection.

## `do_not_touch` compliance (re: #677)

- ✅ No `EyePostureReminder/TCA/Features/*Feature.swift` modified.
- ✅ No `EyePostureReminder/TCA/Dependencies/*.swift` modified.
- ✅ Single-file edit, 15 additions / 6 deletions.

## Related

- Closes #752.
- Residual scope of #677 (`p0-tca-14` umbrella).
- `SelectedAppsState.swift` deletion remains tracked under #678 (`p0-tca-15`).
- `SettingsStore` `ObservableObject` strip remains tracked under #701
  (`p0-tca-14b`) — still blocked on view consumers, separate scope.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
