### PR TITLE
refactor(HomeView): drop @EnvironmentObject, drive from HomeFeature store (#755 Phase A)

### DIFF
--- a/EyePostureReminder/Views/ContentView.swift
+++ b/EyePostureReminder/Views/ContentView.swift
@@ -9,6 +9,10 @@ import SwiftUI
 /// via `.onChange` so `OnboardingView`'s `UserDefaults` write (which still
 /// owns persistence until `p0-tca-14`) propagates to the TCA state and flips
 /// the gate without an MVVM-side observer.
+///
+/// `HomeView` is scoped onto `AppFeature.State.home` here as part of `#755`
+/// Phase A. `OnboardingView` keeps its `@EnvironmentObject` graph until
+/// Phase C migrates it onto `OnboardingFeature`.
 struct ContentView: View {
     @Perception.Bindable var store: StoreOf<AppFeature>
     @AppStorage(AppStorageKey.hasSeenOnboarding) private var persistedHasSeenOnboarding = false
@@ -19,7 +23,7 @@ struct ContentView: View {
             ZStack {
                 if store.hasSeenOnboarding {
                     NavigationStack {
-                        HomeView()
+                        HomeView(store: store.scope(state: \.home, action: \.home))
                     }
                     .transition(.opacity)
                 } else {

--- a/EyePostureReminder/Views/HomeView.swift
+++ b/EyePostureReminder/Views/HomeView.swift
@@ -1,13 +1,24 @@
+import ComposableArchitecture
 import SwiftUI
 import UIKit
 import UserNotifications
 
+/// Home screen, wired to `HomeFeature` as part of `#755` Phase A.
+///
+/// The legacy `@EnvironmentObject SettingsStore` / `AppCoordinator` graph has
+/// been removed from this view: every per-type enable flag, master toggle, and
+/// notification auth status is now read from `StoreOf<HomeFeature>`. Local
+/// `@AppStorage`-backed state (`openSettingsOnLaunch`,
+/// `trueInterruptSkippedBannerDismissed`) stays in the view because
+/// `HomeFeature` doesn't persist those yet; the sheet still hands off to the
+/// MVVM `SettingsView`, which receives `SettingsStore` / `AppCoordinator` via
+/// SwiftUI environment inheritance from `EyePostureReminderApp` until
+/// `#755` Phase B migrates that surface as well.
 struct HomeView: View {
     typealias LaunchArgumentsProvider = () -> [String]
     typealias ProcessEnvironmentProvider = () -> [String: String]
 
-    @EnvironmentObject var settings: SettingsStore
-    @EnvironmentObject var coordinator: AppCoordinator
+    @Perception.Bindable var store: StoreOf<HomeFeature>
 
     @State private var showSettings = false
     @AppStorage(AppStorageKey.openSettingsOnLaunch) private var openSettingsOnLaunch = false
@@ -25,6 +36,7 @@ struct HomeView: View {
     private let processEnvironmentProvider: ProcessEnvironmentProvider
 
     init(
+        store: StoreOf<HomeFeature>,
         accessibilityNotificationPoster: AccessibilityNotificationPosting
             = LiveAccessibilityNotificationPoster(),
         launchArguments: [String]? = nil,
@@ -33,6 +45,7 @@ struct HomeView: View {
         processEnvironmentProvider: @escaping ProcessEnvironmentProvider
             = { ProcessInfo.processInfo.environment }
     ) {
+        self.store = store
         self.accessibilityNotificationPoster = accessibilityNotificationPoster
         self.launchArguments = launchArguments
         self.launchArgumentsProvider = launchArgumentsProvider
@@ -42,26 +55,26 @@ struct HomeView: View {
 
     private var statusLabel: String {
         let key = Self.statusLocalizationKey(
-            globalEnabled: settings.globalEnabled,
-            eyesEnabled: settings.eyesEnabled,
-            postureEnabled: settings.postureEnabled,
-            notificationAuthStatus: coordinator.notificationAuthStatus
+            globalEnabled: store.globalEnabled,
+            eyesEnabled: store.eyesEnabled,
+            postureEnabled: store.postureEnabled,
+            notificationAuthStatus: store.notificationAuthStatus
         )
         return String(localized: String.LocalizationValue(key), bundle: .module)
     }
 
     private var shouldShowNotificationRecovery: Bool {
         Self.shouldShowNotificationRecovery(
-            globalEnabled: settings.globalEnabled,
-            notificationAuthStatus: coordinator.notificationAuthStatus
+            globalEnabled: store.globalEnabled,
+            notificationAuthStatus: store.notificationAuthStatus
         )
     }
 
     private var shouldShowNoRemindersConfigured: Bool {
         Self.shouldShowNoRemindersConfigured(
-            globalEnabled: settings.globalEnabled,
-            eyesEnabled: settings.eyesEnabled,
-            postureEnabled: settings.postureEnabled
+            globalEnabled: store.globalEnabled,
+            eyesEnabled: store.eyesEnabled,
+            postureEnabled: store.postureEnabled
         )
     }
 
@@ -106,9 +119,13 @@ struct HomeView: View {
     }
 
     private var shouldShowTrueInterruptPrompts: Bool {
-        if coordinator.screenTimeAuthorization.authorizationStatus == .notDetermined {
-            return true
-        }
+        // Pre-entitlement production builds always resolve Screen Time
+        // authorization to `.unavailable` via `ScreenTimeAuthorizationNoop`,
+        // so the legacy `coordinator.screenTimeAuthorization` check never
+        // returned `true` outside DEBUG launch-arg overrides (#201). The
+        // DEBUG paths below preserve UI-test backdoor parity until Phase 2
+        // wires a real `screenTimeAuthorizationClient` observation into
+        // `HomeFeature.State`.
 #if DEBUG
         if uiTestScreenTimeStatusRaw == ScreenTimeAuthorizationStatus.notDetermined.rawValue {
             return true
@@ -181,115 +198,124 @@ struct HomeView: View {
 #endif
 
     var body: some View {
-        VStack(spacing: AppSpacing.lg) {
-            Spacer()
-
+        WithPerceptionTracking {
             VStack(spacing: AppSpacing.lg) {
-                YinYangEyeView()
+                Spacer()
 
-                // Status copy crossfades as a unit when globalEnabled changes.
-                ZStack {
-                    VStack(spacing: AppSpacing.sm) {
-                        Text("home.title", bundle: .module)
-                            .font(AppTypography.headline)
-                            .foregroundStyle(AppColor.textPrimary)
-                            .multilineTextAlignment(.center)
-                            .accessibilityIdentifier("home.title")
+                VStack(spacing: AppSpacing.lg) {
+                    YinYangEyeView()
 
-                        Text(statusLabel)
-                            .font(AppTypography.body)
-                            .foregroundStyle(AppColor.textSecondary)
-                            .multilineTextAlignment(.center)
-                            .accessibilityIdentifier("home.statusLabel")
+                    // Status copy crossfades as a unit when globalEnabled changes.
+                    ZStack {
+                        VStack(spacing: AppSpacing.sm) {
+                            Text("home.title", bundle: .module)
+                                .font(AppTypography.headline)
+                                .foregroundStyle(AppColor.textPrimary)
+                                .multilineTextAlignment(.center)
+                                .accessibilityIdentifier("home.title")
+
+                            Text(statusLabel)
+                                .font(AppTypography.body)
+                                .foregroundStyle(AppColor.textSecondary)
+                                .multilineTextAlignment(.center)
+                                .accessibilityIdentifier("home.statusLabel")
+                        }
+                        .id(store.globalEnabled)
+                        .transition(.opacity)
                     }
-                    .id(settings.globalEnabled)
-                    .transition(.opacity)
+                    .animation(
+                        reduceMotion ? nil : AppAnimation.statusCrossfadeCurve,
+                        value: store.globalEnabled
+                    )
                 }
-                .animation(
-                    reduceMotion ? nil : AppAnimation.statusCrossfadeCurve,
-                    value: settings.globalEnabled
-                )
+
+                Spacer()
+
+                // Post-onboarding True Interrupt discoverability banner (#258).
+                // Shown only when setup was skipped (notDetermined) and not yet dismissed.
+                if shouldShowTrueInterruptPrompts,
+                   !effectiveTrueInterruptBannerDismissed {
+                    TrueInterruptSkippedBanner(
+                        onSetUp: {
+                            trueInterruptBannerDismissed = true
+                            showSettings = true
+                        },
+                        onDismiss: {
+                            trueInterruptBannerDismissed = true
+                        }
+                    )
+                }
+
+                // Persistent low-noise rediscovery affordance (#280).
+                // Shown after the banner is dismissed while setup is still pending.
+                if shouldShowTrueInterruptPrompts,
+                   effectiveTrueInterruptBannerDismissed {
+                    TrueInterruptSetupPill(onTap: { showSettings = true })
+                }
+
+                if shouldShowNotificationRecovery && !shouldShowNoRemindersConfigured {
+                    HomeNotificationWarningBanner(onOpenSettings: openApplicationSettings)
+                }
+
+                if shouldShowNoRemindersConfigured {
+                    HomeNoRemindersConfiguredBanner(onOpenSettings: { showSettings = true })
+                }
             }
-
-            Spacer()
-
-            // Post-onboarding True Interrupt discoverability banner (#258).
-            // Shown only when setup was skipped (notDetermined) and not yet dismissed.
-            if shouldShowTrueInterruptPrompts,
-               !effectiveTrueInterruptBannerDismissed {
-                TrueInterruptSkippedBanner(
-                    onSetUp: {
-                        trueInterruptBannerDismissed = true
+            .padding(.horizontal, AppSpacing.xl)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .navigationTitle(Text("home.navTitle", bundle: .module))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
                         showSettings = true
-                    },
-                    onDismiss: {
-                        trueInterruptBannerDismissed = true
+                    } label: {
+                        Image(systemName: AppSymbol.settings)
+                            .symbolRenderingMode(.hierarchical)
+                            .foregroundStyle(AppColor.primaryRest)
+                            .accessibilityHidden(true)
                     }
-                )
-            }
-
-            // Persistent low-noise rediscovery affordance (#280).
-            // Shown after the banner is dismissed while setup is still pending.
-            if shouldShowTrueInterruptPrompts,
-               effectiveTrueInterruptBannerDismissed {
-                TrueInterruptSetupPill(onTap: { showSettings = true })
-            }
-
-            if shouldShowNotificationRecovery && !shouldShowNoRemindersConfigured {
-                HomeNotificationWarningBanner(onOpenSettings: openApplicationSettings)
-            }
-
-            if shouldShowNoRemindersConfigured {
-                HomeNoRemindersConfiguredBanner(onOpenSettings: { showSettings = true })
-            }
-        }
-        .padding(.horizontal, AppSpacing.xl)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .navigationTitle(Text("home.navTitle", bundle: .module))
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                Button {
-                    showSettings = true
-                } label: {
-                    Image(systemName: AppSymbol.settings)
-                        .symbolRenderingMode(.hierarchical)
-                        .foregroundStyle(AppColor.primaryRest)
-                        .accessibilityHidden(true)
+                    .accessibilityLabel(Text("home.settingsButton", bundle: .module))
+                    .accessibilityHint(Text("home.settingsButton.hint", bundle: .module))
+                    .accessibilityIdentifier("home.settingsButton")
                 }
-                .accessibilityLabel(Text("home.settingsButton", bundle: .module))
-                .accessibilityHint(Text("home.settingsButton.hint", bundle: .module))
-                .accessibilityIdentifier("home.settingsButton")
             }
-        }
-        .sheet(isPresented: $showSettings) {
-            NavigationStack {
-                SettingsView(isPresented: $showSettings)
-                    .environmentObject(settings)
-                    .environmentObject(coordinator)
+            .sheet(isPresented: $showSettings) {
+                // `SettingsView` still consumes `@EnvironmentObject
+                // SettingsStore` / `AppCoordinator`; SwiftUI's automatic
+                // sheet-environment inheritance from
+                // `EyePostureReminderApp`'s WindowGroup-level
+                // `.environmentObject(...)` chain provides them. The explicit
+                // re-injection used by the pre-#755 MVVM HomeView is no
+                // longer needed and would also force this view to keep its
+                // own `@EnvironmentObject` declarations.
+                NavigationStack {
+                    SettingsView(isPresented: $showSettings)
+                }
             }
-        }
-        .background(AppColor.background.ignoresSafeArea())
-        .onAppear {
-            if openSettingsOnLaunch {
-                openSettingsOnLaunch = false
-                showSettings = true
+            .background(AppColor.background.ignoresSafeArea())
+            .onAppear {
+                store.send(.onAppear)
+                if openSettingsOnLaunch {
+                    openSettingsOnLaunch = false
+                    showSettings = true
+                }
             }
-        }
-        .task {
-            await coordinator.refreshAuthStatus()
-        }
-        .onChangeCompat(of: openSettingsOnLaunch) { newValue in
-            if newValue {
-                openSettingsOnLaunch = false
-                showSettings = true
+            .task {
+                await store.send(.task).finish()
             }
-        }
-        // Announce master-toggle state changes to VoiceOver (#287).
-        // Guard prevents double-announcement while SettingsView sheet is open.
-        .onChangeCompat(of: settings.globalEnabled) { _ in
-            guard !showSettings else { return }
-            accessibilityNotificationPoster.postAnnouncement(message: statusLabel)
+            .onChangeCompat(of: openSettingsOnLaunch) { newValue in
+                if newValue {
+                    openSettingsOnLaunch = false
+                    showSettings = true
+                }
+            }
+            // Announce master-toggle state changes to VoiceOver (#287).
+            // Guard prevents double-announcement while SettingsView sheet is open.
+            .onChangeCompat(of: store.globalEnabled) { _ in
+                guard !showSettings else { return }
+                accessibilityNotificationPoster.postAnnouncement(message: statusLabel)
+            }
         }
     }
 
@@ -492,10 +518,11 @@ struct TrueInterruptSkippedBanner: View {
 }
 
 #Preview {
-    let coordinator = AppCoordinator()
     NavigationStack {
-        HomeView()
-            .environmentObject(coordinator.settings)
-            .environmentObject(coordinator)
+        HomeView(
+            store: Store(initialState: HomeFeature.State()) {
+                HomeFeature()
+            }
+        )
     }
 }


### PR DESCRIPTION
## Summary

Phase A of #755 — wires `HomeView` to `StoreOf<HomeFeature>` and removes both legacy `@EnvironmentObject` declarations (`SettingsStore` + `AppCoordinator`). No `HomeFeature` reducer changes; this is a pure view-side migration onto the Phase-1 reducer that has been in place since #668.

## Diff

```
2 files changed, 144 insertions(+), 113 deletions(-)
```

- `EyePostureReminder/Views/HomeView.swift` — drop both `@EnvironmentObject`, add `@Perception.Bindable var store: StoreOf<HomeFeature>`, wrap body in `WithPerceptionTracking`, swap every `settings.*` / `coordinator.notificationAuthStatus` access for `store.*`, replace `await coordinator.refreshAuthStatus()` with `await store.send(.task).finish()` (which polls `NotificationClient.authorizationStatus` on a 1-second `continuousClock` timer and streams settings snapshots through `SettingsClient.stream`).
- `EyePostureReminder/Views/ContentView.swift` — pass `store.scope(state: \\.home, action: \\.home)` to the new `HomeView(store:)` initializer.

## Screen-time prompt gate behavior

`shouldShowTrueInterruptPrompts` drops its production-side `coordinator.screenTimeAuthorization` check. Rationale:

- The pre-entitlement (#201) `ScreenTimeAuthorizationNoop` implementation always reports `.unavailable`, so the production check was never `true` in Release — the True Interrupt banner never appeared from that branch outside UI tests.
- DEBUG launch-arg (`--simulate-screen-time-not-determined`) / process-env (`UITEST_SCREEN_TIME_STATUS`) / `AppStorageKey.uiTestScreenTimeStatus` overrides are preserved verbatim, so `OverlayUITests` / `HomeScreenTests` backdoors continue to work.
- When #201 lands, a follow-up patch can promote a real `screenTimeAuthorizationClient` observation into `HomeFeature.State` (this is exactly the kind of work issue #755 ear-marks for a later phase).

## Settings sheet handoff

The explicit `.environmentObject(settings).environmentObject(coordinator)` re-injection on the sheet body is removed. `SettingsView` still consumes those env-objects, but SwiftUI's automatic sheet environment inheritance from `EyePostureReminderApp`'s WindowGroup-level `.environmentObject(coordinator.settings)` / `.environmentObject(coordinator)` chain (`EyePostureReminderApp.swift:117-118`) supplies them transparently. This is path **(a)** of the two options listed in #755 Phase A. Phase B will migrate `SettingsView` onto `SettingsFeature` and dissolve the env-object chain entirely.

## Build status

```
./scripts/build.sh all  →  ✓ All steps passed in 120s
                            ✓ Executed 2236 tests, 1 skipped, 0 failures
```

Test-count delta vs `main@6846cd0`: **0** (no tests added or removed). `HomeFeatureTests`, `HomeViewLaunchContextResolverTests`, `ContentViewTests`, `RegressionTests` (which all continued to compile against the new `HomeView(store:)` initializer or never instantiated `HomeView` directly) all pass green.

## Acceptance criteria for Phase A of #755

- [x] `HomeView` body compiles without referencing `settings.*` or `coordinator.*`.
- [x] Both `@EnvironmentObject` declarations are removed.
- [x] `./scripts/build.sh all` passes.
- [x] No Phase-1 reducer file (`HomeFeature.swift`) modified.
- [x] No file under `EyePostureReminder/TCA/Dependencies/*.swift` modified.
- [x] Branch: `users/squad/issue-755-phase-a-homeview-tca`.

Refs #755 — Phase A only. Phases B / C / D / E remain.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>