### PR TITLE
refactor(OnboardingView): drop @EnvironmentObject, drive from OnboardingFeature store (#755 Phase C)

### DIFF
--- a/EyePostureReminder/TCA/Features/OnboardingFeature.swift
+++ b/EyePostureReminder/TCA/Features/OnboardingFeature.swift
@@ -51,6 +51,12 @@ struct OnboardingFeature {
         case openAppCategoryPicker
         case dismissAppCategoryPicker
         case completedOnboarding
+        /// Writes the current `TabView` page index back into the reducer.
+        /// `nextTapped` covers tap-based navigation; this case covers
+        /// swipe-driven page changes so the reducer remains the single source
+        /// of truth for `currentPage`. Values outside `0...lastPageIndex` are
+        /// clamped.
+        case pageChanged(Int)
     }
 
     @Dependency(\.notificationClient) var notification: NotificationClient
@@ -134,6 +140,10 @@ struct OnboardingFeature {
                 // Parent (`AppFeature`) intercepts to flip
                 // `hasSeenOnboarding` and dismiss onboarding (Phase 2,
                 // `p0-tca-11`); the reducer itself has no local effect.
+                return .none
+
+            case let .pageChanged(page):
+                state.currentPage = max(0, min(page, Self.lastPageIndex))
                 return .none
             }
         }

--- a/EyePostureReminder/Views/ContentView.swift
+++ b/EyePostureReminder/Views/ContentView.swift
@@ -7,12 +7,12 @@ import SwiftUI
 /// reads from `AppFeature.State.hasSeenOnboarding`. The legacy
 /// `@AppStorage(AppStorageKey.hasSeenOnboarding)` is bridged into the store
 /// via `.onChange` so `OnboardingView`'s `UserDefaults` write (which still
-/// owns persistence until `p0-tca-14`) propagates to the TCA state and flips
-/// the gate without an MVVM-side observer.
+/// owns persistence until `p0-tca-14` Phase D) propagates to the TCA state
+/// and flips the gate without an MVVM-side observer.
 ///
 /// `HomeView` is scoped onto `AppFeature.State.home` here as part of `#755`
-/// Phase A. `OnboardingView` keeps its `@EnvironmentObject` graph until
-/// Phase C migrates it onto `OnboardingFeature`.
+/// Phase A; `OnboardingView` is scoped onto `AppFeature.State.onboarding`
+/// as part of `#755` Phase C.
 struct ContentView: View {
     @Perception.Bindable var store: StoreOf<AppFeature>
     @AppStorage(AppStorageKey.hasSeenOnboarding) private var persistedHasSeenOnboarding = false
@@ -27,7 +27,9 @@ struct ContentView: View {
                     }
                     .transition(.opacity)
                 } else {
-                    OnboardingView()
+                    OnboardingView(
+                        store: store.scope(state: \.onboarding, action: \.onboarding)
+                    )
                         .transition(.opacity)
                 }
             }

--- a/EyePostureReminder/Views/Onboarding/OnboardingSetupView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingSetupView.swift
@@ -3,13 +3,28 @@
 //
 // Onboarding Screen 3 — Reminder Schedule Setup.
 // Users choose their eye break and posture check windows before getting started.
-// Selections bind directly to SettingsStore so Settings shows the same values later.
+// Selections bind directly to `@AppStorage(SettingsStore.Keys.*)` so the same
+// values surface in `SettingsView` later — no environment-object plumbing
+// required. Picker option lists / labels still come from the legacy
+// `SettingsViewModel` statics until `#755` Phase B's `SettingsPickerOptions`
+// extraction lands; the rebase swaps the references over without touching this
+// file's shape.
 
 import SwiftUI
 
 struct OnboardingSetupView: View {
     let onGetStarted: () -> Void
-    @EnvironmentObject private var settings: SettingsStore
+
+    /// Backed by `SettingsStore.Keys.eyesInterval`. The compile-time default
+    /// matches `AppConfig.fallback.defaults.eyeInterval` so the first cold
+    /// launch (before `SettingsStore` has persisted anything to UserDefaults)
+    /// lands on a picker option that exists in
+    /// `SettingsViewModel.intervalOptions`.
+    @AppStorage(SettingsStore.Keys.eyesInterval) private var eyesInterval: Double = 1200
+    @AppStorage(SettingsStore.Keys.eyesBreakDuration) private var eyesBreakDuration: Double = 20
+    @AppStorage(SettingsStore.Keys.postureInterval) private var postureInterval: Double = 1800
+    @AppStorage(SettingsStore.Keys.postureBreakDuration)
+    private var postureBreakDuration: Double = 10
 
     var body: some View {
         ScrollView {
@@ -41,8 +56,8 @@ struct OnboardingSetupView: View {
                         typeID: "eyes",
                         intervalKey: .eyesInterval,
                         durationKey: .eyesBreakDuration,
-                        interval: $settings.eyesInterval,
-                        breakDuration: $settings.eyesBreakDuration
+                        interval: $eyesInterval,
+                        breakDuration: $eyesBreakDuration
                     )
                     OnboardingReminderPickerCard(
                         icon: AppSymbol.postureCheck,
@@ -54,8 +69,8 @@ struct OnboardingSetupView: View {
                         typeID: "posture",
                         intervalKey: .postureInterval,
                         durationKey: .postureBreakDuration,
-                        interval: $settings.postureInterval,
-                        breakDuration: $settings.postureBreakDuration
+                        interval: $postureInterval,
+                        breakDuration: $postureBreakDuration
                     )
                 }
                 .padding(.horizontal, AppSpacing.md)
@@ -212,5 +227,4 @@ private struct OnboardingReminderPickerCard: View {
 
 #Preview {
     OnboardingSetupView(onGetStarted: {})
-        .environmentObject(SettingsStore())
 }

--- a/EyePostureReminder/Views/Onboarding/OnboardingView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingView.swift
@@ -2,6 +2,19 @@
 // kshana
 //
 // Main onboarding container — 4-screen TabView with page indicator.
+//
+// Migrated off `@EnvironmentObject AppCoordinator` / `SettingsStore` to a
+// scoped `StoreOf<OnboardingFeature>` as part of `#755` Phase C (was #702
+// Phase 5). The legacy `finishOnboarding()` / `finishOnboardingAndCustomize()`
+// instance methods are preserved as button-handler entry points that emit
+// the `.onboardingCompleted` analytics event directly via `AnalyticsLogger`
+// to keep the #324 single-event invariant cleanly testable from unit-test
+// processes without bootstrapping a TCA `TestStore`. Phase D collapses these
+// view methods into reducer-driven actions once `RootView` owns the button
+// wiring.  The `notificationCenter` / `screenTimeAuthorization` references
+// previously pulled from `AppCoordinator` are now sourced from
+// `OnboardingFeature.State` (status fields refreshed via `.onAppear` + the
+// injected dependency clients).
 
 import ComposableArchitecture
 import SwiftUI
@@ -10,19 +23,21 @@ import UIKit
 struct OnboardingView: View {
     typealias AccessibilityNotificationPosterFactory = () -> AccessibilityNotificationPosting
 
-    @EnvironmentObject private var coordinator: AppCoordinator
-    @EnvironmentObject private var settings: SettingsStore
-    @State private var currentPage = 0
+    @Perception.Bindable var store: StoreOf<OnboardingFeature>
     @State private var showAppCategoryPicker = false
 
     private let accessibilityNotificationPoster: AccessibilityNotificationPosting
 
     init(
+        store: StoreOf<OnboardingFeature> = Store(initialState: OnboardingFeature.State()) {
+            OnboardingFeature()
+        },
         accessibilityNotificationPoster: AccessibilityNotificationPosting? = nil,
         makeAccessibilityNotificationPoster: @escaping AccessibilityNotificationPosterFactory = {
             LiveAccessibilityNotificationPoster()
         }
     ) {
+        self.store = store
         self.accessibilityNotificationPoster =
             accessibilityNotificationPoster ?? makeAccessibilityNotificationPoster()
     }
@@ -33,52 +48,78 @@ struct OnboardingView: View {
     }()
 
     var body: some View {
-        TabView(selection: $currentPage) {
-            OnboardingWelcomeView(onNext: { currentPage = 1 })
-                .tag(0)
-            // Inject the coordinator's notification center so the permission
-            // request can be driven by a mock in UI tests without swizzling.
-            OnboardingPermissionView(
-                onNext: { currentPage = 2 },
-                notificationCenter: coordinator.notificationCenter,
-                requestPermission: { await coordinator.requestNotificationPermission() }
-            )
-                .tag(1)
-            // Settings store is forwarded so picker bindings write directly to
-            // persisted values — no separate sync step needed before first use.
-            OnboardingSetupView(onGetStarted: { currentPage = 3 })
-                .environmentObject(settings)
-                .tag(2)
-            // True Interrupt Mode introduction — shows pre-permission copy and
-            // sets honest expectations while #201 (FamilyControls entitlement)
-            // is pending. Users can skip without losing core reminder functionality.
-            OnboardingInterruptModeView(
-                onGetStarted: finishOnboarding,
-                onSetUp: onboardingSetUpAction,
-                onCustomize: finishOnboardingAndCustomize,
-                authorizationStatus: coordinator.screenTimeAuthorization.authorizationStatus
-            )
-                .tag(3)
-        }
-        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .always))
-        .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
-        .background(AppColor.background.ignoresSafeArea())
-        .onAppear { _ = Self.configurePageControl }
-        .onChangeCompat(of: currentPage) { _ in
-            accessibilityNotificationPoster.postScreenChanged()
-        }
-        .sheet(isPresented: $showAppCategoryPicker) {
-            OnboardingAppCategoryPickerSheet(onSelectApps: {})
+        WithPerceptionTracking {
+            TabView(selection: pageBinding) {
+                OnboardingWelcomeView(onNext: { store.send(.nextTapped) })
+                    .tag(0)
+                // Notification permission flows through the reducer's
+                // `.requestNotificationPermission` effect (which uses the
+                // injected `NotificationClient`), so the view no longer needs
+                // to thread `AppCoordinator.notificationCenter` through.
+                OnboardingPermissionView(
+                    onNext: { store.send(.nextTapped) },
+                    requestPermission: {
+                        store.send(.requestNotificationPermission)
+                    }
+                )
+                    .tag(1)
+                // Picker bindings inside `OnboardingSetupView` now write
+                // directly to `@AppStorage(SettingsStore.Keys.*)` — no
+                // `SettingsStore` environment object required.
+                OnboardingSetupView(onGetStarted: { store.send(.nextTapped) })
+                    .tag(2)
+                // True Interrupt Mode introduction. The pre-permission copy
+                // and the disabled-button gating are driven by the reducer's
+                // `screenTimeStatus`, which is seeded on `.onAppear` via
+                // `ScreenTimeAuthorizationClient`.
+                OnboardingInterruptModeView(
+                    onGetStarted: finishOnboarding,
+                    onSetUp: onboardingSetUpAction,
+                    onCustomize: finishOnboardingAndCustomize,
+                    authorizationStatus: store.screenTimeStatus
+                )
+                    .tag(3)
+            }
+            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .always))
+            .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
+            .background(AppColor.background.ignoresSafeArea())
+            .onAppear {
+                _ = Self.configurePageControl
+                store.send(.onAppear)
+            }
+            .onChangeCompat(of: store.currentPage) { _ in
+                accessibilityNotificationPoster.postScreenChanged()
+            }
+            .sheet(isPresented: $showAppCategoryPicker) {
+                OnboardingAppCategoryPickerSheet(onSelectApps: {})
+            }
         }
     }
 
+    /// Two-way binding to `OnboardingFeature.State.currentPage`.
+    ///
+    /// Reads pull the latest reducer-owned value (so `.nextTapped` driven
+    /// transitions reflect immediately); writes round-trip through
+    /// `.pageChanged` so swipe-driven page changes mutate state through the
+    /// same reducer pathway as tap-driven navigation.
+    private var pageBinding: Binding<Int> {
+        Binding(
+            get: { store.currentPage },
+            set: { store.send(.pageChanged($0)) }
+        )
+    }
+
     private var onboardingSetUpAction: (() -> Void)? {
-        coordinator.screenTimeAuthorization.authorizationStatus == .unavailable
+        store.screenTimeStatus == .unavailable
             ? nil
             : { showAppCategoryPicker = true }
     }
 
     func finishOnboarding() {
+        // Direct AnalyticsLogger emit preserves the synchronous test-handler
+        // contract (#324 single-event invariant). Reducer-side TCA tests
+        // continue to drive `.finishTapped` for the same emission; Phase D
+        // collapses both paths once `RootView` owns the button wiring.
         AnalyticsLogger.log(.onboardingCompleted(cta: .getStarted))
         accessibilityNotificationPoster.postScreenChanged()
         markOnboardingComplete()
@@ -87,6 +128,8 @@ struct OnboardingView: View {
     /// Completes onboarding and signals HomeView to open the Settings sheet immediately.
     /// Sets `openSettingsOnLaunch` so HomeView auto-opens Settings on first appear.
     func finishOnboardingAndCustomize() {
+        // Direct AnalyticsLogger emit — see `finishOnboarding()` for the
+        // single-event invariant note (#324).
         AnalyticsLogger.log(.onboardingCompleted(cta: .customize))
         UserDefaults.standard.set(true, forKey: AppStorageKey.openSettingsOnLaunch)
         accessibilityNotificationPoster.postScreenChanged()
@@ -99,20 +142,15 @@ struct OnboardingView: View {
     private func markOnboardingComplete() {
         UserDefaults.standard.set(true, forKey: AppStorageKey.hasSeenOnboarding)
     }
-
-    private func openApplicationSettings() {
-        if let url = URL(string: UIApplication.openSettingsURLString) {
-            UIApplication.shared.open(url)
-        }
-    }
 }
 
 // MARK: - AppCategoryPicker Sheet Wrapper
 
-/// Owns a local `Store` for `AppCategoryPickerView` while `OnboardingView` is
-/// still presented from the legacy MVVM stack. When Phase 7 of #702 wires
-/// `RootView` as the destination owner, this wrapper is removed and the picker
-/// is presented via `$store.scope(...)`.
+/// Owns a local `Store` for `AppCategoryPickerView` while the onboarding
+/// flow's app-category picker presentation is still view-owned. When
+/// `#755` Phase D wires `RootView` as the destination owner, this wrapper
+/// is removed and the picker is presented via `$store.scope(...)` against
+/// `AppFeature.Destination.appCategoryPicker`.
 private struct OnboardingAppCategoryPickerSheet: View {
     let onSelectApps: () -> Void
 
@@ -135,6 +173,4 @@ private struct OnboardingAppCategoryPickerSheet: View {
 
 #Preview {
     OnboardingView()
-        .environmentObject(AppCoordinator())
-        .environmentObject(SettingsStore())
 }

--- a/Tests/EyePostureReminderTests/TCA/OnboardingFeatureTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/OnboardingFeatureTests.swift
@@ -277,4 +277,43 @@ final class OnboardingFeatureTests: XCTestCase {
 
         await store.send(.completedOnboarding)
     }
+
+    // MARK: - .pageChanged
+
+    /// `.pageChanged` writes the new index into state, mirroring the
+    /// swipe-driven `TabView` selection.
+    func test_pageChanged_writesValueIntoState() async {
+        let store = TestStore(initialState: OnboardingFeature.State()) {
+            OnboardingFeature()
+        }
+
+        await store.send(.pageChanged(2)) {
+            $0.currentPage = 2
+        }
+    }
+
+    /// `.pageChanged` clamps values above `lastPageIndex` so swipe noise
+    /// can't move the reducer into an invalid page.
+    func test_pageChanged_clampsAboveLastPageIndex() async {
+        let store = TestStore(initialState: OnboardingFeature.State()) {
+            OnboardingFeature()
+        }
+
+        await store.send(.pageChanged(99)) {
+            $0.currentPage = OnboardingFeature.lastPageIndex
+        }
+    }
+
+    /// `.pageChanged` clamps negative values to zero.
+    func test_pageChanged_clampsNegativeValuesToZero() async {
+        var initial = OnboardingFeature.State()
+        initial.currentPage = 2
+        let store = TestStore(initialState: initial) {
+            OnboardingFeature()
+        }
+
+        await store.send(.pageChanged(-5)) {
+            $0.currentPage = 0
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Phase C of #755: migrate `OnboardingView` and `OnboardingSetupView` off the legacy `@EnvironmentObject` graph (`AppCoordinator`, `SettingsStore`) onto the existing TCA `OnboardingFeature` store and `@AppStorage`. ContentView now scopes the onboarding store down to the view.

Phase B (PR #757) and Phase A landed previously; this PR is the last view migration before Phase D wires the root + Phase E deletes `AppCoordinator`.

## Changes

- `EyePostureReminder/TCA/Features/OnboardingFeature.swift`
  - Add `pageChanged(Int)` to `Action`; reducer clamps to `0...Self.lastPageIndex`.
- `EyePostureReminder/Views/Onboarding/OnboardingView.swift`
  - Drop `@EnvironmentObject coordinator` / `settings`. Adopt `@Perception.Bindable var store: StoreOf<OnboardingFeature>` with a default-init for test-site compat. Body wrapped in `WithPerceptionTracking`.
  - `TabView` selection drives `pageChanged`; subviews call `nextTapped` / `requestNotificationPermission` / `onAppear`.
  - `finishOnboarding()` / `finishOnboardingAndCustomize()` retained as view-level methods that call `AnalyticsLogger.log(.onboardingCompleted(...))` directly (preserves the single-emission invariant tested in `OnboardingTests`); reducer-driven `.finishTapped` / `.finishAndCustomizeTapped` paths remain available for Phase D.
- `EyePostureReminder/Views/Onboarding/OnboardingSetupView.swift`
  - Drop `@EnvironmentObject SettingsStore`; bind pickers via `@AppStorage(SettingsStore.Keys.*)` with defaults matching `AppConfig.fallback.defaults` so first-launch selection is valid.
- `EyePostureReminder/Views/ContentView.swift`
  - `OnboardingView(store: store.scope(state: \.onboarding, action: \.onboarding))`.
- `Tests/EyePostureReminderTests/TCA/OnboardingFeatureTests.swift`
  - +3 tests covering `pageChanged` write + clamp-above/clamp-below.

## Verification

- `./scripts/build.sh build` — ✓
- `./scripts/build.sh test` — 2048 tests, 1 skipped, **0 failures**
- `./scripts/build.sh lint` — ✓ (SwiftLint + privacy-sync)

## Notes / Follow-ups

- View-level `finishOnboarding()` stays for now so existing `OnboardingTests` (which call `OnboardingView().finishOnboarding()`) don't trip TCA's test-context dependency check. Phase D will collapse both paths through the reducer once the root is wired and those tests can adopt `withDependencies`.
- Doesn't touch any `EyePostureReminder/TCA/Dependencies/*.swift` (per issue `do_not_touch`).

Closes #755 (Phase C).
