### PR TITLE
refactor(RootView): drive app from RootView store, drop AppCoordinator from EyePostureReminderApp (#755 Phase D)

### DIFF
--- a/EyePostureReminder/App/EyePostureReminderApp.swift
+++ b/EyePostureReminder/App/EyePostureReminderApp.swift
@@ -4,13 +4,14 @@ import SwiftUI
 @main
 struct EyePostureReminderApp: App {
     @UIApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    @StateObject private var coordinator = AppCoordinator()
     @Environment(\.scenePhase) private var scenePhase
 
-    /// Single TCA `Store` driving the app, introduced by `p0-tca-11` (#674).
-    /// `AppCoordinator` is intentionally kept alongside the store so legacy
-    /// MVVM surfaces (Settings/Home views consuming `@EnvironmentObject`)
-    /// keep working until `p0-tca-14` (#677) decommissions them.
+    /// Single TCA `Store` driving the app. `#755` Phase D removed the
+    /// legacy `@StateObject AppCoordinator` + `.environmentObject(...)`
+    /// injections that previously sat alongside the store: every SwiftUI
+    /// view in the tree (`HomeView`, `SettingsView`, `OnboardingView`,
+    /// `OnboardingSetupView`, `ContentView`/`RootView`) now reads from the
+    /// store scope or `@AppStorage` directly.
     private let store: StoreOf<AppFeature>
 
     init() {
@@ -113,9 +114,7 @@ struct EyePostureReminderApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView(store: store)
-                .environmentObject(coordinator.settings)
-                .environmentObject(coordinator)
+            RootView(store: store)
                 .task {
                     await store.send(.scheduling(.start)).finish()
                 }

--- a/EyePostureReminder/TCA/RootView.swift
+++ b/EyePostureReminder/TCA/RootView.swift
@@ -1,28 +1,60 @@
 import ComposableArchitecture
 import SwiftUI
 
-/// Phase-0 root SwiftUI surface for the TCA migration of the Eye & Posture
-/// Reminder app.
+/// Canonical TCA root surface for the Eye & Posture Reminder app.
 ///
-/// This view exists solely to give Phase 1 issues a concrete attachment
-/// point for sheet, picker, and overlay presentations. Every destination
-/// body deliberately renders `EmptyView()` for now — Phase 1 issues
-/// (#668–#673) will replace each placeholder with the real SwiftUI body
-/// when the corresponding feature reducer is filled in.
+/// `#755` Phase D wires this view into `EyePostureReminderApp.swift` (via the
+/// thin `ContentView` wrapper retained for test compatibility) so the
+/// onboarding gate, sheet presentations, and overlay cover are all owned by
+/// the `AppFeature` store rather than by an `@EnvironmentObject AppCoordinator`
+/// graph.
 ///
-/// `RootView` is **not** wired into `EyePostureReminderApp.swift` yet.
-/// Phase 2 issue `p0-tca-11` (#674) takes ownership of swapping it in for
-/// the legacy MVVM `AppCoordinator` stack.
+/// Responsibilities split:
+/// - **Gate**: branches between `OnboardingView` and `HomeView` off of
+///   `store.hasSeenOnboarding`. The `@AppStorage` bridge mirrors the
+///   `UserDefaults` write `OnboardingView.finishOnboarding()` still performs
+///   into a `hasSeenOnboardingChanged` action so the TCA state flips even
+///   though the persistence path doesn't yet route through the reducer.
+/// - **Destinations**: the `@Presents var destination` slot on
+///   `AppFeature.State` (`settingsSheet` / `appCategoryPicker`) is scoped
+///   here as scaffolding. No production code path currently assigns
+///   `state.destination` — `HomeView` / `SettingsView` still own their local
+///   sheet presentations — so these covers render `EmptyView()` until a
+///   follow-up issue migrates the local presentations onto the destination
+///   graph. Keeping the scaffolding live (rather than deleted) preserves the
+///   contract `AppFeature` already documents for the slot.
+/// - **Overlay**: same scaffolding pattern as destinations. `OverlayManager`
+///   still owns the `UIWindow`-hosted overlay presentation; `state.overlay`
+///   is currently only used as a teardown sink (`#738`'s two-phase dismiss).
+///   A follow-up issue will swap the UIKit path for the SwiftUI
+///   `.fullScreenCover` once `OverlayView` accepts `StoreOf<OverlayFeature>`.
 struct RootView: View {
     @Perception.Bindable var store: StoreOf<AppFeature>
+    @AppStorage(AppStorageKey.hasSeenOnboarding) private var persistedHasSeenOnboarding = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         WithPerceptionTracking {
-            Group {
+            ZStack {
                 if store.hasSeenOnboarding {
-                    EmptyView()
+                    NavigationStack {
+                        HomeView(store: store.scope(state: \.home, action: \.home))
+                    }
+                    .transition(.opacity)
                 } else {
-                    EmptyView()
+                    OnboardingView(
+                        store: store.scope(state: \.onboarding, action: \.onboarding)
+                    )
+                        .transition(.opacity)
+                }
+            }
+            .animation(
+                reduceMotion ? nil : AppAnimation.onboardingTransition,
+                value: store.hasSeenOnboarding
+            )
+            .onChangeCompat(of: persistedHasSeenOnboarding) { newValue in
+                if store.hasSeenOnboarding != newValue {
+                    store.send(.hasSeenOnboardingChanged(newValue))
                 }
             }
             .sheet(

--- a/EyePostureReminder/Views/ContentView.swift
+++ b/EyePostureReminder/Views/ContentView.swift
@@ -1,48 +1,20 @@
 import ComposableArchitecture
 import SwiftUI
 
-/// Root SwiftUI surface that gates between `OnboardingView` and `HomeView`.
+/// Thin compatibility wrapper around `RootView`.
 ///
-/// `p0-tca-11` (#674) wires this view to the TCA `Store` so the gate decision
-/// reads from `AppFeature.State.hasSeenOnboarding`. The legacy
-/// `@AppStorage(AppStorageKey.hasSeenOnboarding)` is bridged into the store
-/// via `.onChange` so `OnboardingView`'s `UserDefaults` write (which still
-/// owns persistence until `p0-tca-14` Phase D) propagates to the TCA state
-/// and flips the gate without an MVVM-side observer.
-///
-/// `HomeView` is scoped onto `AppFeature.State.home` here as part of `#755`
-/// Phase A; `OnboardingView` is scoped onto `AppFeature.State.onboarding`
-/// as part of `#755` Phase C.
+/// `#755` Phase D promotes `RootView` to the canonical TCA root surface (it
+/// owns the onboarding gate, destination sheets, and overlay cover). This
+/// wrapper is retained so existing test fixtures and a future
+/// `EyePostureReminderApp.body` keep referencing a stable `ContentView(store:)`
+/// entry point during the in-flight Phase D / Phase E migration. The wrapper
+/// has no behaviour of its own — every responsibility (gating, presentation,
+/// `@AppStorage` bridge) lives in `RootView`.
 struct ContentView: View {
     @Perception.Bindable var store: StoreOf<AppFeature>
-    @AppStorage(AppStorageKey.hasSeenOnboarding) private var persistedHasSeenOnboarding = false
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
-        WithPerceptionTracking {
-            ZStack {
-                if store.hasSeenOnboarding {
-                    NavigationStack {
-                        HomeView(store: store.scope(state: \.home, action: \.home))
-                    }
-                    .transition(.opacity)
-                } else {
-                    OnboardingView(
-                        store: store.scope(state: \.onboarding, action: \.onboarding)
-                    )
-                        .transition(.opacity)
-                }
-            }
-            .animation(
-                reduceMotion ? nil : AppAnimation.onboardingTransition,
-                value: store.hasSeenOnboarding
-            )
-            .onChangeCompat(of: persistedHasSeenOnboarding) { newValue in
-                if store.hasSeenOnboarding != newValue {
-                    store.send(.hasSeenOnboardingChanged(newValue))
-                }
-            }
-        }
+        RootView(store: store)
     }
 }
 

--- a/Tests/EyePostureReminderTests/TCA/ContentViewTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/ContentViewTests.swift
@@ -5,13 +5,13 @@ import XCTest
 
 @testable import EyePostureReminder
 
-/// `ContentView` body coverage — exercises both the onboarding-gated branch
-/// and the home branch wired up by Phase 2 issue `p0-tca-11` (#674).
+/// `ContentView` body coverage — verifies the thin wrapper still mounts
+/// `RootView` (the canonical TCA root introduced by `#755` Phase D) for both
+/// onboarding-gated and home branches of `AppFeature.State`.
 ///
-/// `ContentView` requires both a TCA `Store` (root state) and the legacy
-/// `@EnvironmentObject` graph (`SettingsStore` + `AppCoordinator`) because
-/// `HomeView` / `OnboardingView` have not yet been migrated off MVVM
-/// (`p0-tca-14` / #677).
+/// As of `#755` Phase D, `ContentView` is a pure pass-through for
+/// `RootView(store:)`; the `@EnvironmentObject` graph (`SettingsStore` +
+/// `AppCoordinator`) has been removed from the view tree.
 @MainActor
 final class ContentViewTests: XCTestCase {
 
@@ -99,19 +99,6 @@ final class ContentViewTests: XCTestCase {
             $0.screenTimeAuthorizationClient = ScreenTimeAuthorizationClient()
             $0.analyticsClient = AnalyticsClient(log: { _ in })
         }
-    }
-
-    /// Builds an `AppCoordinator` whose collaborators are all mock doubles —
-    /// matches `PreviewTests.makeTestCoordinator()`.
-    private func makeTestCoordinator() -> AppCoordinator {
-        AppCoordinator(
-            scheduler: MockReminderScheduler(),
-            notificationCenter: MockNotificationCenter(),
-            overlayManager: MockOverlayPresenting(),
-            screenTimeTracker: MockScreenTimeTracker(),
-            pauseConditionProvider: MockPauseConditionProvider(),
-            ipcStore: MockAppGroupIPCRecorder()
-        )
     }
 
     // MARK: - Body description coverage


### PR DESCRIPTION
## Summary

Phase D of #755. Promotes `RootView` to the canonical TCA root surface so `EyePostureReminderApp.swift` no longer holds an `@StateObject AppCoordinator` or injects it (or `SettingsStore`) via `.environmentObject(...)`. The legacy MVVM root chain is gone from the app entry point; only the store survives.

Phases A (#756), B (#757), and C (#758) landed previously; this PR closes the root-wiring half of the Phase A–E plan from #755. Phase E (deleting the `AppCoordinator*.swift` files + the 10 `Services/AppCoordinator*Tests.swift` files) is the only remaining sub-phase.

## Changes

- `EyePostureReminder/TCA/RootView.swift`
  - Promote from placeholder to canonical root: owns the `OnboardingView` ↔ `HomeView` gate (moved from `ContentView`), the `@AppStorage(AppStorageKey.hasSeenOnboarding)` bridge that fires `AppFeature.hasSeenOnboardingChanged`, and the destination + overlay presentation scaffolding.
  - Destination sheets / covers remain wired against `AppFeature.Destination` and `AppFeature.State.overlay`. No production code currently writes to those slots (`HomeView` / `OnboardingView` still own local sheet presentations, `OverlayManager` still hosts the overlay UIWindow), so the slots render `EmptyView()` until a follow-up issue migrates the presentation triggers into the reducer. The scaffolding shape is preserved so `state.overlay = nil` teardown (#738) keeps working.
- `EyePostureReminder/Views/ContentView.swift`
  - Collapse to a one-line wrapper around `RootView(store:)`. Retained so `ContentViewTests` and existing call sites have a stable entry point during the Phase D / Phase E migration; new callers should prefer `RootView` directly.
- `EyePostureReminder/App/EyePostureReminderApp.swift`
  - Drop `@StateObject private var coordinator = AppCoordinator()`.
  - Drop `.environmentObject(coordinator.settings)` and `.environmentObject(coordinator)` on the root view.
  - Mount `RootView(store: store)` directly.
  - Refresh the store docstring to reflect the new contract (every view in the tree reads from the store scope or `@AppStorage`).
- `Tests/EyePostureReminderTests/TCA/ContentViewTests.swift`
  - Drop the unused `makeTestCoordinator()` helper; refresh the file docstring to describe the wrapper pattern. All six existing assertions still exercise the gate via `ContentView(store:)`, which now transitively covers `RootView`.

## Verification

- `./scripts/build.sh build` — ✓
- `./scripts/build.sh test`  — ✓ **2048 tests, 1 skipped, 0 failures**
- `./scripts/build.sh lint`  — ✓ (SwiftLint + privacy-sync)
- Test-count delta vs. main@55d331d: **0** (Phase D restructures wiring; no symbols added or deleted).

## Acceptance check (vs. #755 Phase D)

- [x] `EyePostureReminderApp.swift` no longer references `AppCoordinator` or `SettingsStore` as an environment object.
- [x] `./scripts/build.sh all` passes.

## Out of scope / Follow-ups

- `AppCoordinator*.swift` source files (5) + 10 `Tests/.../Services/AppCoordinator*Tests.swift` files: still present, scheduled for deletion in **Phase E**. The post-Phase-D build keeps compiling them because non-app code (test bundles, the `snoozeWakeCategory` lookup in `AppDelegate.NotificationRoute`) still references `AppCoordinator` symbols. Phase E inlines that one production reference and deletes the rest.
- `EyePostureReminder/TCA/Dependencies/*.swift` remain `do_not_touch` per the issue spec.

Refs #755 (Phase D).