### PR TITLE
refactor(SettingsStore): drop ObservableObject conformance (#701)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -259,7 +259,7 @@ EyePostureReminder/                  (SPM executable target)
 │   ├── AppConfig.swift               Codable struct; loads defaults.json; .fallback hardcoded
 │   ├── ReminderType.swift            enum: .eyes / .posture; display + notification identity
 │   ├── ReminderSettings.swift        struct: interval + breakDuration (seconds)
-│   └── SettingsStore.swift           @MainActor + ObservableObject; UserDefaults wrapper; SettingsPersisting protocol; UUID-keyed observer surface (Combine `@Published` removed; `objectWillChange.send()` driven from `broadcastChange()`)
+│   └── SettingsStore.swift           @MainActor UserDefaults wrapper; SettingsPersisting protocol; UUID-keyed observer surface (Combine + `ObservableObject` conformance removed in #701; consumers subscribe via `addObserver` / `removeObserver`)
 │
 ├── Services/
 │   ├── AppCoordinator.swift          @MainActor; owns all services; ReminderScheduling conformance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ existing `@StateObject AppCoordinator`, so behaviour is byte-equivalent.
 - **#696 — Wire root TCA `Store` in `EyePostureReminderApp`.**
 - **#699 — Bridge `AppDelegate` notification routes to TCA root Store.**
 - **#700 — Wire `ScenePhase` observation as a TCA effect.**
+- **#701 — Strip `: ObservableObject` (and the manual `objectWillChange.send()` broadcast) from `SettingsStore`.** Closes the final piece of the MVVM decommission: all SwiftUI surfaces now read settings through their feature stores, non-SwiftUI consumers use the existing `addObserver` / `removeObserver` surface, and `import Combine` is gone from the file.
 
 #### #462 Phase A — Dependency-injection seams across services
 A long mechanical pass replacing every implicit global / singleton lookup in
@@ -181,8 +182,8 @@ to make the TCA Phase-1 reducers testable in isolation.
 - **165 PRs** merged on top of `v0.2.0` — see `git log v0.2.0..main` for the
   full ledger; this section groups the contributor-visible delta.
 - **Phase 3 of the TCA migration is in flight** (per-feature `TestStore`
-  coverage); the remaining MVVM decommission work is tracked in #677, #701,
-  and #702 and will appear in the next release section once those land.
+  coverage); the remaining MVVM decommission work is tracked in #677 and
+  #702 and will appear in the next release section once those land.
 
 ---
 

--- a/EyePostureReminder/Models/SettingsStore.swift
+++ b/EyePostureReminder/Models/SettingsStore.swift
@@ -1,4 +1,3 @@
-import Combine
 import Foundation
 import os
 
@@ -7,11 +6,12 @@ import os
 /// Mutations drive a lightweight observer surface (`addObserver` /
 /// `removeObserver`) so consumers — `SettingsClient.liveValue` and any other
 /// listeners — can react without paying the Combine / `@Published` tax.
-/// `: ObservableObject` conformance is retained so legacy SwiftUI surfaces
-/// using `@EnvironmentObject SettingsStore` continue to refresh;
-/// `objectWillChange.send()` is invoked manually from `broadcastChange()`. The
-/// full `ObservableObject` strip is deferred until the MVVM → TCA view
-/// migration (#677) is complete.
+/// The MVVM → TCA view migration (#677 / #755) removed every
+/// `@EnvironmentObject SettingsStore` callsite, so `: ObservableObject`
+/// conformance and the manual `objectWillChange.send()` broadcast were
+/// dropped under #701. SwiftUI surfaces now read settings exclusively
+/// through their feature stores; non-SwiftUI consumers use the observer
+/// surface below.
 /// The initialiser accepts a `SettingsPersisting` dependency so unit tests
 /// can inject an in-memory store without touching the file system.
 ///
@@ -33,7 +33,7 @@ import os
 /// kshana.notificationFallbackEnabled    Bool   – default true
 /// ```
 @MainActor
-final class SettingsStore: ObservableObject {
+final class SettingsStore {
 
     // MARK: - Global Toggle
 
@@ -191,9 +191,8 @@ final class SettingsStore: ObservableObject {
 
     /// Registers `callback` to receive the current `settings(for: .eyes)`
     /// snapshot every time **any** mutable property changes (or
-    /// `resetToDefaults()` runs). Replaces the legacy `objectWillChange`
-    /// publisher so consumers no longer need Combine. Returns a token that
-    /// must be passed back to `removeObserver(_:)` to unsubscribe.
+    /// `resetToDefaults()` runs). Returns a token that must be passed back
+    /// to `removeObserver(_:)` to unsubscribe.
     @discardableResult
     func addObserver(_ callback: @escaping (ReminderSettings) -> Void) -> ObserverID {
         let id = ObserverID()
@@ -208,7 +207,6 @@ final class SettingsStore: ObservableObject {
     }
 
     private func broadcastChange() {
-        objectWillChange.send()
         guard !observers.isEmpty else { return }
         let snapshot = settings(for: .eyes)
         for callback in observers.values { callback(snapshot) }


### PR DESCRIPTION
## Summary

Strips `: ObservableObject` and the manual `objectWillChange.send()` broadcast from `SettingsStore`, completing the deferred Phase-2 task from #677. The observer surface added by #716 (`addObserver` / `removeObserver`) is now the sole subscription path; `SettingsClient.liveValue` already consumes it (line 160).

After #755 Phases A/B/C/D/E (PRs #756/#757/#758/#759/#760) every `@EnvironmentObject SettingsStore` callsite is gone, so the conformance is no longer load-bearing.

## Changes

- `EyePostureReminder/Models/SettingsStore.swift`
  - Drop `: ObservableObject` on `final class SettingsStore`.
  - Drop `objectWillChange.send()` from `broadcastChange()`.
  - Drop `import Combine` — no remaining users in this file.
  - Refresh the type-level + `addObserver` docstrings (drop the "deferred until #677" wording).
- `ARCHITECTURE.md`
  - One-line SettingsStore description in the file tree section now reflects the post-strip state. The rest of the doc still describes MVVM-era state under #725 docs-drift cleanup.
- `CHANGELOG.md`
  - Note the ObservableObject strip under Unreleased.

## Acceptance criteria (from #701)

- ✓ `SettingsStore` no longer conforms to `ObservableObject`.
- ✓ `SettingsClient.liveValue.stream()` still emits on every settings mutation (covered by existing `SettingsClientLiveValueTests`).
- ✓ No regressions in `SettingsFeature` or any consumer of `SettingsClient.stream`.

## Verification

`./scripts/build.sh all` locally → green:
- Build: ✓
- Lint (SwiftLint --strict): ✓
- Tests: 1817 executed, 1 skipped, 0 failures.

`grep -rn "settingsStore\.objectWillChange\|SettingsStore.*ObservableObject\|store\.objectWillChange" EyePostureReminder/ Tests/` returns 0 hits outside the docstring noting the strip.

## Risks

- **Low.** `SettingsClient.liveValue` already routes through `addObserver` (#716); no production code consumed `objectWillChange` on this type. SwiftUI surfaces all read settings through their feature stores after #755.

Closes #701