### PR TITLE
docs(sources): strip stale `AppCoordinator` doc references (#767)

### DIFF
--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -91,12 +91,13 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     private var pendingNotificationRoutes: [NotificationRoute] = []
 
 #if DEBUG
-    /// Pre-seeds UI-test UserDefaults keys in `init()` — before `@StateObject
-    /// AppCoordinator()` in `EyePostureReminderApp` can read them. Without this
-    /// guard, `AppCoordinator.init()` races with `didFinishLaunchingWithOptions`
-    /// and falls back to `ScreenTimeAuthorizationNoop(.unavailable)`, which
-    /// prevents `TrueInterruptSkippedBanner` from ever rendering on the first
-    /// cold launch (#457).
+    /// Pre-seeds UI-test UserDefaults keys before the SwiftUI store seed
+    /// in `EyePostureReminderApp.init()` reads them. Without this guard,
+    /// the seed (which historically lived on `@StateObject AppCoordinator`,
+    /// deleted in `#755` Phase E) raced with `didFinishLaunchingWithOptions`
+    /// and fell back to `ScreenTimeAuthorizationNoop(.unavailable)`, which
+    /// prevented `TrueInterruptSkippedBanner` from ever rendering on the
+    /// first cold launch (#457).
     ///
     /// `hasSeenOnboarding` is pre-seeded earlier — directly in
     /// `EyePostureReminderApp.init()` — because `@UIApplicationDelegateAdaptor`
@@ -105,13 +106,13 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     ///
     /// Overlay launch arguments (`--show-overlay-eyes` / `--show-overlay-posture`)
     /// are also seeded here so the `uiTestOverlayType` key and inflated break
-    /// durations land before `@StateObject AppCoordinator()` constructs its
-    /// `SettingsStore` (which reads `eyes.breakDuration`/`posture.breakDuration`
-    /// from `UserDefaults` at init). Without this, `applyUITestLaunchArguments()`
-    /// — which runs from `didFinishLaunchingWithOptions`, after the SwiftUI
-    /// state-object instantiation in some launch orderings — wrote inflated
-    /// values into a settings store the active overlay was no longer using,
-    /// causing the overlay to auto-dismiss before tests asserted on it (#711).
+    /// durations land before the TCA root state's initial seed reads
+    /// `eyes.breakDuration` / `posture.breakDuration` from `UserDefaults`.
+    /// Without this, `applyUITestLaunchArguments()` — which runs from
+    /// `didFinishLaunchingWithOptions`, after the SwiftUI state seed in
+    /// some launch orderings — wrote inflated values into a settings store
+    /// the active overlay was no longer using, causing the overlay to
+    /// auto-dismiss before tests asserted on it (#711).
     private func preSeedUITestDefaults() {
         if launchArguments.contains("--simulate-screen-time-not-determined") {
             uiTestDefaults.set(

--- a/EyePostureReminder/App/EyePostureReminderApp.swift
+++ b/EyePostureReminder/App/EyePostureReminderApp.swift
@@ -138,9 +138,9 @@ struct EyePostureReminderApp: App {
     /// Routes through `store.send(.notificationRouted(.reminder(type)))` —
     /// the same path UNUserNotificationCenter delivery takes via
     /// `AppDelegate.dispatchNotificationRoute` — so the backdoor exercises
-    /// production reducer code instead of the deprecated
-    /// `AppCoordinator.handleNotification` shim that #677 / #702 are
-    /// dismantling. The synchronous `state.scheduling.settings` seed in
+    /// production reducer code instead of the legacy
+    /// `AppCoordinator.handleNotification` shim that was deleted in `#755`
+    /// Phase E. The synchronous `state.scheduling.settings` seed in
     /// `init()` plus the `--show-overlay-*` UserDefaults inflation guarantees
     /// the reducer reads the inflated `breakDuration` immediately, without
     /// racing the `SettingsClient.stream` first emission (#737).

--- a/EyePostureReminder/Services/AppGroupIPCProviding.swift
+++ b/EyePostureReminder/Services/AppGroupIPCProviding.swift
@@ -3,7 +3,8 @@ import ScreenTimeExtensionShared
 
 // MARK: - AppGroupIPCProviding
 
-/// Abstraction over `AppGroupIPCStore` used by `AppCoordinator` for dependency injection.
+/// Abstraction over `AppGroupIPCStore` used by the TCA dependency
+/// clients (`IPCClient`, `SchedulingFeature`) for substitution in tests.
 protocol AppGroupIPCProviding: AppGroupIPCEventRecording {
     func isTrueInterruptEnabled() -> Bool
     func readSelection() throws -> AppGroupSelectionSnapshot

--- a/EyePostureReminder/Services/DeviceActivityMonitorNoop.swift
+++ b/EyePostureReminder/Services/DeviceActivityMonitorNoop.swift
@@ -1,12 +1,13 @@
 /// Compile-safe no-op implementation of `DeviceActivityMonitorProviding`.
 ///
-/// Injected by `AppCoordinator` until:
+/// Used as the default `DeviceActivityMonitorProviding` injection until:
 ///   1. The `com.apple.developer.family-controls` entitlement is provisioned (#201), AND
-///   2. A real `DeviceActivityCenter`-backed scheduler is wired into the coordinator.
+///   2. A real `DeviceActivityCenter`-backed scheduler is wired into the runtime.
 ///
-/// `isAvailable` is always `false`, ensuring `AppCoordinator` never calls
-/// `scheduleBreakMonitoring(for:)` with this stub (callers guard on `isAvailable`).
-/// No `DeviceActivity`, `ManagedSettings`, or `FamilyControls` frameworks are imported.
+/// `isAvailable` is always `false`, so callers never invoke
+/// `scheduleBreakMonitoring(for:)` against this stub (every call site
+/// guards on `isAvailable`). No `DeviceActivity`, `ManagedSettings`, or
+/// `FamilyControls` frameworks are imported.
 
 import Foundation
 

--- a/EyePostureReminder/Services/DeviceActivityMonitorProviding.swift
+++ b/EyePostureReminder/Services/DeviceActivityMonitorProviding.swift
@@ -10,10 +10,10 @@
 /// `FamilyControls`, `DeviceActivity`, or `ManagedSettings` references.
 /// The concrete implementation will add those imports once #201 is resolved.
 ///
-/// **Default injection:** `AppCoordinator` holds `DeviceActivityMonitorNoop` until:
+/// **Default injection:** the live runtime holds `DeviceActivityMonitorNoop` until:
 ///   1. FamilyControls entitlement is provisioned (#201).
 ///   2. The user grants `AuthorizationCenter.shared.requestAuthorization(for: .individual)`.
-///   3. `DeviceActivityMonitorScheduler` (real impl) is passed to the coordinator init.
+///   3. `DeviceActivityMonitorScheduler` (real impl) is wired into the dependency client.
 ///
 /// **Session lifecycle:**
 ///   - Call `scheduleBreakMonitoring(for:)` when the break overlay is actually visible.
@@ -37,7 +37,7 @@ protocol DeviceActivityMonitorProviding: ServiceLifecycle {
     /// - The user has not granted FamilyControls authorization.
     /// - The device is a simulator (DeviceActivity does not function in Simulator).
     ///
-    /// `AppCoordinator` guards on `isAvailable` before scheduling monitor operations.
+    /// Callers guard on `isAvailable` before scheduling monitor operations.
     var isAvailable: Bool { get }
 
     /// The currently active break monitoring session, or `nil` when no window is running.

--- a/EyePostureReminder/Services/NoopServices.swift
+++ b/EyePostureReminder/Services/NoopServices.swift
@@ -1,4 +1,4 @@
-// Lightweight no-op stubs injected by AppCoordinator in UI test mode.
+// Lightweight no-op stubs swapped in via dependency injection in UI test mode.
 // They satisfy the ScreenTimeTracking / PauseConditionProviding protocols
 // without registering UIKit lifecycle observers or starting repeating timers,
 // which would otherwise fire on the main thread every second and prevent

--- a/EyePostureReminder/Services/OverlayManager.swift
+++ b/EyePostureReminder/Services/OverlayManager.swift
@@ -153,8 +153,8 @@ final class OverlayManager: OverlayPresenting {
     /// Whether a break overlay window is currently on screen and visible to the user.
     ///
     /// `true` while a `UIWindow` is installed and not hidden, `false` after dismissal
-    /// or before the first overlay is shown. Read by `AppCoordinator` to decide
-    /// whether to suppress duplicate threshold-triggered presentations.
+    /// or before the first overlay is shown. Read by the scheduling surface to
+    /// decide whether to suppress duplicate threshold-triggered presentations.
     var isOverlayVisible: Bool {
         overlayWindow != nil && overlayWindow?.isHidden == false
     }

--- a/EyePostureReminder/Services/ReminderScheduler.swift
+++ b/EyePostureReminder/Services/ReminderScheduler.swift
@@ -94,11 +94,11 @@ final class ReminderScheduler: ReminderScheduling {
 
     // MARK: Scheduling — production + test paths
     //
-    // `scheduleReminders(using:)` and `rescheduleReminder(for:using:)` are called
-    // by `AppCoordinator.scheduleReminders()` and `performReschedule(for:)` when
-    // notification permission is `.authorized`, and are also exercised by unit tests.
-    // `AppCoordinator`'s `ReminderScheduling` conformance routes calls through its
-    // own auth-aware paths before delegating here.
+    // `scheduleReminders(using:)` and `rescheduleReminder(for:using:)` are
+    // called by `SchedulingFeature`'s scheduling effects when notification
+    // permission is `.authorized`, and are also exercised by unit tests.
+    // Callers route through their own auth-aware paths before delegating
+    // here.
 
     func scheduleReminders(using settings: SettingsStore) async {
         Logger.scheduling.info("Scheduling all reminders")

--- a/EyePostureReminder/Services/ScreenTimeAuthorizationNoop.swift
+++ b/EyePostureReminder/Services/ScreenTimeAuthorizationNoop.swift
@@ -1,11 +1,11 @@
 /// Compile-safe no-op implementation of `ScreenTimeAuthorizationProviding`.
 ///
-/// Injected by `AppCoordinator` until:
+/// Used as the default `ScreenTimeAuthorizationProviding` injection until:
 /// 1. The `com.apple.developer.family-controls` entitlement is provisioned (#201), AND
 /// 2. A real FamilyControls-backed authorization manager is wired in.
 ///
 /// Returns `.unavailable` for all state queries, accurately reflecting the
-/// pre-entitlement condition. `AppCoordinator` and the onboarding / settings UI
+/// pre-entitlement condition. The TCA onboarding / settings reducers
 /// check `authorizationStatus == .unavailable` to show appropriate copy.
 
 import Foundation

--- a/EyePostureReminder/Services/ScreenTimeAuthorizationStub.swift
+++ b/EyePostureReminder/Services/ScreenTimeAuthorizationStub.swift
@@ -1,8 +1,9 @@
 /// Test-only stub implementation of `ScreenTimeAuthorizationProviding`.
 ///
-/// Injected by `AppCoordinator` when the `--simulate-screen-time-not-determined`
-/// launch argument is present. Allows UITests to reach `.notDetermined` authorization
-/// state without requiring the `com.apple.developer.family-controls` entitlement
+/// Swapped in for the live `ScreenTimeAuthorizationProviding` when the
+/// `--simulate-screen-time-not-determined` launch argument is present.
+/// Allows UITests to reach `.notDetermined` authorization state without
+/// requiring the `com.apple.developer.family-controls` entitlement
 /// or real FamilyControls APIs (#399).
 ///
 /// Only compiled in DEBUG builds — never ships in release.

--- a/EyePostureReminder/Services/ScreenTimeShieldNoop.swift
+++ b/EyePostureReminder/Services/ScreenTimeShieldNoop.swift
@@ -1,12 +1,12 @@
 /// Compile-safe no-op implementation of `ScreenTimeShieldProviding`.
 ///
-/// Injected by `AppCoordinator` until:
+/// Used as the default `ScreenTimeShieldProviding` injection until:
 /// 1. The FamilyControls entitlement is provisioned (#201), AND
 /// 2. The project is migrated to an Xcode project with the required extension
 ///    targets (`ShieldConfigurationExtension`, `DeviceActivityMonitorExtension`).
 ///
-/// The no-op ensures the `AppCoordinator` shield wiring point compiles and
-/// tests pass unconditionally, with `isAvailable = false` accurately reflecting
+/// The no-op ensures the shield wiring point compiles and tests pass
+/// unconditionally, with `isAvailable = false` accurately reflecting
 /// the pre-entitlement state.
 
 import Foundation

--- a/EyePostureReminder/Services/ScreenTimeShieldProtocols.swift
+++ b/EyePostureReminder/Services/ScreenTimeShieldProtocols.swift
@@ -5,9 +5,10 @@
 /// require the `com.apple.developer.family-controls` entitlement (#201) and
 /// App Extension targets that cannot be expressed in SPM alone.
 ///
-/// These protocols define the integration boundary so `AppCoordinator` can be
-/// wired to the shield provider now, before the Xcode project migration and
-/// entitlement approval unblock the concrete implementation.
+/// These protocols define the integration boundary so the TCA scheduling
+/// surface can be wired to the shield provider now, before the Xcode
+/// project migration and entitlement approval unblock the concrete
+/// implementation.
 
 import Foundation
 
@@ -32,7 +33,7 @@ protocol ScreenTimeShieldProviding: ServiceLifecycle {
     /// Whether Screen Time shielding is authorized and available.
     ///
     /// When `false`, `beginShield(for:)` is a no-op and should not be called.
-    /// `AppCoordinator` checks this before attempting to shield.
+    /// Callers check this before attempting to shield.
     var isAvailable: Bool { get }
 
     /// Begin a shielding session for the given break.

--- a/EyePostureReminder/Services/ScreenTimeShieldTypes.swift
+++ b/EyePostureReminder/Services/ScreenTimeShieldTypes.swift
@@ -26,8 +26,8 @@ extension ShieldTriggerReason {
 
 /// Describes a single, discrete screen-time shielding session.
 ///
-/// Created by `AppCoordinator` when a break begins and passed to
-/// `ScreenTimeShieldProviding.beginShield(for:)` and
+/// Created by the scheduling surface (`SchedulingFeature`) when a break
+/// begins and passed to `ScreenTimeShieldProviding.beginShield(for:)` and
 /// `DeviceActivityMonitorProviding.scheduleBreakMonitoring(for:)`.
 struct ShieldSession: Sendable, Equatable {
     /// The reason the shield is being applied.
@@ -67,8 +67,9 @@ extension ShieldSession {
 
     /// Convenience initialiser that derives the `ShieldTriggerReason` from a `ReminderType`.
     ///
-    /// Used by `AppCoordinator` when bridging the `ScreenTimeTracker.onThresholdReached`
-    /// callback into a `DeviceActivityMonitorProviding.scheduleBreakMonitoring(for:)` call.
+    /// Used by the scheduling surface when bridging the
+    /// `ScreenTimeTracker.onThresholdReached` callback into a
+    /// `DeviceActivityMonitorProviding.scheduleBreakMonitoring(for:)` call.
     ///
     /// - Parameters:
     ///   - type: The reminder type that reached its threshold.

--- a/EyePostureReminder/Services/ScreenTimeTracker.swift
+++ b/EyePostureReminder/Services/ScreenTimeTracker.swift
@@ -35,7 +35,7 @@ extension UIApplication: AppStateProviding {}
 /// the foreground (e.g., on `scheduleReminders()` with the app open) so the
 /// tracker begins counting without waiting for the next lifecycle event.
 ///
-/// All methods must be called on the main thread (owned by `@MainActor AppCoordinator`).
+/// All methods must be called on the main thread.
 @MainActor
 protocol ScreenTimeTracking: ServiceLifecycle {
     var onThresholdReached: (@MainActor (ReminderType) -> Void)? { get set }

--- a/EyePostureReminder/Services/ServiceLifecycle.swift
+++ b/EyePostureReminder/Services/ServiceLifecycle.swift
@@ -1,7 +1,10 @@
 /// A protocol for services that have a monitoring lifecycle.
 ///
-/// Conforming types can be uniformly started and stopped by
-/// `AppCoordinator` without knowledge of their concrete type.
+/// Conforming types can be uniformly started and stopped by their
+/// owning feature/service composition without knowledge of the concrete
+/// type (originally consumed by `AppCoordinator` before it was deleted
+/// in `#755` Phase E; the lifecycle contract still applies to the
+/// services injected through the TCA dependency clients).
 ///
 /// Both methods must be called on the main actor — implementations
 /// typically own `@MainActor`-isolated state.

--- a/EyePostureReminder/TCA/Features/OnboardingFeature.swift
+++ b/EyePostureReminder/TCA/Features/OnboardingFeature.swift
@@ -2,13 +2,13 @@ import ComposableArchitecture
 import Foundation
 import UserNotifications
 
-/// Phase 1 reducer (`p0-tca-7` / #670) backing the onboarding flow.
+/// TCA reducer (`p0-tca-7` / #670) backing the onboarding flow.
 ///
-/// Mirrors the observable behaviour of `OnboardingView` and the
-/// `OnboardingCoordinator`-style hooks routed through `AppCoordinator`
-/// today, so a later Phase 2 issue (`p0-tca-14` / #677) can swap the
-/// onboarding views to read from this store and the legacy
-/// `AppCoordinator` plumbing can be retired.
+/// Owns the observable behaviour previously handled by `OnboardingView` +
+/// the `OnboardingCoordinator`-style hooks that historically routed
+/// through `AppCoordinator` (deleted in `#755` Phase E). The onboarding
+/// views now read from this store directly, so the legacy coordinator
+/// plumbing is fully retired.
 ///
 /// ## Persistence and parent wiring
 ///
@@ -67,8 +67,9 @@ struct OnboardingFeature {
     static let lastPageIndex: Int = 3
 
     /// Notification authorisation options requested by the onboarding
-    /// permission page. Mirrors the set used by `AppCoordinator` so the
-    /// system prompt copy stays identical across the migration.
+    /// permission page. Matches the set used by the legacy `AppCoordinator`
+    /// (deleted in `#755` Phase E) so the system prompt copy stayed
+    /// identical across the migration.
     static let notificationOptions: UNAuthorizationOptions = [.alert, .sound, .badge]
 
     var body: some ReducerOf<Self> {

--- a/EyePostureReminder/TCA/Features/SchedulingFeature.swift
+++ b/EyePostureReminder/TCA/Features/SchedulingFeature.swift
@@ -3,19 +3,19 @@ import Foundation
 import ScreenTimeExtensionShared
 import UserNotifications
 
-/// Phase 1 reducer (`p0-tca-10` / #673) backing the long-running scheduling
-/// orchestration that the legacy `AppCoordinator` owns today.
+/// TCA reducer (`p0-tca-10` / #673) owning the long-running scheduling
+/// orchestration that the legacy `AppCoordinator` previously held.
 ///
-/// Mirrors the hot paths from `EyePostureReminder/Services/AppCoordinator.swift`
-/// — the streams installed at init plus `scheduleReminders`,
-/// `reschedule(for:)`, `handleNotification(for:)`, `handleForegroundTransition`,
-/// and `appWillResignActive` — using only the dependency clients defined by
-/// `p0-tca-2`. Per the Phase 1 isolation contract this file ships the reducer
-/// surface only; existing `AppCoordinator*.swift` files remain authoritative
-/// at runtime until the Phase 2 wiring issues (`p0-tca-11`–`p0-tca-15`) flip
-/// the production runtime to read from this store.
+/// Built as a behavioural mirror of the (now-deleted) hot paths from
+/// `EyePostureReminder/Services/AppCoordinator.swift` — the streams
+/// installed at init plus `scheduleReminders`, `reschedule(for:)`,
+/// `handleNotification(for:)`, `handleForegroundTransition`, and
+/// `appWillResignActive` — using the dependency clients defined by
+/// `p0-tca-2`. The legacy `AppCoordinator*.swift` files were removed
+/// in `#755` Phase E (commit b9a1c96, PR #760); this reducer is now
+/// the canonical runtime for the surface it ports.
 ///
-/// Behavioural fidelity caveats (intentional Phase-1 deferrals, tracked under
+/// Behavioural fidelity caveats (intentional deferrals, tracked under
 /// `p0-tca-15`):
 ///   * `SettingsClient` only vends a single eyes-side `ReminderSettings`
 ///     snapshot, so per-type interval differentiation reuses
@@ -25,7 +25,7 @@ import UserNotifications
 ///     analytics, launch-readiness analytics, DeviceActivity scheduling on
 ///     overlay present, and the `OverlayClient.lifecycleEvents`-driven
 ///     bookkeeping all require dependency-client surface that does not yet
-///     exist; those side-effects stay on `AppCoordinator` until Phase 2.
+///     exist; those side-effects are tracked under `p0-tca-15` follow-ups.
 ///   * `hapticsEnabled`/`pauseMediaDuringBreaks` are not yet exposed on
 ///     `ReminderSettings`; the reducer passes `false` for both when calling
 ///     `OverlayClient.show` (matches the SettingsClient default state).
@@ -34,9 +34,10 @@ struct SchedulingFeature {
 
     typealias NotificationRoute = AppDelegate.NotificationRoute
 
-    /// Identifier shared with `AppCoordinator.snoozeWakeCategory` so the
-    /// snooze-wake notification scheduled here can be cancelled by either
-    /// runtime during the migration window.
+    /// Identifier for the silent one-time wake notification scheduled when
+    /// a snooze begins. Stable across the legacy `AppCoordinator` → TCA
+    /// migration so a snooze-wake notification scheduled under the old
+    /// runtime is still cancellable here.
     static let snoozeWakeCategory = "com.yashasgujjar.kshana.snooze-wake"
 
     @ObservableState
@@ -192,7 +193,8 @@ extension SchedulingFeature {
             let status = await notificationClient.authorizationStatus()
             await send(.internalAction(.authStatusRefreshed(status)))
 
-            // Snooze guard — port of `AppCoordinator.scheduleReminders` lines 408-431.
+            // Snooze guard — ported from the deleted `AppCoordinator.scheduleReminders`
+            // (#755 Phase E).
             if let until = snapshot.snoozedUntil {
                 if until > Date() {
                     await trackerClient.pauseAll()
@@ -218,7 +220,7 @@ extension SchedulingFeature {
             }
 
             // Skip foreground tracker reconfig in UI-test mode for parity with
-            // `AppCoordinator.scheduleReminders` lines 452-455.
+            // the deleted `AppCoordinator.scheduleReminders` (#755 Phase E).
             guard !snapshot.isUITestMode else { return }
 
             await Self.configureTracker(
@@ -241,7 +243,8 @@ extension SchedulingFeature {
             try? await clock.sleep(for: .milliseconds(300))
             if Task.isCancelled { return }
 
-            // Snooze guard — port of `AppCoordinator.performReschedule` line 226.
+            // Snooze guard — ported from the deleted `AppCoordinator.performReschedule`
+            // (#755 Phase E).
             if let until = snoozedUntil, until > Date() { return }
 
             let status = await notificationClient.authorizationStatus()
@@ -286,7 +289,8 @@ extension SchedulingFeature {
         type: ReminderType,
         state: inout State
     ) -> Effect<Action> {
-        // Snooze guard — port of `AppCoordinator.handleNotification` line 514.
+        // Snooze guard — ported from the deleted `AppCoordinator.handleNotification`
+        // (#755 Phase E).
         if let until = state.snoozedUntil, until > now() { return .none }
         let duration = state.settings.breakDuration
         let interval = state.settings.interval
@@ -329,8 +333,8 @@ extension SchedulingFeature {
         let settingsClient = self.settingsClient
 
         // Defensive guard mirroring the 300 ms disable-debounce window from
-        // `AppCoordinator` init (line 282) — interval is the only signal the
-        // Phase-1 SettingsClient surfaces for the per-type enable check.
+        // the deleted `AppCoordinator` init (#755 Phase E) — interval is the
+        // only signal the SettingsClient surfaces for the per-type enable check.
         guard interval > 0 else { return .none }
 
         return .run { _ in
@@ -359,7 +363,8 @@ extension SchedulingFeature {
                 await overlayClient.dismiss()
                 return
             }
-            // Resume only if no active snooze (port of `AppCoordinator` line 320).
+            // Resume only if no active snooze (ported from the deleted
+            // `AppCoordinator.pauseConditionChanged`, #755 Phase E).
             guard (snoozedUntil ?? .distantPast) <= currentNow else { return }
             await trackerClient.resumeAll()
         }
@@ -377,7 +382,8 @@ extension SchedulingFeature {
             let status = await notificationClient.authorizationStatus()
             await send(.internalAction(.authStatusRefreshed(status)))
 
-            // Port of `AppCoordinator.handleForegroundTransition` lines 587-606.
+            // Ported from the deleted `AppCoordinator.handleForegroundTransition`
+            // (#755 Phase E).
             if let until = snoozedUntil {
                 if until <= Date() {
                     await settingsClient.setSnoozedUntil(nil)
@@ -546,9 +552,9 @@ extension SchedulingFeature {
     }
 
     /// Returns a sendable closure that schedules the silent one-time wake
-    /// notification for the supplied date — mirrors
-    /// `AppCoordinator.scheduleSnoozeWakeNotification(at:)` so a killed app
-    /// is woken when the snooze period expires.
+    /// notification for the supplied date — ports the behaviour of the
+    /// deleted `AppCoordinator.scheduleSnoozeWakeNotification(at:)` (#755
+    /// Phase E) so a killed app is woken when the snooze period expires.
     func makeScheduleSnoozeNotification() -> @Sendable (Date) async -> Void {
         let notificationClient = self.notificationClient
         return { date in

--- a/EyePostureReminder/Utilities/AppStorageKeys.swift
+++ b/EyePostureReminder/Utilities/AppStorageKeys.swift
@@ -24,7 +24,7 @@ enum AppStorageKey {
     static let trueInterruptSkippedBannerDismissed = "kshana.trueInterruptSkippedBannerDismissed"
 
     /// Set by XCUITest launch argument `--simulate-screen-time-not-determined` to override
-    /// the `ScreenTimeAuthorizationProviding` injected into `AppCoordinator` with a stub
+    /// the `ScreenTimeAuthorizationProviding` injected into the live runtime with a stub
     /// that returns the stored `ScreenTimeAuthorizationStatus.rawValue`. Cleared after use.
     static let uiTestScreenTimeStatus = "kshana.ui-test.screenTimeStatus"
 }

--- a/EyePostureReminder/Views/HomeView.swift
+++ b/EyePostureReminder/Views/HomeView.swift
@@ -10,10 +10,10 @@ import UserNotifications
 /// notification auth status is now read from `StoreOf<HomeFeature>`. Local
 /// `@AppStorage`-backed state (`openSettingsOnLaunch`,
 /// `trueInterruptSkippedBannerDismissed`) stays in the view because
-/// `HomeFeature` doesn't persist those yet; the sheet still hands off to the
-/// MVVM `SettingsView`, which receives `SettingsStore` / `AppCoordinator` via
-/// SwiftUI environment inheritance from `EyePostureReminderApp` until
-/// `#755` Phase B migrates that surface as well.
+/// `HomeFeature` doesn't persist those yet; the sheet now hands off to the
+/// TCA-driven `SettingsView` (`#755` Phase B), which is sourced from a
+/// scoped `StoreOf<SettingsFeature>` and no longer relies on environment
+/// inheritance from `EyePostureReminderApp`.
 struct HomeView: View {
     typealias LaunchArgumentsProvider = () -> [String]
     typealias ProcessEnvironmentProvider = () -> [String: String]

--- a/Tests/EyePostureReminderTests/Mocks/MockOverlayPresenting.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockOverlayPresenting.swift
@@ -28,7 +28,7 @@ final class MockOverlayPresenting: OverlayPresenting {
     // MARK: - Ordered Call History
 
     /// `ReminderType` arguments passed to `showOverlay`, in call order.
-    /// Use this to verify FIFO ordering at the AppCoordinator integration level.
+    /// Use this to verify FIFO ordering at the scheduling-feature integration level.
     private(set) var showCallOrder: [ReminderType] = []
 
     /// Duration arguments passed to `showOverlay`, parallel to `showCallOrder`.

--- a/Tests/EyePostureReminderTests/Mocks/MockPauseConditionProvider.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockPauseConditionProvider.swift
@@ -2,9 +2,11 @@ import Foundation
 
 @testable import EyePostureReminder
 
-/// Mock implementation of `PauseConditionProviding` for use in `AppCoordinatorTests`
-/// and any test that needs to control pause-condition state without real Focus mode,
-/// CarPlay, or driving-detection logic.
+/// Mock implementation of `PauseConditionProviding` for use in scheduling /
+/// pause-condition integration tests (formerly `AppCoordinatorTests`,
+/// migrated to `SchedulingFeature*Tests` in `#755` Phase E). Lets tests
+/// control pause-condition state without real Focus mode, CarPlay, or
+/// driving-detection logic.
 @MainActor
 final class MockPauseConditionProvider: PauseConditionProviding {
 

--- a/Tests/EyePostureReminderTests/Mocks/MockScreenTimeShieldProviding.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockScreenTimeShieldProviding.swift
@@ -3,10 +3,10 @@ import Foundation
 @testable import EyePostureReminder
 
 /// Mock implementation of `ScreenTimeShieldProviding` for use in
-/// `AppCoordinator` integration tests (M3.3+).
+/// scheduling / shield integration tests (M3.3+).
 ///
 /// Records calls to `beginShield` and `endShield` so tests can assert
-/// the coordinator calls the shield provider at the correct times.
+/// the scheduling surface calls the shield provider at the correct times.
 @MainActor
 final class MockScreenTimeShieldProviding: ScreenTimeShieldProviding {
 

--- a/Tests/EyePostureReminderTests/Mocks/MockScreenTimeTracker.swift
+++ b/Tests/EyePostureReminderTests/Mocks/MockScreenTimeTracker.swift
@@ -2,9 +2,11 @@ import Foundation
 
 @testable import EyePostureReminder
 
-/// Mock implementation of `ScreenTimeTracking` for use in `AppCoordinatorTests`
-/// and any test that needs to control or observe screen-time tracking behaviour
-/// without spinning up real `Timer`s or UIApplication lifecycle observers.
+/// Mock implementation of `ScreenTimeTracking` for use in scheduling /
+/// tracker integration tests (formerly `AppCoordinatorTests`, migrated to
+/// `SchedulingFeature*Tests` in `#755` Phase E). Lets tests control or
+/// observe screen-time tracking behaviour without spinning up real
+/// `Timer`s or UIApplication lifecycle observers.
 @MainActor
 final class MockScreenTimeTracker: ScreenTimeTracking {
 


### PR DESCRIPTION
## Summary

`AppCoordinator` was deleted in #755 Phase E (commit b9a1c96, PR #760), but ~17 production sources and 4 test mocks still carried doc comments describing it as a live, current runtime actor — _"Injected by `AppCoordinator`"_, _"`AppCoordinator` checks this before…"_, _"Created by `AppCoordinator` when…"_, _"owned by `@MainActor AppCoordinator`"_, _"existing `AppCoordinator*.swift` files remain authoritative at runtime"_, etc. Those references cite a file that no longer exists.

This PR is **comment-only**. It rewords each stale reference to either:

- drop the `AppCoordinator` name where the caller is generic (e.g. `ServiceLifecycle`, `ScreenTimeTracking`, `AppGroupIPCProviding`, `OverlayManager.isOverlayVisible`); or
- make the historical link explicit by adding _"legacy"_, _"previously"_, _"ported from the deleted `AppCoordinator.X` (#755 Phase E)"_.

## Files touched

**Production sources:**
- `EyePostureReminder/Services/{NoopServices, ServiceLifecycle, ScreenTimeShieldNoop, ScreenTimeShieldProtocols, ScreenTimeShieldTypes, ScreenTimeAuthorizationNoop, ScreenTimeAuthorizationStub, ScreenTimeTracker, DeviceActivityMonitorNoop, DeviceActivityMonitorProviding, AppGroupIPCProviding, OverlayManager, ReminderScheduler}.swift`
- `EyePostureReminder/Utilities/AppStorageKeys.swift`
- `EyePostureReminder/App/{AppDelegate, EyePostureReminderApp}.swift`
- `EyePostureReminder/Views/HomeView.swift`
- `EyePostureReminder/TCA/Features/{OnboardingFeature, SchedulingFeature}.swift`

**Test mocks:**
- `Tests/EyePostureReminderTests/Mocks/{MockPauseConditionProvider, MockScreenTimeTracker, MockScreenTimeShieldProviding, MockOverlayPresenting}.swift`

## Out of scope

The line-by-line _"Direct port of `AppCoordinator.X` lines Y-Z"_ archaeology comments in `Tests/.../TCA/SchedulingFeature_*Tests.swift` are kept for now. They still reference specific deleted line ranges, but they're recoverable via git history and don't claim `AppCoordinator` exists at runtime today. A future pass can prune them if desired.

## Verification

- `./scripts/build.sh all` ⇒ **1817 tests, 0 failures, lint clean** (105s)
- No behaviour changes — comment-only edits

Closes #767
