### PR TITLE
test(tca): strip `AppCoordinator` archaeology from `SchedulingFeature_*Tests` (#769)

### DIFF
--- a/Tests/EyePostureReminderTests/TCA/ContentViewTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/ContentViewTests.swift
@@ -10,8 +10,9 @@ import XCTest
 /// onboarding-gated and home branches of `AppFeature.State`.
 ///
 /// As of `#755` Phase D, `ContentView` is a pure pass-through for
-/// `RootView(store:)`; the `@EnvironmentObject` graph (`SettingsStore` +
-/// `AppCoordinator`) has been removed from the view tree.
+/// `RootView(store:)`; the legacy `@EnvironmentObject` graph
+/// (`SettingsStore` plus the now-deleted `AppCoordinator` from `#755` Phase
+/// E) has been removed from the view tree.
 @MainActor
 final class ContentViewTests: XCTestCase {
 

--- a/Tests/EyePostureReminderTests/TCA/SchedulingFeature_ForegroundTransitionTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/SchedulingFeature_ForegroundTransitionTests.swift
@@ -5,8 +5,9 @@ import XCTest
 @testable import EyePostureReminder
 
 /// `TestStore` parity coverage for `SchedulingFeature.foregroundTransition`
-/// — Phase 3 issue `p0-tca-17` (#680). Mirrors the foreground branches of
-/// the legacy `AppCoordinatorTests`.
+/// — Phase 3 issue `p0-tca-17` (#680). Ports the foreground-branch coverage
+/// that previously lived against the legacy `AppCoordinator` (deleted in
+/// `#755` Phase E, PR #760).
 @MainActor
 final class SchedulingForegroundTransitionTests: XCTestCase {
 
@@ -36,8 +37,8 @@ final class SchedulingForegroundTransitionTests: XCTestCase {
 
     /// When the cached auth status differs from the live one, the reducer
     /// must re-run `.scheduleReminders` so newly-granted authorisation gets
-    /// picked up immediately, mirroring `handleForegroundTransition`
-    /// lines 587-606.
+    /// picked up immediately, porting the auth-status-changed branch of the
+    /// deleted `AppCoordinator.handleForegroundTransition` (#755 Phase E).
     func test_foregroundTransition_noSnooze_authChanged_runsScheduleReminders() async {
         var initial = SchedulingFeature.State()
         initial.notificationAuthStatus = .notDetermined
@@ -65,8 +66,8 @@ final class SchedulingForegroundTransitionTests: XCTestCase {
 
     /// Future snooze + authorized notifications: reducer arms the wake task
     /// and posts the silent snooze-wake notification, but never re-runs
-    /// `.scheduleReminders`. Direct port of `handleForegroundTransition`
-    /// lines 588-595.
+    /// `.scheduleReminders`. Ports the future-snooze branch of the deleted
+    /// `AppCoordinator.handleForegroundTransition` (#755 Phase E).
     func test_foregroundTransition_futureSnooze_authorized_armsWakeAndPostsSilentNotification() async {
         // Snooze branch in `foregroundTransitionEffect` compares `until <=
         // Date()` (system wall-clock), so use `Date.distantFuture` to keep
@@ -155,7 +156,8 @@ final class SchedulingForegroundTransitionTests: XCTestCase {
     // MARK: - Expired snooze on foreground
 
     /// Returning to foreground after a snooze expired must clear state and
-    /// re-run scheduling — `handleForegroundTransition` lines 596-605.
+    /// re-run scheduling — ports the expired-snooze branch of the deleted
+    /// `AppCoordinator.handleForegroundTransition` (#755 Phase E).
     func test_foregroundTransition_expiredSnooze_clearsAndReschedules() async {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let setUntilCalls = LockIsolated<[Date?]>([])

--- a/Tests/EyePostureReminderTests/TCA/SchedulingFeature_NotificationRoutingTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/SchedulingFeature_NotificationRoutingTests.swift
@@ -7,9 +7,9 @@ import XCTest
 
 /// `TestStore` parity coverage for `SchedulingFeature`'s notification
 /// routing + threshold-reached paths — Phase 3 issue `p0-tca-17` (#680).
-/// Mirrors `AppCoordinatorNotificationFallbackTests` and the
-/// `handleNotification` / `thresholdReached` branches of
-/// `AppCoordinatorTests`.
+/// Ports the notification-fallback / `handleNotification` /
+/// `thresholdReached` branches that previously lived against the legacy
+/// `AppCoordinator` (deleted in `#755` Phase E, PR #760).
 @MainActor
 final class SchedulingNotificationRoutingTests: XCTestCase {
 
@@ -19,7 +19,8 @@ final class SchedulingNotificationRoutingTests: XCTestCase {
     /// pipeline: clears the snooze counter, records an IPC fallback event,
     /// emits `.reminderTriggered(.notificationFallback)`, presents the
     /// overlay, and resets the in-app tracker so it doesn't double-fire.
-    /// Direct port of `AppCoordinator.handleNotification` lines 510-555.
+    /// Ports the eyes branch of the deleted
+    /// `AppCoordinator.handleNotification` (#755 Phase E).
     func test_notificationRouted_reminderEyes_runsFallbackPipeline() async {
         let setSnoozeCounts = LockIsolated<[Int]>([])
         let recordedEvents = LockIsolated<[AppGroupIPCEvent]>([])
@@ -96,7 +97,8 @@ final class SchedulingNotificationRoutingTests: XCTestCase {
     // MARK: - .notificationRouted while snoozed
 
     /// While a snooze is active, an arriving reminder notification must be
-    /// ignored — port of `handleNotification` line 514 snooze guard.
+    /// ignored — ports the snooze-guard branch of the deleted
+    /// `AppCoordinator.handleNotification` (#755 Phase E).
     func test_notificationRouted_reminderDuringActiveSnooze_isNoOp() async {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let recordedEvents = LockIsolated<[AppGroupIPCEvent]>([])
@@ -141,8 +143,9 @@ final class SchedulingNotificationRoutingTests: XCTestCase {
 
     // MARK: - .notificationRouted(.snoozeWake)
 
-    /// `.snoozeWake` clears the snooze state and re-runs scheduling — port
-    /// of `handleNotification` lines 488-498.
+    /// `.snoozeWake` clears the snooze state and re-runs scheduling — ports
+    /// the snooze-wake branch of the deleted
+    /// `AppCoordinator.handleNotification` (#755 Phase E).
     func test_notificationRouted_snoozeWake_clearsAndReschedules() async {
         var initial = SchedulingFeature.State()
         initial.snoozedUntil = Date(timeIntervalSince1970: 1_700_000_000)
@@ -181,8 +184,8 @@ final class SchedulingNotificationRoutingTests: XCTestCase {
 
     /// When `state.settings.interval == 0` the type is treated as disabled
     /// (Phase-1 SettingsClient single-value caveat) and `.thresholdReached`
-    /// must short-circuit, mirroring the `AppCoordinator` 300 ms
-    /// disable-debounce guard.
+    /// must short-circuit, porting the 300 ms disable-debounce guard from
+    /// the deleted `AppCoordinator.handleNotification` path (#755 Phase E).
     func test_thresholdReached_intervalZero_isNoOp() async {
         let shownOverlays = LockIsolated<[ReminderType]>([])
         let loggedEvents = LockIsolated<[String]>([])
@@ -277,9 +280,10 @@ final class SchedulingNotificationRoutingTests: XCTestCase {
     // MARK: - .thresholdReached — enabled, unauthorized
 
     /// When notifications are denied the foreground threshold path still
-    /// presents the overlay (mirrors `AppCoordinator` line 287 callback) but
-    /// the reducer must not call `scheduler.rescheduleReminder` because there
-    /// is no notification queue to reschedule into.
+    /// presents the overlay (ports the threshold-callback branch of the
+    /// deleted `AppCoordinator`, #755 Phase E) but the reducer must not call
+    /// `scheduler.rescheduleReminder` because there is no notification queue
+    /// to reschedule into.
     func test_thresholdReached_enabledUnauthorized_showsOverlayButSkipsReschedule() async {
         let shownOverlays = LockIsolated<[ReminderType]>([])
         let rescheduledTypes = LockIsolated<[ReminderType]>([])
@@ -321,8 +325,8 @@ final class SchedulingNotificationRoutingTests: XCTestCase {
     // MARK: - .overlayDismissed
 
     /// `.overlayDismissed` cancels every active DeviceActivity monitoring
-    /// window so a dismissed break stops accruing shield time, mirroring
-    /// `AppCoordinator.dismissOverlay`.
+    /// window so a dismissed break stops accruing shield time — ports the
+    /// deleted `AppCoordinator.dismissOverlay` (#755 Phase E).
     func test_overlayDismissed_cancelsAllDeviceActivitySessions() async {
         let cancelArgs = LockIsolated<[UUID?]>([])
 

--- a/Tests/EyePostureReminderTests/TCA/SchedulingFeature_SchedulingTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/SchedulingFeature_SchedulingTests.swift
@@ -5,12 +5,11 @@ import XCTest
 @testable import EyePostureReminder
 
 /// `TestStore` parity coverage for `SchedulingFeature` — Phase 3 issue
-/// `p0-tca-17` (#680). Mirrors the scheduling and reschedule paths exercised
-/// by the legacy `AppCoordinatorTests` family
-/// (`AppCoordinatorTests`, `AppCoordinatorCancelReminderTests`,
-/// `AppCoordinatorThresholdGuardTests`).
+/// `p0-tca-17` (#680). Ports the scheduling and reschedule branches that
+/// previously lived against the legacy `AppCoordinator` (deleted in `#755`
+/// Phase E, PR #760).
 ///
-/// Behavioural-fidelity caveats from `SchedulingFeature.swift` lines 18-31
+/// Behavioural-fidelity caveats from the `SchedulingFeature` preamble
 /// (deferred to Phase 2):
 ///   * `analytics.log(.schedulePathSelected(...))` is not yet emitted by the
 ///     reducer, so the matching assertion is omitted here.
@@ -98,8 +97,9 @@ final class SchedulingFeatureSchedulingTests: XCTestCase {
     // MARK: - .scheduleReminders — unauthorized path
 
     /// `.scheduleReminders` while notifications are denied must call
-    /// `cancelAllReminders` instead of scheduling, mirroring
-    /// `AppCoordinator.scheduleReminders` lines 432-447.
+    /// `cancelAllReminders` instead of scheduling — ports the
+    /// unauthorized branch of the deleted
+    /// `AppCoordinator.scheduleReminders` (#755 Phase E).
     func test_scheduleReminders_unauthorized_cancelsAllReminders() async {
         let scheduledCount = LockIsolated(0)
         let cancelledAll = LockIsolated(0)
@@ -134,9 +134,9 @@ final class SchedulingFeatureSchedulingTests: XCTestCase {
 
     // MARK: - .scheduleReminders — UI-test mode skips tracker reconfig
 
-    /// UI-test mode must short-circuit the foreground tracker reconfig per
-    /// `AppCoordinator.scheduleReminders` lines 452-455 — same parity carried
-    /// over to `scheduleRemindersEffect` line 222.
+    /// UI-test mode must short-circuit the foreground tracker reconfig —
+    /// parity carried over from the deleted `AppCoordinator.scheduleReminders`
+    /// UI-test guard (#755 Phase E) into `scheduleRemindersEffect`.
     func test_scheduleReminders_uiTestMode_skipsTrackerConfig() async {
         let setThresholdCount = LockIsolated(0)
 
@@ -176,7 +176,7 @@ final class SchedulingFeatureSchedulingTests: XCTestCase {
 
     /// Two rapid `.rescheduleType(.eyes)` calls within the 300 ms debounce
     /// window must collapse to a single tracker / scheduler invocation, per
-    /// `rescheduleTypeEffect` line 264 (`cancelInFlight: true`).
+    /// `rescheduleTypeEffect`'s `.cancellable(..., cancelInFlight: true)`.
     func test_rescheduleType_doubleFireWithinDebounce_collapsesToSingleInvocation() async {
         let clock = TestClock()
         let setThresholds = LockIsolated<[ReminderType]>([])
@@ -230,8 +230,8 @@ final class SchedulingFeatureSchedulingTests: XCTestCase {
     // MARK: - .rescheduleType — interval == 0 disables tracking
 
     /// When the per-type interval is 0 the reducer must disable tracking and
-    /// cancel scheduled reminders for that type, mirroring
-    /// `AppCoordinator.performReschedule` lines 234-249.
+    /// cancel scheduled reminders for that type — ports the disable-debounce
+    /// branch of the deleted `AppCoordinator.performReschedule` (#755 Phase E).
     func test_rescheduleType_intervalZero_disablesAndCancels() async {
         let clock = TestClock()
         let disabledTypes = LockIsolated<[ReminderType]>([])
@@ -280,7 +280,8 @@ final class SchedulingFeatureSchedulingTests: XCTestCase {
 
     /// While notifications are denied the reducer must keep tracker enabled
     /// (so the foreground threshold path still fires) but cancel any pending
-    /// scheduled notifications, per `rescheduleTypeEffect` lines 254-258.
+    /// scheduled notifications, per `rescheduleTypeEffect`'s authorized vs.
+    /// denied scheduler branches.
     func test_rescheduleType_unauthorized_keepsTrackerCancelsScheduler() async {
         let clock = TestClock()
         let cancelledTypes = LockIsolated<[ReminderType]>([])
@@ -353,9 +354,10 @@ final class SchedulingFeatureSchedulingTests: XCTestCase {
 
     // MARK: - .backgroundTransition — emits appSessionEnd analytics
 
-    /// `.backgroundTransition` mirrors `AppCoordinator.appWillResignActive` by
-    /// emitting `.appSessionEnd` so Console.app traces show the session
-    /// boundary even after the migration.
+    /// `.backgroundTransition` is the TCA analogue of the deleted
+    /// `AppCoordinator.appWillResignActive` (#755 Phase E) — it emits
+    /// `.appSessionEnd` so Console.app traces show the session boundary
+    /// after the migration.
     func test_backgroundTransition_logsAppSessionEnd() async {
         let loggedEvents = LockIsolated<[String]>([])
 

--- a/Tests/EyePostureReminderTests/TCA/SchedulingFeature_SnoozeTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/SchedulingFeature_SnoozeTests.swift
@@ -5,8 +5,9 @@ import XCTest
 @testable import EyePostureReminder
 
 /// `TestStore` parity coverage for `SchedulingFeature`'s snooze paths —
-/// Phase 3 issue `p0-tca-17` (#680). Mirrors `AppCoordinatorSnoozeWakeTests`
-/// and the snooze branches of `AppCoordinatorTests`.
+/// Phase 3 issue `p0-tca-17` (#680). Ports the snooze-wake / snooze-branch
+/// behavioural coverage that previously lived against the legacy
+/// `AppCoordinator` (deleted in `#755` Phase E, PR #760).
 @MainActor
 final class SchedulingFeatureSnoozeTests: XCTestCase {
 
@@ -17,7 +18,8 @@ final class SchedulingFeatureSnoozeTests: XCTestCase {
     ///   * cancel every pending scheduled reminder,
     ///   * arm the snooze-wake clock task via `.scheduleSnoozeWake`,
     ///   * schedule the silent snooze-wake notification when authorized.
-    /// Mirrors `AppCoordinator.scheduleReminders` lines 408-431.
+    /// Ports the active-snooze branch of the deleted
+    /// `AppCoordinator.scheduleReminders` (#755 Phase E).
     func test_scheduleReminders_activeSnooze_authorized_pausesAndArmsWake() async {
         // The active-snooze guard inside `scheduleRemindersEffect` compares
         // against the system wall-clock (`Date()`), not `@Dependency(\.date)`,
@@ -88,8 +90,9 @@ final class SchedulingFeatureSnoozeTests: XCTestCase {
 
     /// `.scheduleReminders` with an active snooze but no notification
     /// authorisation must skip the silent-wake notification but still arm
-    /// the in-process snooze-wake task — matches the
-    /// `AppCoordinator.scheduleSnoozeWakeNotification` guard.
+    /// the in-process snooze-wake task — matches the unauthorized-guard
+    /// behaviour ported from the deleted
+    /// `AppCoordinator.scheduleSnoozeWakeNotification` (#755 Phase E).
     func test_scheduleReminders_activeSnooze_unauthorized_skipsSilentNotification() async {
         let snoozedUntil = Date.distantFuture
         let scheduledNotifications = LockIsolated<[String]>([])
@@ -131,7 +134,8 @@ final class SchedulingFeatureSnoozeTests: XCTestCase {
     // MARK: - .scheduleReminders — expired snooze branch
 
     /// An expired snooze must be cleared before the regular schedule path
-    /// runs, mirroring `AppCoordinator.scheduleReminders` lines 421-431.
+    /// runs — ports the expired-snooze branch of the deleted
+    /// `AppCoordinator.scheduleReminders` (#755 Phase E).
     func test_scheduleReminders_expiredSnooze_clearsThenSchedules() async {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let snoozedUntil = now.addingTimeInterval(-60)  // expired one minute ago
@@ -214,8 +218,8 @@ final class SchedulingFeatureSnoozeTests: XCTestCase {
     }
 
     /// An expired snooze must be cleared from state, persisted via the
-    /// settings client, and emit `.snoozeExpired` analytics — port of
-    /// `AppCoordinator.clearExpiredSnoozeIfNeeded`.
+    /// settings client, and emit `.snoozeExpired` analytics — ports the
+    /// deleted `AppCoordinator.clearExpiredSnoozeIfNeeded` (#755 Phase E).
     func test_clearExpiredSnoozeIfNeeded_expiredSnooze_clearsState() async {
         let now = Date(timeIntervalSince1970: 1_700_000_000)
         let setUntilCalls = LockIsolated<[Date?]>([])
@@ -258,7 +262,8 @@ final class SchedulingFeatureSnoozeTests: XCTestCase {
 
     /// `.snoozeWakeFired` clears state, persists, logs analytics, and
     /// re-runs `.scheduleReminders` so the regular schedule resumes — direct
-    /// analogue of `AppCoordinator.handleNotification(.snoozeWake)`.
+    /// analogue of the deleted
+    /// `AppCoordinator.handleNotification(.snoozeWake)` (#755 Phase E).
     func test_snoozeWakeFired_clearsStateAndReschedules() async {
         let setUntilCalls = LockIsolated<[Date?]>([])
         let setCountCalls = LockIsolated<[Int]>([])

--- a/Tests/EyePostureReminderTests/TCA/SchedulingFeature_WatchdogRecoveryTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/SchedulingFeature_WatchdogRecoveryTests.swift
@@ -7,21 +7,18 @@ import XCTest
 /// Watchdog-recovery TestStore coverage for `SchedulingFeature` —
 /// Phase 3 issue `p0-tca-17` (#680).
 ///
-/// The legacy `AppCoordinator.runWatchdogRecoveryIfNeeded(at:)` family
-/// (`AppCoordinatorWatchdogHeartbeatTests`) reads the App Group IPC log,
-/// detects a stale heartbeat, then cancels every reminder and restarts the
-/// schedule. The TCA `SchedulingFeature` reducer (this file's PR is the
-/// Phase-3 test rewrite, not the Phase-2 wiring) does not yet expose a
-/// watchdog-recovery action because the dependency-client surface required
-/// for it (an `IPCClient.recentEvents`-style accessor + a heartbeat clock
-/// adapter) has not been added — see the explicit deferral comment in
-/// `EyePostureReminder/TCA/Features/SchedulingFeature.swift` lines 24-28:
-///
-///     "Watchdog recovery, fallback-routing IPC reads, session-timing
-///     analytics, launch-readiness analytics, DeviceActivity scheduling on
-///     overlay present, and the OverlayClient.lifecycleEvents-driven
-///     bookkeeping all require dependency-client surface that does not yet
-///     exist; those side-effects stay on AppCoordinator until Phase 2."
+/// The legacy `AppCoordinator.runWatchdogRecoveryIfNeeded(at:)` (deleted in
+/// `#755` Phase E, PR #760) read the App Group IPC log, detected a stale
+/// heartbeat, then cancelled every reminder and restarted the schedule. The
+/// TCA `SchedulingFeature` reducer (this file's PR is the Phase-3 test
+/// rewrite, not the Phase-2 wiring) does not yet expose a watchdog-recovery
+/// action because the dependency-client surface required for it (an
+/// `IPCClient.recentEvents`-style accessor + a heartbeat clock adapter) has
+/// not been added — see the deferral note in the `SchedulingFeature.swift`
+/// preamble (watchdog recovery, fallback-routing IPC reads, session-timing
+/// analytics, launch-readiness analytics, DeviceActivity scheduling on
+/// overlay present, and `OverlayClient.lifecycleEvents`-driven bookkeeping
+/// are tracked under `p0-tca-15` follow-ups).
 ///
 /// The pause-condition + IPC stream effects defined in `startEffect()` are
 /// the closest in-scope analogues to "external trigger reschedules" so the
@@ -40,9 +37,10 @@ final class SchedulingFeatureWatchdogRecoveryTests: XCTestCase {
     func test_watchdogRecovery_deferredToPhase2() throws {
         try XCTSkipIf(true, """
             SchedulingFeature lacks watchdog-recovery surface in Phase 1
-            (see SchedulingFeature.swift lines 24-28). Re-enable once an
-            IPCClient.recentEvents accessor + heartbeat clock adapter ship
-            so AppCoordinatorWatchdogHeartbeatTests can be ported.
+            (see the deferral note in the SchedulingFeature.swift preamble).
+            Re-enable once an IPCClient.recentEvents accessor + heartbeat
+            clock adapter ship so the legacy watchdog-heartbeat coverage
+            can be ported into a behavioural-parity test.
             """)
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #767 / PR #768. The original PR explicitly left the line-number "archaeology" comments in `Tests/EyePostureReminderTests/TCA/SchedulingFeature_*Tests.swift` for a future pass; this PR is that pass.

`AppCoordinator` was deleted in #755 Phase E (commit b9a1c96, PR #760). After that deletion, ~22 test docstrings still cited specific line ranges of a file that no longer exists — _`AppCoordinator.scheduleReminders` lines 408-431_, _`AppCoordinator.handleNotification` lines 510-555_, _`AppCoordinator.performReschedule` lines 234-249_, etc. — plus references to the matching `AppCoordinator*Tests` XCTestCase classes that were removed with the file.

A small number of citations also pointed at **current** `SchedulingFeature` line numbers (_`rescheduleTypeEffect` line 264_, _lines 254-258_). Those were already stale relative to the live file (`cancelInFlight: true` now lives at line 267, the disable-tracking branch starts at line 262), so they've been reworded to cite the symbol rather than its line range.

## What changed

Comment-only. No behaviour, no test coverage change. Each occurrence was reworded to either:

- **drop entirely** when the surrounding test docstring already named the `SchedulingFeature` action under test, or
- **preserve the historical link** via _"ported from the deleted `AppCoordinator.X` (#755 Phase E)"_ — same wording PR #768 used in production sources.

The stale prose quote in `SchedulingFeature_WatchdogRecoveryTests` (which copied a `SchedulingFeature.swift` comment that PR #768 has since reworded) was also dropped in favour of a paraphrased reference to the current preamble's `p0-tca-15` deferral note.

## Files touched

All under `Tests/EyePostureReminderTests/TCA/`:

- `ContentViewTests.swift`
- `SchedulingFeature_ForegroundTransitionTests.swift`
- `SchedulingFeature_NotificationRoutingTests.swift`
- `SchedulingFeature_SchedulingTests.swift`
- `SchedulingFeature_SnoozeTests.swift`
- `SchedulingFeature_WatchdogRecoveryTests.swift`

## Acceptance criteria

- [x] No `Tests/.../TCA/SchedulingFeature_*Tests.swift` or `ContentViewTests.swift` comment carries an `AppCoordinator.swift` line-number citation.
- [x] No comment in those files references `AppCoordinator*Tests` XCTestCase classes by name.
- [x] Historical references that survive (e.g. on `SchedulingFeature_*Tests.swift`) make it explicit that `AppCoordinator` was deleted in #755 Phase E.
- [x] `./scripts/build.sh all` still passes (build + lint + tests).
- [x] No behavioural changes — comment-only edits.

## Verification

- `./scripts/build.sh all` ⇒ **1817 tests, 1 skipped, 0 failures, lint clean** (104 s)
- `grep -nE 'line[s]? [0-9]+' Tests/EyePostureReminderTests/TCA/*.swift` ⇒ no matches
- `grep -nE 'AppCoordinator[A-Z][a-zA-Z]*Tests' Tests/EyePostureReminderTests/TCA/*.swift` ⇒ no matches

Closes #769
