### PR TITLE
chore(docs+comments): strip remaining stale `AppCoordinator` references (#772)

### DIFF
--- a/EyePostureReminder/App/AppDelegate.swift
+++ b/EyePostureReminder/App/AppDelegate.swift
@@ -276,7 +276,8 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
     }
 
     /// Returns and clears a pending UI-test overlay request if present.
-    /// Used by `EyePostureReminderApp` after the coordinator is active.
+    /// Used by `EyePostureReminderApp.presentUITestOverlayIfNeeded()` after the
+    /// `AppFeature` store is active.
     func consumeUITestOverlayType() -> ReminderType? {
         guard let rawType = uiTestDefaults.string(forKey: AppStorageKey.uiTestOverlayType),
               let type = ReminderType(rawValue: rawType) else {
@@ -350,7 +351,8 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         }
     }
 
-    /// Foreground delivery — show overlay immediately via coordinator.
+    /// Foreground delivery — route to the `AppFeature` store immediately so
+    /// `SchedulingFeature` can present the overlay.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         willPresent notification: UNNotification,
@@ -362,7 +364,9 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         completionHandler([])
     }
 
-    /// Background tap — queue via coordinator (scene may not be active yet).
+    /// Background tap — dispatch to the `AppFeature` store; the route is
+    /// buffered in `pendingNotificationRoutes` and flushed once `store` is
+    /// wired up if the scene is not active yet.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse,

--- a/EyePostureReminder/Services/ScreenTimeAuthorizationProviding.swift
+++ b/EyePostureReminder/Services/ScreenTimeAuthorizationProviding.swift
@@ -49,9 +49,9 @@ enum ScreenTimeAuthorizationStatus: String, Sendable, Equatable, CaseIterable {
 /// Provides FamilyControls authorization management for True Interrupt Mode.
 ///
 /// Conforming types are `@MainActor`-isolated so SwiftUI can observe their
-/// published state directly. In production the coordinator holds a reference to
-/// `ScreenTimeAuthorizationNoop` until the entitlement is provisioned; then
-/// `ScreenTimeAuthorizationManager` is injected.
+/// published state directly. In production the `ScreenTimeAuthorizationClient`
+/// TCA dependency vends a `ScreenTimeAuthorizationNoop` until the entitlement
+/// is provisioned; then `ScreenTimeAuthorizationManager` is injected.
 @MainActor
 protocol ScreenTimeAuthorizationProviding: AnyObject {
     /// Current authorization status. Changes are expected to be observable.

--- a/Tests/EyePostureReminderTests/README.md
+++ b/Tests/EyePostureReminderTests/README.md
@@ -8,14 +8,16 @@ the Google Swift Style guide (`docs/google_swift_coding_style.md`).
 Test cases routinely declare fixtures as IUOs:
 
 ```swift
-final class AppCoordinatorTests: XCTestCase {
+final class ReminderSchedulerTests: XCTestCase {
+    var mockCenter: MockNotificationCenter!
     var settings: SettingsStore!
-    var sut: AppCoordinator!
+    var sut: ReminderScheduler!
 
-    override func setUp() async throws {
-        try await super.setUp()
+    override func setUp() {
+        super.setUp()
+        mockCenter = MockNotificationCenter()
         settings = SettingsStore(store: MockSettingsPersisting())
-        sut = AppCoordinator(settings: settings, …)
+        sut = ReminderScheduler(notificationCenter: mockCenter)
     }
 }
 ```

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -494,9 +494,9 @@ final class AppDelegateTests: XCTestCase {
     /// Regression for #711: the `--show-overlay-eyes` launch arg must seed
     /// `uiTestOverlayType`, `hasSeenOnboarding`, and the inflated break
     /// durations during `init()` (before `didFinishLaunchingWithOptions`),
-    /// so `@StateObject AppCoordinator()`'s `SettingsStore` reads the
-    /// inflated values from `UserDefaults` and the overlay does not
-    /// auto-dismiss before the UI test asserts on it.
+    /// so the `AppFeature` store seed in `EyePostureReminderApp.init()`
+    /// reads the inflated `SettingsStore` values from `UserDefaults` and
+    /// the overlay does not auto-dismiss before the UI test asserts on it.
     func test_init_showOverlayEyes_preSeedsOverlayDefaultsBeforeDidFinishLaunching() throws {
         let defaults = try makeIsolatedDefaults(suffix: #function)
 

--- a/Tests/EyePostureReminderUITests/OverlayTests.swift
+++ b/Tests/EyePostureReminderUITests/OverlayTests.swift
@@ -3,8 +3,10 @@
 //
 // XCUITest suite — Overlay view accessibility and dismiss behavior.
 //
-// NOTE: The overlay is presented by the app coordinator when a reminder notification
-// fires. In UI tests, the overlay can be triggered by using the
+// NOTE: The overlay is presented by the `SchedulingFeature` reducer when a
+// reminder notification fires (routed in via `AppDelegate` →
+// `AppFeature` store → `.notificationRouted`). In UI tests, the overlay can be
+// triggered by using the
 // TestLaunchArguments.showOverlayEyes or TestLaunchArguments.showOverlayPosture
 // launch arguments, which are fully wired to AppDelegate and EyePostureReminderApp.
 //
@@ -112,7 +114,8 @@ final class OverlayPresentationTests: XCTestCase {
             app.waitForElementExists(dismissButton),
             "Overlay dismiss button must be visible when --show-overlay-eyes is used. " +
             "Check that AppDelegate stores 'eyes' in AppStorageKey.uiTestOverlayType and " +
-            "EyePostureReminderApp calls coordinator.handleNotification(for:) in its .task."
+            "EyePostureReminderApp.presentUITestOverlayIfNeeded() routes it to the " +
+            "AppFeature store via .notificationRouted(.reminder(.eyes)) in its .task."
         )
     }
 

--- a/docs/ONBOARDING_SPEC.md
+++ b/docs/ONBOARDING_SPEC.md
@@ -52,18 +52,20 @@ Onboarding is shown exactly once. If the user force-quits mid-onboarding, they s
 Use SwiftUI `TabView` with `PageTabViewStyle` for horizontal swipe between screens.
 
 ```swift
-TabView(selection: $currentPage) {
-    OnboardingWelcomeView(onNext: { currentPage = 1 })
+TabView(selection: pageBinding) {
+    OnboardingWelcomeView(onNext: { store.send(.nextTapped) })
         .tag(0)
-    OnboardingPermissionView(onNext: { currentPage = 2 }, notificationCenter: coordinator.notificationCenter)
+    OnboardingPermissionView(
+        onNext: { store.send(.nextTapped) },
+        requestPermission: { store.send(.requestNotificationPermission) }
+    )
         .tag(1)
-    OnboardingSetupView(onGetStarted: { currentPage = 3 })
-        .environmentObject(settings)
+    OnboardingSetupView(onGetStarted: { store.send(.nextTapped) })
         .tag(2)
     OnboardingInterruptModeView(
         onGetStarted: finishOnboarding,
         onCustomize: finishOnboardingAndCustomize,
-        authorizationStatus: coordinator.screenTimeAuthorization.authorizationStatus
+        authorizationStatus: store.screenTimeStatus
     )
     .tag(3)
 }
@@ -73,7 +75,7 @@ TabView(selection: $currentPage) {
 
 - **Page dots:** Shown at the bottom centre of all 4 screens. Standard iOS page indicator style.
 - **Swipe:** Left/right swipe navigates between pages freely (no lock on forward-only).
-- **"Next" buttons:** Advance to the next page programmatically (`currentPage += 1`).
+- **"Next" buttons:** Advance to the next page programmatically by dispatching `.nextTapped` to the `OnboardingFeature` reducer.
 - **Back swipe:** Fully supported — users can go back and re-read.
 - **Screen 4 swipe lock:** A `highPriorityGesture` prevents accidental horizontal swiping on `OnboardingInterruptModeView`, ensuring deliberate completion.
 
@@ -423,29 +425,32 @@ See `EyePostureReminder/Views/Onboarding/OnboardingView.swift` for the current i
 
 ```swift
 struct OnboardingView: View {
-    @EnvironmentObject private var coordinator: AppCoordinator
-    @EnvironmentObject private var settings: SettingsStore
-    @State private var currentPage = 0
+    @Perception.Bindable var store: StoreOf<OnboardingFeature>
 
     var body: some View {
-        TabView(selection: $currentPage) {
-            OnboardingWelcomeView(onNext: { currentPage = 1 })
-                .tag(0)
-            OnboardingPermissionView(onNext: { currentPage = 2 }, notificationCenter: coordinator.notificationCenter)
-                .tag(1)
-            OnboardingSetupView(onGetStarted: { currentPage = 3 })
-                .environmentObject(settings)
-                .tag(2)
-            OnboardingInterruptModeView(
-                onGetStarted: finishOnboarding,
-                onCustomize: finishOnboardingAndCustomize,
-                authorizationStatus: coordinator.screenTimeAuthorization.authorizationStatus
-            )
-            .tag(3)
+        WithPerceptionTracking {
+            TabView(selection: pageBinding) {
+                OnboardingWelcomeView(onNext: { store.send(.nextTapped) })
+                    .tag(0)
+                OnboardingPermissionView(
+                    onNext: { store.send(.nextTapped) },
+                    requestPermission: { store.send(.requestNotificationPermission) }
+                )
+                    .tag(1)
+                OnboardingSetupView(onGetStarted: { store.send(.nextTapped) })
+                    .tag(2)
+                OnboardingInterruptModeView(
+                    onGetStarted: finishOnboarding,
+                    onCustomize: finishOnboardingAndCustomize,
+                    authorizationStatus: store.screenTimeStatus
+                )
+                .tag(3)
+            }
+            .tabViewStyle(PageTabViewStyle(indexDisplayMode: .always))
+            .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
+            .background(AppColor.background.ignoresSafeArea())
+            .onAppear { store.send(.onAppear) }
         }
-        .tabViewStyle(PageTabViewStyle(indexDisplayMode: .always))
-        .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
-        .background(AppColor.background.ignoresSafeArea())
     }
 
     private func finishOnboarding() {
@@ -460,6 +465,11 @@ struct OnboardingView: View {
     }
 }
 ```
+
+`OnboardingFeature` injects the `NotificationClient` and
+`ScreenTimeAuthorizationClient` TCA dependencies; permission requests run
+inside the reducer's `.requestNotificationPermission` and `.onAppear` effects
+rather than being threaded through the view layer.
 
 **Parent integration pattern:**
 

--- a/docs/TEST_REPORT.md
+++ b/docs/TEST_REPORT.md
@@ -44,17 +44,11 @@
 
 ---
 
-### Services — 716 tests
+### Services — 580 tests
 
 | File | Tests | Coverage Focus |
 |---|---|---|
 | `ReminderSchedulerTests` | 39 | Schedule all/single/cancel, notification content, triggers, identifiers, error resilience |
-| `AppCoordinatorTests` | 45 | Init, lifecycle hooks, ReminderScheduling conformance, overlay delegation, FIFO ordering |
-| `AppCoordinatorExtendedTests` | 47 | Extended coordinator paths, edge cases |
-| `AppCoordinatorNotificationFallbackTests` | 20 | Notification fallback when True Interrupt shield inactive |
-| `AppCoordinatorSnoozeWakeTests` | 7 | Snooze wake-up scheduling |
-| `AppCoordinatorCancelReminderTests` | 4 | Cancel reminder paths |
-| `AppCoordinatorWatchdogHeartbeatTests` | 13 | Watchdog heartbeat correctness |
 | `OverlayManagerTests` | 12 | Singleton identity, visible state, guard paths, queue management, audio wiring |
 | `OverlayManagerExtendedTests` | 20 | Extended overlay manager coverage |
 | `AudioInterruptionManagerTests` | 9 | Protocol conformance, pause/resume cycles, invariant safety |
@@ -174,7 +168,7 @@
 | **Snooze count** persistence + reset | 5 in `SettingsStorePhase2Tests` | ✅ Complete |
 | **Onboarding flag** (`hasSeenOnboarding`) | 12 in `OnboardingTests` | ✅ Complete |
 | **Accessibility** (`AppFont` Dynamic Type, `AppLayout` HIG) | 52 in `DesignSystemTests` | ✅ Complete |
-| **OverlayManager queue FIFO** (coordinator level via `MockOverlayPresenting`) | 5 in `AppCoordinatorTests` + 4 in `OverlayManagerTests` | ✅ Unit-testable paths complete |
+| **OverlayManager queue FIFO** (notification-routing level via `MockOverlayPresenting`) | 4 in `OverlayManagerTests` + routing coverage in `SchedulingFeature_NotificationRoutingTests` | ✅ Unit-testable paths complete |
 | **Smart Pause** (Focus Mode, CarPlay, driving) | 33 in `PauseConditionManagerTests` + 21 in `FocusModeExtendedTests` + 29 in `DrivingDetectionExtendedTests` | ✅ Complete |
 | **Screen-Time Triggers** (`ScreenTimeTracker`) | 54 in `ScreenTimeTrackerTests` + 19 in `ScreenTimeAuthorizationTests` | ✅ Complete |
 | **True Interrupt Mode** (shield, IPC, DeviceActivity) | 12 in `ScreenTimeShieldTests` + 31 in `DeviceActivityMonitorTests` + 24 in `AppGroupIPCStoreTests` | ✅ Unit-testable paths complete |
@@ -197,8 +191,8 @@ The following test scenarios require a live `UIWindowScene` or `UIApplication` w
 | `OverlayView` swipe-up dismiss gesture | Requires `DragGesture` and a rendered View | Simulator UI test |
 | `OverlayView` countdown ring animation | Timer-driven animation requires render loop | Simulator UI test |
 | `ContentView` onboarding routing (`@AppStorage` → View branch) | SwiftUI `@AppStorage` bridging cannot be unit-tested cleanly | Simulator UI test |
-| `AppCoordinator.startFallbackTimers` + timer fire | `Timer.scheduledTimer` requires a live run loop | Simulator integration |
-| `AppCoordinator.handleNotification` foreground path | Requires `UIApplication.shared.connectedScenes` active | Simulator integration |
+| `SchedulingFeature` watchdog/fallback effect end-to-end | Effect uses `Clock.sleep` on a live run loop and a real `UIApplication` scene to observe foreground transitions | Simulator integration |
+| `SchedulingFeature.notificationRouted` foreground path | Requires `UIApplication.shared.connectedScenes` active | Simulator integration |
 | Notification permission prompt | System UI — cannot be automated in CI | Manual test / TestFlight |
 
 ### CI Notes

--- a/docs/TEST_STRATEGY.md
+++ b/docs/TEST_STRATEGY.md
@@ -346,7 +346,7 @@ final class MockAuthorizationCenter {
 }
 ```
 
-**Tests that use this mock:** `AppCoordinatorTests` (Phase 3 branch), main app authorization flow tests
+**Tests that use this mock:** `SchedulingFeature_*Tests` and `OnboardingFeature` TCA tests (Phase 3 branch), main app authorization flow tests
 
 #### 3.5.4 Phase 3+ Extension Test Targets
 
@@ -692,7 +692,7 @@ Re-run the **full manual test checklist** whenever any of these files change:
 | `DeviceActivityMonitorExtension/` | EXT-01, EXT-02, EXT-05, manual device tests |
 | `ShieldConfigurationExtension/` | EXT-02, EXT-03, manual visual inspection |
 | `ShieldActionExtension/` | EXT-03, EXT-04, EXT-10, App Group state sync |
-| `AppCoordinator.swift` (Phase 3 branch) | EXT-06, EXT-07 (shield → fallback overlay flow) |
+| `SchedulingFeature.swift` (Phase 3 branch) | EXT-06, EXT-07 (shield → fallback overlay flow) |
 | `SettingsStore.swift` (Phase 3 branch) | Phase 2 tests + EXT-05 (App Group state isolation) |
 
 **Critical:** Always test Phase 3 changes on a **physical device**. DeviceActivity, ManagedSettings, and FamilyControls APIs are not available in simulator.

--- a/docs/app-store-submission-status.md
+++ b/docs/app-store-submission-status.md
@@ -28,7 +28,7 @@ Legend: ✅ Done · ⚠️ In progress / partial · ❌ Not started · 🔒 Bloc
 |---|------|--------|-------|
 | E1 | `NSMotionUsageDescription` present in Info.plist | ✅ Done | Present in `EyePostureReminder/Info.plist` |
 | E2 | Focus Status capability enabled on App ID for distribution signing | ⚠️ Partial | `EyePostureReminder.Distribution.entitlements` intentionally omits Focus Status to unblock archiving; enable when regenerating App Store profile |
-| E3 | Notification permission rationale accurate | ✅ Done | iOS does not require a `NS*UsageDescription` plist key for `UNUserNotificationCenter`. Authorization is requested at runtime in `OnboardingPermissionView` and `AppCoordinator.requestNotificationAuthorisation()` via `requestAuthorization(options: [.alert, .sound, .badge])`; user-facing rationale is presented on the onboarding permission screen before the system prompt. |
+| E3 | Notification permission rationale accurate | ✅ Done | iOS does not require a `NS*UsageDescription` plist key for `UNUserNotificationCenter`. Authorization is requested at runtime in `OnboardingPermissionView` via the `OnboardingFeature` reducer's `.requestNotificationPermission` effect, which calls `NotificationClient.requestAuthorization(options: [.alert, .sound, .badge])`; user-facing rationale is presented on the onboarding permission screen before the system prompt. |
 
 ---
 


### PR DESCRIPTION
Closes #772.

Strips the high-signal stale `AppCoordinator` references missed by the previous
sweeps (#767 / #770). All edits are comments / doc strings / Markdown — no
runtime / behaviour deltas.

## Scope (exactly mirrors issue #772)

### Production source comments
- `EyePostureReminder/App/AppDelegate.swift`
  - `:279` `consumeUITestOverlayType()` doc comment now points at
    `EyePostureReminderApp.presentUITestOverlayIfNeeded()` + the `AppFeature`
    store instead of "the coordinator is active".
  - `:353` foreground `willPresent` doc comment now says "route to the
    `AppFeature` store immediately so `SchedulingFeature` can present the
    overlay".
  - `:365` background `didReceive` doc comment now describes dispatching to the
    `AppFeature` store with `pendingNotificationRoutes` buffering until `store`
    is wired up.
- `EyePostureReminder/Services/ScreenTimeAuthorizationProviding.swift:52–54`
  rewritten: "In production the `ScreenTimeAuthorizationClient` TCA dependency
  vends a `ScreenTimeAuthorizationNoop` until the entitlement is provisioned;
  then `ScreenTimeAuthorizationManager` is injected."

### Test sources
- `Tests/EyePostureReminderTests/README.md` — IUO example skeleton now uses
  the still-extant `ReminderSchedulerTests` fixture.
- `Tests/EyePostureReminderTests/Services/AppDelegateTests.swift:494–499` —
  `#711` regression comment now describes the `AppFeature` store seed in
  `EyePostureReminderApp.init()` consuming the inflated `SettingsStore` values.
- `Tests/EyePostureReminderUITests/OverlayTests.swift`
  - `:6` file header NOTE retargeted to `SchedulingFeature` reducer +
    `AppDelegate` → `AppFeature` store → `.notificationRouted` routing.
  - `:113–115` `--show-overlay-eyes` assertion message now references
    `EyePostureReminderApp.presentUITestOverlayIfNeeded()` →
    `.notificationRouted(.reminder(.eyes))`.

### Docs
- `docs/TEST_REPORT.md`
  - Services table (`:47–57`): six deleted `AppCoordinator*Tests` rows
    removed; section header `716 → 580` to match the new total.
  - `:177` Phase 2 OverlayManager FIFO row rephrased to
    "(notification-routing level)" + cites
    `SchedulingFeature_NotificationRoutingTests` rather than the deleted
    `AppCoordinatorTests`.
  - `:200–201` simulator-integration gap rows replaced with the equivalent
    `SchedulingFeature` watchdog/fallback effect and `notificationRouted`
    foreground-path rows.
- `docs/TEST_STRATEGY.md`
  - `:349` mock consumers list now points at `SchedulingFeature_*Tests` /
    `OnboardingFeature` TCA tests.
  - `:695` Phase 3+ re-test matrix row retargeted to `SchedulingFeature.swift`.
- `docs/ONBOARDING_SPEC.md`
  - Both `TabView` skeletons (Navigation Structure + Full Skeleton) rewritten
    to the current `StoreOf<OnboardingFeature>` pattern: `store.send(...)`
    for page transitions, `requestPermission: { store.send(.requestNotificationPermission) }`
    on `OnboardingPermissionView`, `store.screenTimeStatus` for True Interrupt
    auth state — no more `@EnvironmentObject AppCoordinator`.
- `docs/app-store-submission-status.md:31` — entitlement E3 now cites
  `OnboardingFeature.requestNotificationPermission` via
  `NotificationClient.requestAuthorization(...)` instead of the deleted
  `AppCoordinator.requestNotificationAuthorisation()`.

## Out of scope (preserved verbatim, per issue)
- `AppDelegate.swift:96` `@StateObject AppCoordinator` provenance comment.
- `AppDelegateTests.swift:735–744` / `:788–796` tombstone comments.
- `ARCHITECTURE.md` / `ROADMAP.md` / `CHANGELOG.md` migration notes.
- All `// Ported from the deleted AppCoordinator…` provenance markers in
  TCA features / Views / `Services/ServiceLifecycle.swift` /
  `Utilities/UITestMode.swift`.

## Verification
```
$ ./scripts/build.sh all
✓ BUILD SUCCEEDED
✓ SwiftLint passed
✓ Executed 1817 tests, with 1 test skipped and 0 failures (107s)
✓ All steps passed in 107s
```

No new `AppCoordinator` mentions introduced; the residual matches in the
touched files are all explicitly out-of-scope provenance tombstones or
historical milestone summary cells (`TEST_REPORT.md` Phase-2 milestone row).
