### PR TITLE
docs(telemetry): re-anchor setting_changed + snooze emitters from deleted SettingsViewModel (#780)

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -289,7 +289,7 @@ Fired when a DeviceActivity shield session is cancelled/deactivated. No payload 
 |-------|---------|---------|--------------|
 | `durationOption` | `duration_option` | `.public` | See snooze duration code table |
 
-**Stable snooze duration codes** (from `SettingsViewModel.SnoozeOption.analyticsCode`):
+**Stable snooze duration codes** (from `SettingsFeature.SnoozeOption.analyticsCode`):
 
 | Preset | Analytics code | Duration |
 |--------|---------------|---------|
@@ -322,19 +322,21 @@ No payload. Fired when the user manually cancels an active snooze.
 
 **Instrumented `setting` key values:**
 
+The full key set is defined by `AnalyticsLogger.SettingKey` (`EyePostureReminder/Services/AnalyticsLogger.swift`). Post-TCA migration, only the interval/duration keys have live emit-sites; re-instating the remaining toggles is tracked in #777.
+
 | `setting` value | Type | Emitted from |
 |----------------|------|--------------|
-| `globalEnabled` | Bool | `SettingsViewModel.globalEnabled` setter (routed via `SettingsView` master toggle `onChange`) |
-| `eyesEnabled` | Bool | `SettingsViewModel.eyesEnabled` setter (routed via `SettingsView` `.onChange(of: settings.eyesEnabled)`) |
-| `eyesInterval` | TimeInterval | `SettingsViewModel.eyesInterval` setter |
-| `eyesBreakDuration` | TimeInterval | `SettingsViewModel.eyesBreakDuration` setter |
-| `postureEnabled` | Bool | `SettingsViewModel.postureEnabled` setter |
-| `postureInterval` | TimeInterval | `SettingsViewModel.postureInterval` setter |
-| `postureBreakDuration` | TimeInterval | `SettingsViewModel.postureBreakDuration` setter |
-| `pauseDuringFocus` | Bool | `SettingsViewModel.pauseDuringFocus` setter (routed via `SettingsSmartPauseSection` toggle `onChange`) |
-| `pauseWhileDriving` | Bool | `SettingsViewModel.pauseWhileDriving` setter |
-| `notificationFallbackEnabled` | Bool | `SettingsViewModel.notificationFallbackEnabled` setter (also triggers reschedule) |
-| `hapticsEnabled` | Bool | `SettingsViewModel.hapticsEnabled` setter (custom Binding in `SettingsView` Preferences section) |
+| `globalEnabled` | Bool | Not currently emitted post-TCA migration — tracked in #777 |
+| `eyesEnabled` | Bool | Not currently emitted post-TCA migration — tracked in #777 |
+| `eyesInterval` | TimeInterval | `SettingsFeature` reducer (`binding(\.eyesInterval)`); also emitted from `OnboardingSetupView` during the eyes setup picker |
+| `eyesBreakDuration` | TimeInterval | `SettingsFeature` reducer (`binding(\.eyesBreakDuration)`); also emitted from `OnboardingSetupView` during the eyes setup picker |
+| `postureEnabled` | Bool | Not currently emitted post-TCA migration — tracked in #777 |
+| `postureInterval` | TimeInterval | `OnboardingSetupView` posture setup picker only — Settings-screen emission tracked in #777 |
+| `postureBreakDuration` | TimeInterval | `OnboardingSetupView` posture setup picker only — Settings-screen emission tracked in #777 |
+| `pauseDuringFocus` | Bool | Not currently emitted post-TCA migration — tracked in #777 |
+| `pauseWhileDriving` | Bool | Not currently emitted post-TCA migration — tracked in #777 |
+| `notificationFallbackEnabled` | Bool | Not currently emitted post-TCA migration — tracked in #777 |
+| `hapticsEnabled` | Bool | Not currently emitted post-TCA migration — tracked in #777 |
 
 ---
 


### PR DESCRIPTION
## Summary

Re-anchors `docs/TELEMETRY.md` to the post-TCA reality. Pure doc change.

- **Snooze duration codes** (L292): `SettingsViewModel.SnoozeOption.analyticsCode` → `SettingsFeature.SnoozeOption.analyticsCode`. The type now lives in `EyePostureReminder/TCA/Features/SettingsFeature.swift:103-118` after the SettingsViewModel deletion in #761.
- **`setting_changed` table** (L323-339): each of the 11 keys in `AnalyticsLogger.SettingKey` now cites either its live TCA / view emitter or is explicitly marked as not currently emitted (tracked in #777, the follow-up emission-gap tracker filed alongside this PR).
- Added a one-sentence header pointing readers at `AnalyticsLogger.SettingKey` and #777 so downstream dashboards aren't misled.

## Verification

- `grep -c SettingsViewModel docs/TELEMETRY.md` → 0.
- Doc-only change; no Swift / build / test impact.

## Related

- Filed simultaneously: #777 (emission-gap tracker), #779 (onboarding picker doc), #778 (CI uitest re-enable follow-up).

Closes #780