### PR TITLE
docs(onboarding-spec): cite SettingsPickerOptions instead of deleted SettingsViewModel (#779)

### DIFF
--- a/docs/ONBOARDING_SPEC.md
+++ b/docs/ONBOARDING_SPEC.md
@@ -270,7 +270,7 @@ Let the user configure their eye break and posture check intervals before enteri
 |---|---|
 | **Primary CTA** | `Get Started` |
 
-Pickers use `SettingsViewModel.intervalOptions` and `SettingsViewModel.breakDurationOptions` for their values.
+Pickers use `SettingsPickerOptions.intervalOptions` and `SettingsPickerOptions.breakDurationOptions` for their values.
 
 ### "Get Started" Behaviour
 


### PR DESCRIPTION
## Summary

Pure doc change. Re-anchors `docs/ONBOARDING_SPEC.md:273` to the post-TCA picker presets type.

`SettingsViewModel` was deleted in #761 (closing #701 Phase B). The picker presets now live in `enum SettingsPickerOptions` at `EyePostureReminder/Models/SettingsPickerOptions.swift:12-29`, which is what `OnboardingSetupView` actually references.

## Verification

- `grep -n SettingsViewModel docs/ONBOARDING_SPEC.md` → no matches.
- Doc-only change.

Closes #779