### PR TITLE
chore(SettingsView): re-cite analytics-deferral comments from closed #679 to tracker #777

### DIFF
--- a/EyePostureReminder/Views/SettingsView.swift
+++ b/EyePostureReminder/Views/SettingsView.swift
@@ -58,8 +58,8 @@ private struct SettingsSectionHeader: View {
 /// The legacy analytics emissions that lived on
 /// `SettingsViewModel.notifySettingChanged(...)` are intentionally left as
 /// no-op `onChange` closures here; re-emitting them from the reducer is
-/// deferred to `p0-tca-16` (#679) once the action vocabulary expands to
-/// cover the non-eyes settings.
+/// tracked in #777 (post-TCA `setting_changed` emission gaps) once the
+/// action vocabulary expands to cover the non-eyes settings.
 struct SettingsView: View {
     @Perception.Bindable var store: StoreOf<SettingsFeature>
 
@@ -190,9 +190,9 @@ struct SettingsView: View {
                 accessibilityIdentifier: "settings.masterToggle",
                 accessibilityHint: Text("settings.masterToggle.hint", bundle: .module),
                 // Legacy `viewModel?.globalToggleChanged()` analytics
-                // emission is deferred to `p0-tca-16` (#679); the
-                // accessibility announcement still fires via
-                // `.onChangeCompat(of: globalEnabled)` below.
+                // emission is tracked in #777 (post-TCA `setting_changed`
+                // emission gaps); the accessibility announcement still
+                // fires via `.onChangeCompat(of: globalEnabled)` below.
                 onChange: { _ in },
                 label: {
                     HStack(spacing: AppSpacing.sm) {
@@ -602,8 +602,9 @@ private struct SettingsSmartPauseSection: View {
                 accessibilityIdentifier: "settings.smartPause.pauseDuringFocus",
                 accessibilityHint: Text("settings.smartPause.pauseDuringFocus.hint", bundle: .module),
                 // `.settingChanged(.pauseDuringFocus, ...)` re-emission is
-                // deferred to `p0-tca-16` (#679); the `@AppStorage` binding
-                // already round-trips through `SettingsStore`.
+                // tracked in #777 (post-TCA setting_changed emission gaps);
+                // the `@AppStorage` binding already round-trips through
+                // `SettingsStore`.
                 onChange: { _ in },
                 label: {
                     Label(
@@ -622,8 +623,9 @@ private struct SettingsSmartPauseSection: View {
                 accessibilityIdentifier: "settings.smartPause.pauseWhileDriving",
                 accessibilityHint: Text("settings.smartPause.pauseWhileDriving.hint", bundle: .module),
                 // `.settingChanged(.pauseWhileDriving, ...)` re-emission is
-                // deferred to `p0-tca-16` (#679); the `@AppStorage` binding
-                // already round-trips through `SettingsStore`.
+                // tracked in #777 (post-TCA setting_changed emission gaps);
+                // the `@AppStorage` binding already round-trips through
+                // `SettingsStore`.
                 onChange: { _ in },
                 label: {
                     Label(


### PR DESCRIPTION
## Summary

Four code comments still cited closed issue **#679** (`p0-tca-16`, a Phase 3 test-rewrite issue) as the deferral target for legacy `setting_changed` analytics re-emission. The real, currently-tracked gap is the post-TCA emission gap covered by **#777**.

Comment-only change. No behaviour change. No public API change.

## Sites updated

| Line | Subject |
|---|---|
| `SettingsView.swift:58-62` | Struct doc / `notifySettingChanged` |
| `SettingsView.swift:192-195` | Master toggle `globalToggleChanged` |
| `SettingsView.swift:604-606` | `pauseDuringFocus` toggle |
| `SettingsView.swift:624-626` | `pauseWhileDriving` toggle |

## Out of scope (intentionally left)

- **L231** — references a dead `reminderSettingChanged(.eyes)` callback that no longer exists anywhere; the reducer already owns eyes debounce + analytics emission. Cleanup is a separate concern from analytics emission gaps.
- **L258** — posture-side reschedule deferral cites a real architectural gap (`SettingsClient.snapshot`/`stream` don't vend posture values yet), unrelated to analytics emission. Warrants its own follow-up tracker.

## Verification

- `grep -c 'p0-tca-16\|#679' EyePostureReminder/Views/SettingsView.swift` → 2 (the two intentionally-left sites described above).
- `swiftlint lint EyePostureReminder/Views/SettingsView.swift` → clean.
- Comment-only diff; no semantic Swift change.

Refs #777