### PR TITLE
feat(analytics): re-instate `setting_changed` emissions for 7 silent SettingKey rows (#777)

### DIFF
--- a/EyePostureReminder/TCA/Features/SettingsFeature.swift
+++ b/EyePostureReminder/TCA/Features/SettingsFeature.swift
@@ -94,6 +94,18 @@ struct SettingsFeature {
         case savedBannerExpired
         case notificationAuthStatusChanged(UNAuthorizationStatus)
         case screenTimeAuthStatusChanged(ScreenTimeAuthorizationStatus)
+
+        /// Emit a `setting_changed` analytics event for settings that are
+        /// still persisted via `@AppStorage` rather than the bindable surface
+        /// of this reducer. `SettingsView` forwards every change to one of
+        /// the seven post-TCA non-bindable rows (#777 silent-emission gap)
+        /// plus the Settings-screen posture interval/duration pickers.
+        ///
+        /// `oldValue` / `newValue` are pre-stringified by the caller so the
+        /// action stays `Equatable` regardless of the underlying setting's
+        /// type (`Bool`, `TimeInterval`, …) and the reducer can forward
+        /// straight into `AnalyticsEvent.settingChanged`.
+        case settingToggleChanged(setting: AnalyticsEvent.SettingKey, oldValue: String, newValue: String)
     }
 
     /// Snooze durations exposed to the Settings UI. Mirrors
@@ -253,6 +265,15 @@ struct SettingsFeature {
             case let .screenTimeAuthStatusChanged(status):
                 state.screenTimeAuthStatus = status
                 return .none
+
+            case let .settingToggleChanged(setting, oldValue, newValue):
+                return .run { [analytics] _ in
+                    analytics.log(.settingChanged(
+                        setting: setting,
+                        oldValue: oldValue,
+                        newValue: newValue
+                    ))
+                }
             }
         }
     }

--- a/EyePostureReminder/Views/SettingsView.swift
+++ b/EyePostureReminder/Views/SettingsView.swift
@@ -55,11 +55,12 @@ private struct SettingsSectionHeader: View {
 ///   `SettingsFeature.State`, refreshed via the same `NotificationClient`
 ///   poll + `ScreenTimeAuthorizationClient` stream used by `HomeFeature`.
 ///
-/// The legacy analytics emissions that lived on
-/// `SettingsViewModel.notifySettingChanged(...)` are intentionally left as
-/// no-op `onChange` closures here; re-emitting them from the reducer is
-/// tracked in #777 (post-TCA `setting_changed` emission gaps) once the
-/// action vocabulary expands to cover the non-eyes settings.
+/// The `setting_changed` analytics emissions that lived on the legacy
+/// `SettingsViewModel.notifySettingChanged(...)` callbacks are restored by
+/// #777 via `prev*` `@State` mirrors and `.onChangeCompat` watchers that
+/// forward each change to `SettingsFeature.Action.settingToggleChanged`.
+/// `eyesInterval` / `eyesBreakDuration` keep emitting directly from the
+/// reducer's bindable surface.
 struct SettingsView: View {
     @Perception.Bindable var store: StoreOf<SettingsFeature>
 
@@ -160,7 +161,9 @@ struct SettingsView: View {
             .sheet(isPresented: $showDisclaimer) {
                 LegalDocumentView(document: .disclaimer)
             }
-            .onAppear { store.send(.onAppear) }
+            .onAppear {
+                store.send(.onAppear)
+            }
             .task { await store.send(.task).finish() }
             // Announce master-toggle state changes to VoiceOver (#287).
             .onChangeCompat(of: globalEnabled) { newValue in
@@ -176,6 +179,11 @@ struct SettingsView: View {
                     : String(localized: "settings.snooze.cancelled.announcement", bundle: .module)
                 accessibilityNotificationPoster.postAnnouncement(message: message)
             }
+            // `setting_changed` emissions for the seven non-bindable
+            // Settings rows + the Settings-screen posture pickers (#777).
+            // `eyesInterval` / `eyesBreakDuration` keep emitting from the
+            // reducer's bindable surface.
+            .modifier(SettingsAnalyticsForwarder(store: store))
         }
     }
 
@@ -189,10 +197,10 @@ struct SettingsView: View {
                 tint: AppColor.primaryRest,
                 accessibilityIdentifier: "settings.masterToggle",
                 accessibilityHint: Text("settings.masterToggle.hint", bundle: .module),
-                // Legacy `viewModel?.globalToggleChanged()` analytics
-                // emission is tracked in #777 (post-TCA `setting_changed`
-                // emission gaps); the accessibility announcement still
-                // fires via `.onChangeCompat(of: globalEnabled)` below.
+                // Analytics and VoiceOver announcements both fire from the
+                // `.onChangeCompat(of: globalEnabled)` modifiers on the
+                // enclosing `Form` so the toggle stays a pure rendering of
+                // the persisted `@AppStorage` value.
                 onChange: { _ in },
                 label: {
                     HStack(spacing: AppSpacing.sm) {
@@ -601,10 +609,8 @@ private struct SettingsSmartPauseSection: View {
                 tint: AppColor.primaryRest,
                 accessibilityIdentifier: "settings.smartPause.pauseDuringFocus",
                 accessibilityHint: Text("settings.smartPause.pauseDuringFocus.hint", bundle: .module),
-                // `.settingChanged(.pauseDuringFocus, ...)` re-emission is
-                // tracked in #777 (post-TCA setting_changed emission gaps);
-                // the `@AppStorage` binding already round-trips through
-                // `SettingsStore`.
+                // `setting_changed` emission is owned by `SettingsView`'s
+                // `.onChangeCompat(of: pauseDuringFocus)` watcher (#777).
                 onChange: { _ in },
                 label: {
                     Label(
@@ -622,10 +628,8 @@ private struct SettingsSmartPauseSection: View {
                 tint: AppColor.primaryRest,
                 accessibilityIdentifier: "settings.smartPause.pauseWhileDriving",
                 accessibilityHint: Text("settings.smartPause.pauseWhileDriving.hint", bundle: .module),
-                // `.settingChanged(.pauseWhileDriving, ...)` re-emission is
-                // tracked in #777 (post-TCA setting_changed emission gaps);
-                // the `@AppStorage` binding already round-trips through
-                // `SettingsStore`.
+                // `setting_changed` emission is owned by `SettingsView`'s
+                // `.onChangeCompat(of: pauseWhileDriving)` watcher (#777).
                 onChange: { _ in },
                 label: {
                     Label(
@@ -821,6 +825,111 @@ private struct SettingsNotificationWarningSection: View {
 private func openApplicationSettings() {
     if let url = URL(string: UIApplication.openSettingsURLString) {
         UIApplication.shared.open(url)
+    }
+}
+
+// MARK: - Setting-change analytics forwarder
+
+/// Forwards every change to a non-bindable `SettingsView` row into
+/// `SettingsFeature.Action.settingToggleChanged` so the post-TCA
+/// `setting_changed` analytics emission gap is closed without growing
+/// `SettingsView`'s body past SwiftLint's `type_body_length` cap.
+///
+/// The view owns the `@AppStorage` mirrors as well; this modifier observes
+/// the same UserDefaults keys so the prev-value snapshot stays in sync with
+/// the row even when the value mutates outside the View (e.g. via reset).
+/// Eyes interval/duration emissions remain owned by `SettingsFeature`'s
+/// bindable surface (#777).
+private struct SettingsAnalyticsForwarder: ViewModifier {
+    let store: StoreOf<SettingsFeature>
+
+    @AppStorage(SettingsStore.Keys.globalEnabled) private var globalEnabled = true
+    @AppStorage(SettingsStore.Keys.eyesEnabled) private var eyesEnabled = true
+    @AppStorage(SettingsStore.Keys.postureEnabled) private var postureEnabled = true
+    @AppStorage(SettingsStore.Keys.postureInterval) private var postureInterval: Double = 0
+    @AppStorage(SettingsStore.Keys.postureBreakDuration) private var postureBreakDuration: Double = 0
+    @AppStorage(SettingsStore.Keys.hapticsEnabled) private var hapticsEnabled = true
+    @AppStorage(SettingsStore.Keys.pauseDuringFocus) private var pauseDuringFocus = true
+    @AppStorage(SettingsStore.Keys.pauseWhileDriving) private var pauseWhileDriving = true
+    @AppStorage(SettingsStore.Keys.notificationFallbackEnabled)
+    private var notificationFallbackEnabled = true
+
+    // Pre-change snapshots used to compute the `oldValue` carried by each
+    // `.settingToggleChanged` emission. `@AppStorage.onChange` fires with the
+    // post-change value only, so we capture the prior value on appearance and
+    // refresh it after every successful emit. Mirrors the `prev*` pattern in
+    // `OnboardingSetupView`.
+    @State private var prevGlobalEnabled = true
+    @State private var prevEyesEnabled = true
+    @State private var prevPostureEnabled = true
+    @State private var prevPostureInterval: Double = 0
+    @State private var prevPostureBreakDuration: Double = 0
+    @State private var prevHapticsEnabled = true
+    @State private var prevPauseDuringFocus = true
+    @State private var prevPauseWhileDriving = true
+    @State private var prevNotificationFallbackEnabled = true
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { primeSnapshots() }
+            .onChangeCompat(of: globalEnabled) { newValue in
+                emit(.globalEnabled, prev: &prevGlobalEnabled, newValue: newValue)
+            }
+            .onChangeCompat(of: eyesEnabled) { newValue in
+                emit(.eyesEnabled, prev: &prevEyesEnabled, newValue: newValue)
+            }
+            .onChangeCompat(of: postureEnabled) { newValue in
+                emit(.postureEnabled, prev: &prevPostureEnabled, newValue: newValue)
+            }
+            .onChangeCompat(of: hapticsEnabled) { newValue in
+                emit(.hapticsEnabled, prev: &prevHapticsEnabled, newValue: newValue)
+            }
+            .onChangeCompat(of: notificationFallbackEnabled) { newValue in
+                emit(
+                    .notificationFallbackEnabled,
+                    prev: &prevNotificationFallbackEnabled,
+                    newValue: newValue
+                )
+            }
+            .onChangeCompat(of: pauseDuringFocus) { newValue in
+                emit(.pauseDuringFocus, prev: &prevPauseDuringFocus, newValue: newValue)
+            }
+            .onChangeCompat(of: pauseWhileDriving) { newValue in
+                emit(.pauseWhileDriving, prev: &prevPauseWhileDriving, newValue: newValue)
+            }
+            .onChangeCompat(of: postureInterval) { newValue in
+                emit(.postureInterval, prev: &prevPostureInterval, newValue: newValue)
+            }
+            .onChangeCompat(of: postureBreakDuration) { newValue in
+                emit(.postureBreakDuration, prev: &prevPostureBreakDuration, newValue: newValue)
+            }
+    }
+
+    private func primeSnapshots() {
+        prevGlobalEnabled = globalEnabled
+        prevEyesEnabled = eyesEnabled
+        prevPostureEnabled = postureEnabled
+        prevPostureInterval = postureInterval
+        prevPostureBreakDuration = postureBreakDuration
+        prevHapticsEnabled = hapticsEnabled
+        prevPauseDuringFocus = pauseDuringFocus
+        prevPauseWhileDriving = pauseWhileDriving
+        prevNotificationFallbackEnabled = notificationFallbackEnabled
+    }
+
+    private func emit<Value: Equatable & CustomStringConvertible>(
+        _ key: AnalyticsEvent.SettingKey,
+        prev: inout Value,
+        newValue: Value
+    ) {
+        guard prev != newValue else { return }
+        let oldValue = prev
+        prev = newValue
+        store.send(.settingToggleChanged(
+            setting: key,
+            oldValue: String(describing: oldValue),
+            newValue: String(describing: newValue)
+        ))
     }
 }
 

--- a/Tests/EyePostureReminderTests/TCA/SettingsFeatureToggleEmissionTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/SettingsFeatureToggleEmissionTests.swift
@@ -1,0 +1,118 @@
+import ComposableArchitecture
+import XCTest
+
+@testable import EyePostureReminder
+
+/// Coverage for `SettingsFeature.Action.settingToggleChanged`, the post-TCA
+/// emission shim wired up by `SettingsView`'s `.onChangeCompat` watchers
+/// (#777). Asserts every silent `AnalyticsEvent.SettingKey` row now produces
+/// a `setting_changed` event through the injected `AnalyticsClient`.
+@MainActor
+final class SettingsFeatureToggleEmissionTests: XCTestCase {
+
+    func test_settingToggleChanged_globalEnabled_logsSettingChanged() async {
+        let analyticsEvents = LockIsolated<[AnalyticsEvent]>([])
+
+        let store = TestStore(initialState: SettingsFeature.State()) {
+            SettingsFeature()
+        } withDependencies: {
+            $0.settingsClient = TCATestDependencies.silentSettingsClient()
+            $0.reminderSchedulerClient = TCATestDependencies.silentReminderSchedulerClient()
+            $0.analyticsClient = AnalyticsClient(log: { event in
+                analyticsEvents.withValue { $0.append(event) }
+            })
+            $0.continuousClock = TestClock()
+        }
+
+        await store.send(.settingToggleChanged(
+            setting: .globalEnabled,
+            oldValue: "true",
+            newValue: "false"
+        ))
+        await store.finish()
+
+        analyticsEvents.withValue { events in
+            XCTAssertEqual(events.count, 1)
+            guard case let .settingChanged(setting, oldValue, newValue) = events.first else {
+                XCTFail("Expected .settingChanged; got \(String(describing: events.first))")
+                return
+            }
+            XCTAssertEqual(setting, .globalEnabled)
+            XCTAssertEqual(oldValue, "true")
+            XCTAssertEqual(newValue, "false")
+        }
+    }
+
+    func test_settingToggleChanged_allSilentSettingKeys_logSettingChanged() async {
+        // The keys that were silent before #777 wired the `.settingToggleChanged`
+        // action up to `SettingsView`'s `.onChangeCompat` watchers. The
+        // interval/break-duration eyes keys are still emitted via the
+        // bindable surface and are covered by `SettingsFeatureBindingTests`.
+        let cases: [(AnalyticsEvent.SettingKey, String, String)] = [
+            (.globalEnabled, "true", "false"),
+            (.eyesEnabled, "true", "false"),
+            (.postureEnabled, "false", "true"),
+            (.postureInterval, "1200.0", "1800.0"),
+            (.postureBreakDuration, "20.0", "30.0"),
+            (.pauseDuringFocus, "true", "false"),
+            (.pauseWhileDriving, "false", "true"),
+            (.hapticsEnabled, "true", "false"),
+            (.notificationFallbackEnabled, "false", "true")
+        ]
+
+        let analyticsEvents = LockIsolated<[AnalyticsEvent]>([])
+
+        let store = TestStore(initialState: SettingsFeature.State()) {
+            SettingsFeature()
+        } withDependencies: {
+            $0.settingsClient = TCATestDependencies.silentSettingsClient()
+            $0.reminderSchedulerClient = TCATestDependencies.silentReminderSchedulerClient()
+            $0.analyticsClient = AnalyticsClient(log: { event in
+                analyticsEvents.withValue { $0.append(event) }
+            })
+            $0.continuousClock = TestClock()
+        }
+
+        for (key, oldValue, newValue) in cases {
+            await store.send(.settingToggleChanged(
+                setting: key,
+                oldValue: oldValue,
+                newValue: newValue
+            ))
+        }
+        await store.finish()
+
+        analyticsEvents.withValue { events in
+            XCTAssertEqual(events.count, cases.count,
+                           "Every emit should be logged exactly once.")
+            for (index, expected) in cases.enumerated() {
+                guard case let .settingChanged(setting, oldValue, newValue) = events[index] else {
+                    XCTFail("Expected .settingChanged at index \(index); got \(events[index])")
+                    return
+                }
+                XCTAssertEqual(setting, expected.0, "setting key mismatch at index \(index)")
+                XCTAssertEqual(oldValue, expected.1, "oldValue mismatch for \(expected.0)")
+                XCTAssertEqual(newValue, expected.2, "newValue mismatch for \(expected.0)")
+            }
+        }
+    }
+
+    func test_settingToggleChanged_doesNotMutateState() async {
+        let store = TestStore(initialState: SettingsFeature.State()) {
+            SettingsFeature()
+        } withDependencies: {
+            $0.settingsClient = TCATestDependencies.silentSettingsClient()
+            $0.reminderSchedulerClient = TCATestDependencies.silentReminderSchedulerClient()
+            $0.analyticsClient = AnalyticsClient(log: { _ in })
+            $0.continuousClock = TestClock()
+        }
+
+        // No trailing closure ⇒ state must be unchanged by the action.
+        await store.send(.settingToggleChanged(
+            setting: .hapticsEnabled,
+            oldValue: "true",
+            newValue: "false"
+        ))
+        await store.finish()
+    }
+}

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -322,21 +322,21 @@ No payload. Fired when the user manually cancels an active snooze.
 
 **Instrumented `setting` key values:**
 
-The full key set is defined by `AnalyticsLogger.SettingKey` (`EyePostureReminder/Services/AnalyticsLogger.swift`). Post-TCA migration, only the interval/duration keys have live emit-sites; re-instating the remaining toggles is tracked in #777.
+The full key set is defined by `AnalyticsLogger.SettingKey` (`EyePostureReminder/Services/AnalyticsLogger.swift`). All 11 keys have at least one live emit-site post-#777: interval/duration eyes keys emit through the bindable surface of `SettingsFeature`; the remaining toggles + the Settings-screen posture pickers emit via `SettingsFeature.Action.settingToggleChanged`, dispatched by `SettingsView`'s `.onChangeCompat` watchers.
 
 | `setting` value | Type | Emitted from |
 |----------------|------|--------------|
-| `globalEnabled` | Bool | Not currently emitted post-TCA migration — tracked in #777 |
-| `eyesEnabled` | Bool | Not currently emitted post-TCA migration — tracked in #777 |
+| `globalEnabled` | Bool | `SettingsView` master toggle (`.settingToggleChanged` via `SettingsFeature`) |
+| `eyesEnabled` | Bool | `SettingsView` eyes section toggle (`.settingToggleChanged` via `SettingsFeature`) |
 | `eyesInterval` | TimeInterval | `SettingsFeature` reducer (`binding(\.eyesInterval)`); also emitted from `OnboardingSetupView` during the eyes setup picker |
 | `eyesBreakDuration` | TimeInterval | `SettingsFeature` reducer (`binding(\.eyesBreakDuration)`); also emitted from `OnboardingSetupView` during the eyes setup picker |
-| `postureEnabled` | Bool | Not currently emitted post-TCA migration — tracked in #777 |
-| `postureInterval` | TimeInterval | `OnboardingSetupView` posture setup picker only — Settings-screen emission tracked in #777 |
-| `postureBreakDuration` | TimeInterval | `OnboardingSetupView` posture setup picker only — Settings-screen emission tracked in #777 |
-| `pauseDuringFocus` | Bool | Not currently emitted post-TCA migration — tracked in #777 |
-| `pauseWhileDriving` | Bool | Not currently emitted post-TCA migration — tracked in #777 |
-| `notificationFallbackEnabled` | Bool | Not currently emitted post-TCA migration — tracked in #777 |
-| `hapticsEnabled` | Bool | Not currently emitted post-TCA migration — tracked in #777 |
+| `postureEnabled` | Bool | `SettingsView` posture section toggle (`.settingToggleChanged` via `SettingsFeature`) |
+| `postureInterval` | TimeInterval | `SettingsView` posture interval picker (`.settingToggleChanged`); also emitted from `OnboardingSetupView` during the posture setup picker |
+| `postureBreakDuration` | TimeInterval | `SettingsView` posture duration picker (`.settingToggleChanged`); also emitted from `OnboardingSetupView` during the posture setup picker |
+| `pauseDuringFocus` | Bool | `SettingsView` Smart Pause section toggle (`.settingToggleChanged` via `SettingsFeature`) |
+| `pauseWhileDriving` | Bool | `SettingsView` Smart Pause section toggle (`.settingToggleChanged` via `SettingsFeature`) |
+| `notificationFallbackEnabled` | Bool | `SettingsView` preferences section toggle (`.settingToggleChanged` via `SettingsFeature`) |
+| `hapticsEnabled` | Bool | `SettingsView` preferences section toggle (`.settingToggleChanged` via `SettingsFeature`) |
 
 ---
 


### PR DESCRIPTION
## Summary

Closes #777.

Re-wires the seven post-TCA `setting_changed` analytics gaps plus the Settings-screen posture interval/duration pickers. After this PR all 11 `AnalyticsLogger.SettingKey` values have at least one live emit-site.

## Changes

- `SettingsFeature` gains a new `settingToggleChanged(setting:oldValue:newValue:)` action that emits `.settingChanged` through the injected `AnalyticsClient`. Eyes interval/duration keep emitting from the bindable surface.
- A new `SettingsAnalyticsForwarder` `ViewModifier` (private, in `SettingsView.swift`) owns the `prev*` snapshots and `.onChangeCompat` watchers for each `@AppStorage` key. Extracted to keep `SettingsView` under SwiftLint's `type_body_length` cap.
- `docs/TELEMETRY.md` table updated — every key now has a concrete emit-site; the '\#777' placeholder rows are gone.
- Stale comments removed/repointed:
  - `SettingsView.swift` master-toggle '#777 emission tracker' comment → describes the new `SettingsAnalyticsForwarder`.
  - `SettingsView.swift` Smart Pause section '#679 deferral' comments → now point at the watcher owning the emission.
- New `SettingsFeatureToggleEmissionTests` (3 tests):
  - Single-key emission shape for `globalEnabled`.
  - Parameterised coverage for all nine silent keys.
  - State-mutation guard (action must not mutate `SettingsFeature.State`).

## Validation

`./scripts/build.sh all` ✓ — build + lint + **1820 unit tests pass** (3 new). 

## Acceptance criteria

- [x] All 11 keys in `AnalyticsLogger.SettingKey` have at least one live emit-site.
- [x] Settings-screen toggles emit `.settingChanged` with correct `oldValue`/`newValue` strings.
- [x] Stale `#679` deferral comments in `SettingsView.swift` are removed/repointed.
- [x] New `SettingsFeature` `TestStore` tests assert the emissions for newly-wired keys.
- [x] `docs/TELEMETRY.md` updated to reflect the restored emitters.
- [x] `./scripts/build.sh all` green.

## Notes

- `oldValue` / `newValue` are pre-stringified by the view (via `String(describing:)`) so the new action stays `Equatable` for TestStore assertions while accepting both `Bool` and `TimeInterval` payloads uniformly.
- The `#679` reschedule-callback comments in `eyesSection`/`postureSection` (re: `reminderSettingChanged`) are intentionally untouched — they refer to the scheduler hand-off, not the analytics gap closed by this PR.