### PR TITLE
fix(home): stream master/per-type enable flags into HomeFeature.State (#785)

### DIFF
--- a/EyePostureReminder/TCA/Dependencies/SettingsClient.swift
+++ b/EyePostureReminder/TCA/Dependencies/SettingsClient.swift
@@ -1,6 +1,25 @@
 import ComposableArchitecture
 import Foundation
 
+/// Snapshot of the three persisted enable-flag keys
+/// (`globalEnabled` / `eyesEnabled` / `postureEnabled`).
+///
+/// Vended by `SettingsClient.enabledFlagsSnapshot` /
+/// `enabledFlagsStream` so reducers (notably `HomeFeature`) stay in lock-step
+/// with master-toggle changes made from `SettingsView` — including the writes
+/// `SettingsView` makes directly via `@AppStorage` bindings, which bypass the
+/// `SettingsStore` setters and therefore do not fire the existing
+/// `SettingsStore` observer surface. See #785.
+struct EnabledFlags: Sendable, Equatable {
+    var global: Bool
+    var eyes: Bool
+    var posture: Bool
+
+    /// All-on default used as the cold-start seed and the `liveValue`
+    /// fallback before `LiveSettingsBridge.bootstrap()` runs.
+    static let allEnabled = EnabledFlags(global: true, eyes: true, posture: true)
+}
+
 /// TCA dependency client wrapping `SettingsStore` for reducer consumption.
 ///
 /// Phase 0 of the MVVM → TCA migration (#665). The closure surface is the
@@ -19,6 +38,17 @@ struct SettingsClient: Sendable {
     /// Multicast stream of `ReminderSettings` snapshots. A new subscriber
     /// receives the current snapshot and every subsequent change.
     var stream: @Sendable () -> AsyncStream<ReminderSettings> = { .finished }
+
+    /// Synchronous snapshot of the persisted enable-flag triplet. Cached on
+    /// the file-scope `enabledFlagsCache` so reducers can read it off the
+    /// main actor. See #785 for why this is separate from `snapshot()`.
+    var enabledFlagsSnapshot: @Sendable () -> EnabledFlags = { .allEnabled }
+
+    /// Multicast stream of `EnabledFlags` snapshots. A new subscriber
+    /// receives the current snapshot synchronously and every subsequent
+    /// change — including writes that bypass `SettingsStore` setters (e.g.
+    /// `SettingsView`'s `@AppStorage` master-toggle binding). See #785.
+    var enabledFlagsStream: @Sendable () -> AsyncStream<EnabledFlags> = { .finished }
 
     /// Toggles the global reminders master switch.
     var updateGlobalEnabled: @Sendable (Bool) async -> Void
@@ -72,6 +102,8 @@ extension SettingsClient: DependencyKey {
         return SettingsClient(
             snapshot: { settingsSnapshotCache.value },
             stream: { makeSettingsStream() },
+            enabledFlagsSnapshot: { enabledFlagsCache.value },
+            enabledFlagsStream: { makeEnabledFlagsStream() },
             updateGlobalEnabled: { value in
                 await MainActor.run { LiveSettingsBridge.shared.store.globalEnabled = value }
             },
@@ -144,6 +176,7 @@ private final class LiveSettingsBridge {
 
     let store = SettingsStore()
     private var hasBootstrapped = false
+    private var defaultsObservationToken: NSObjectProtocol?
 
     private nonisolated init() {}
 
@@ -157,9 +190,48 @@ private final class LiveSettingsBridge {
         settingsSnapshotCache.setValue(initial)
         broadcastSettings(initial)
 
+        let initialFlags = EnabledFlags(
+            global: store.globalEnabled,
+            eyes: store.eyesEnabled,
+            posture: store.postureEnabled
+        )
+        enabledFlagsCache.setValue(initialFlags)
+        broadcastEnabledFlags(initialFlags)
+
         store.addObserver { snapshot in
             settingsSnapshotCache.setValue(snapshot)
             broadcastSettings(snapshot)
+        }
+
+        // `SettingsView` writes the master / per-type enable flags directly to
+        // `UserDefaults` through `@AppStorage`, which bypasses `SettingsStore`
+        // setters and therefore the existing `addObserver` surface. Listen for
+        // `UserDefaults.didChangeNotification` so both write paths (store
+        // setter and direct `@AppStorage`) keep the file-scope cache and the
+        // multicast continuations in sync. See #785.
+        defaultsObservationToken = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: UserDefaults.standard,
+            queue: .main
+        ) { _ in
+            let defaults = UserDefaults.standard
+            let flags = EnabledFlags(
+                global: defaults.bool(
+                    forKey: SettingsStore.Keys.globalEnabled,
+                    defaultValue: true
+                ),
+                eyes: defaults.bool(
+                    forKey: SettingsStore.Keys.eyesEnabled,
+                    defaultValue: true
+                ),
+                posture: defaults.bool(
+                    forKey: SettingsStore.Keys.postureEnabled,
+                    defaultValue: true
+                )
+            )
+            guard flags != enabledFlagsCache.value else { return }
+            enabledFlagsCache.setValue(flags)
+            broadcastEnabledFlags(flags)
         }
     }
 }
@@ -169,11 +241,22 @@ private let settingsSnapshotCache = LockIsolated<ReminderSettings>(
     ReminderSettings(interval: 0, breakDuration: 0)
 )
 
+/// File-scoped enable-flag cache; safe to read from any actor. Seeded to
+/// `.allEnabled` so reads before `LiveSettingsBridge.bootstrap()` finishes
+/// (e.g. during early Phase-2 `state.home.*` initialisation) match the
+/// all-on shipping default.
+private let enabledFlagsCache = LockIsolated<EnabledFlags>(.allEnabled)
+
 /// File-scoped multicast continuations. Held outside the `@MainActor` bridge
 /// to side-step a Swift constraint-solver bug that surfaces when
 /// `Continuation.onTermination` captures `@MainActor`-isolated static storage.
 private let settingsContinuations =
     LockIsolated<[UUID: AsyncStream<ReminderSettings>.Continuation]>([:])
+
+/// File-scoped multicast continuations for `EnabledFlags` subscribers. Kept
+/// alongside `settingsContinuations` for the same `@MainActor` reason.
+private let enabledFlagsContinuations =
+    LockIsolated<[UUID: AsyncStream<EnabledFlags>.Continuation]>([:])
 
 /// File-scoped factory used by the live `stream` closure to register a new
 /// multicast subscriber. Yields the current snapshot synchronously so first
@@ -191,8 +274,31 @@ private func makeSettingsStream() -> AsyncStream<ReminderSettings> {
     return stream
 }
 
+/// File-scoped factory used by the live `enabledFlagsStream` closure to
+/// register a new multicast subscriber. Yields the current cached flags
+/// synchronously so the first emission carries the persisted truth without
+/// waiting for the next `UserDefaults` mutation.
+private func makeEnabledFlagsStream() -> AsyncStream<EnabledFlags> {
+    let (stream, continuation) = AsyncStream<EnabledFlags>.makeStream()
+    let id = UUID()
+    continuation.yield(enabledFlagsCache.value)
+    enabledFlagsContinuations.withValue { $0[id] = continuation }
+    continuation.onTermination = { _ in
+        enabledFlagsContinuations.withValue { dict in
+            dict[id] = nil
+        }
+    }
+    return stream
+}
+
 private func broadcastSettings(_ value: ReminderSettings) {
     settingsContinuations.withValue { dict in
+        for continuation in dict.values { continuation.yield(value) }
+    }
+}
+
+private func broadcastEnabledFlags(_ value: EnabledFlags) {
+    enabledFlagsContinuations.withValue { dict in
         for continuation in dict.values { continuation.yield(value) }
     }
 }

--- a/EyePostureReminder/TCA/Features/HomeFeature.swift
+++ b/EyePostureReminder/TCA/Features/HomeFeature.swift
@@ -9,12 +9,10 @@ import UserNotifications
 /// this store without altering observable behaviour.
 ///
 /// Inputs come from the shared dependency clients defined by `p0-tca-2`:
-/// `SettingsClient` exposes the eyes-side `ReminderSettings` snapshot/stream,
-/// and `NotificationClient` exposes the system authorisation status. Per-type
-/// enable flags (`globalEnabled` / `eyesEnabled` / `postureEnabled`) are held
-/// directly on `State` because the Phase 0 `SettingsClient` snapshot only
-/// vends the eyes `ReminderSettings`. Those flags will be wired into the
-/// store as part of Phase 2 (`p0-tca-15`) when bindings are introduced.
+/// `SettingsClient` exposes the eyes-side `ReminderSettings` snapshot/stream
+/// **and** an `EnabledFlags` snapshot/stream that tracks the master /
+/// per-type toggles (#785). `NotificationClient` exposes the system
+/// authorisation status.
 @Reducer
 struct HomeFeature {
     @ObservableState
@@ -58,6 +56,7 @@ struct HomeFeature {
         case settingsTapped
         case dismissTrueInterruptBanner
         case settingsChanged(ReminderSettings)
+        case enabledFlagsChanged(EnabledFlags)
         case notificationAuthStatusChanged(UNAuthorizationStatus)
     }
 
@@ -67,6 +66,7 @@ struct HomeFeature {
 
     private enum CancelID: Hashable {
         case settingsStream
+        case enabledFlagsStream
         case authStatusPoll
     }
 
@@ -75,6 +75,10 @@ struct HomeFeature {
             switch action {
             case .onAppear:
                 state.settings = settingsClient.snapshot()
+                let flags = settingsClient.enabledFlagsSnapshot()
+                state.globalEnabled = flags.global
+                state.eyesEnabled = flags.eyes
+                state.postureEnabled = flags.posture
                 return .run { send in
                     let status = await notificationClient.authorizationStatus()
                     await send(.notificationAuthStatusChanged(status))
@@ -88,6 +92,12 @@ struct HomeFeature {
                         }
                     }
                     .cancellable(id: CancelID.settingsStream, cancelInFlight: true),
+                    .run { send in
+                        for await flags in settingsClient.enabledFlagsStream() {
+                            await send(.enabledFlagsChanged(flags))
+                        }
+                    }
+                    .cancellable(id: CancelID.enabledFlagsStream, cancelInFlight: true),
                     .run { [clock, notificationClient] send in
                         for await _ in clock.timer(interval: .seconds(1)) {
                             let status = await notificationClient.authorizationStatus()
@@ -108,6 +118,12 @@ struct HomeFeature {
 
             case let .settingsChanged(snapshot):
                 state.settings = snapshot
+                return .none
+
+            case let .enabledFlagsChanged(flags):
+                state.globalEnabled = flags.global
+                state.eyesEnabled = flags.eyes
+                state.postureEnabled = flags.posture
                 return .none
 
             case let .notificationAuthStatusChanged(status):

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -98,6 +98,8 @@ final class AppDelegateTests: XCTestCase {
             $0.settingsClient = SettingsClient(
                 snapshot: { initialEyesSnapshot },
                 stream: { .finished },
+                enabledFlagsSnapshot: { .allEnabled },
+                enabledFlagsStream: { .finished },
                 updateGlobalEnabled: { _ in },
                 updateEyesEnabled: { _ in },
                 updatePostureEnabled: { _ in },

--- a/Tests/EyePostureReminderTests/TCA/AppFeatureTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/AppFeatureTests.swift
@@ -34,6 +34,8 @@ final class AppFeatureTests: XCTestCase {
             $0.settingsClient = SettingsClient(
                 snapshot: { ReminderSettings(interval: 0, breakDuration: 0) },
                 stream: { .finished },
+                enabledFlagsSnapshot: { .allEnabled },
+                enabledFlagsStream: { .finished },
                 updateGlobalEnabled: { _ in },
                 updateEyesEnabled: { _ in },
                 updatePostureEnabled: { _ in },

--- a/Tests/EyePostureReminderTests/TCA/ContentViewTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/ContentViewTests.swift
@@ -30,6 +30,8 @@ final class ContentViewTests: XCTestCase {
             $0.settingsClient = SettingsClient(
                 snapshot: { ReminderSettings(interval: 0, breakDuration: 0) },
                 stream: { .finished },
+                enabledFlagsSnapshot: { .allEnabled },
+                enabledFlagsStream: { .finished },
                 updateGlobalEnabled: { _ in },
                 updateEyesEnabled: { _ in },
                 updatePostureEnabled: { _ in },

--- a/Tests/EyePostureReminderTests/TCA/HomeFeatureTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/HomeFeatureTests.swift
@@ -34,6 +34,8 @@ final class HomeFeatureTests: XCTestCase {
             $0.settingsClient = SettingsClient(
                 snapshot: { snapshot },
                 stream: { .finished },
+                enabledFlagsSnapshot: { .allEnabled },
+                enabledFlagsStream: { .finished },
                 updateGlobalEnabled: { _ in },
                 updateEyesEnabled: { _ in },
                 updatePostureEnabled: { _ in },
@@ -57,6 +59,34 @@ final class HomeFeatureTests: XCTestCase {
 
         await store.send(.onAppear) {
             $0.settings = snapshot
+        }
+        await store.receive(\.notificationAuthStatusChanged) {
+            $0.notificationAuthStatus = .authorized
+        }
+    }
+
+    /// Regression coverage for #785: `.onAppear` must seed the enable-flag
+    /// state from `SettingsClient.enabledFlagsSnapshot()` so a relaunch
+    /// after the user toggled the master switch off renders the paused
+    /// status label, instead of using the all-on `State` defaults.
+    func test_onAppear_seedsEnabledFlagsFromSnapshot() async {
+        var settings = TCATestDependencies.silentSettingsClient()
+        settings.enabledFlagsSnapshot = {
+            EnabledFlags(global: false, eyes: false, posture: true)
+        }
+        let store = TestStore(initialState: HomeFeature.State()) {
+            HomeFeature()
+        } withDependencies: {
+            $0.settingsClient = settings
+            $0.notificationClient = TCATestDependencies.silentNotificationClient(
+                authorizationStatus: .authorized
+            )
+        }
+
+        await store.send(.onAppear) {
+            $0.globalEnabled = false
+            $0.eyesEnabled = false
+            $0.postureEnabled = true
         }
         await store.receive(\.notificationAuthStatusChanged) {
             $0.notificationAuthStatus = .authorized
@@ -95,6 +125,33 @@ final class HomeFeatureTests: XCTestCase {
 
         await store.send(.settingsChanged(snapshot)) {
             $0.settings = snapshot
+        }
+    }
+
+    // MARK: - .enabledFlagsChanged
+
+    /// `.enabledFlagsChanged` writes every field of the supplied `EnabledFlags`
+    /// triplet to `State`, including transitions back to `true` so a
+    /// re-enable broadcast clears the paused status label (#785).
+    func test_enabledFlagsChanged_writesAllThreeFlagsToState() async {
+        let store = TestStore(initialState: HomeFeature.State()) {
+            HomeFeature()
+        }
+
+        await store.send(.enabledFlagsChanged(EnabledFlags(
+            global: false, eyes: false, posture: false
+        ))) {
+            $0.globalEnabled = false
+            $0.eyesEnabled = false
+            $0.postureEnabled = false
+        }
+
+        await store.send(.enabledFlagsChanged(EnabledFlags(
+            global: true, eyes: true, posture: false
+        ))) {
+            $0.globalEnabled = true
+            $0.eyesEnabled = true
+            $0.postureEnabled = false
         }
     }
 
@@ -216,6 +273,48 @@ final class HomeFeatureTests: XCTestCase {
         }
 
         continuation.finish()
+        await task.cancel()
+    }
+
+    // MARK: - .task — enabled-flags stream subscription (#785)
+
+    /// `.task` subscribes to `SettingsClient.enabledFlagsStream` and pipes
+    /// each emission through `.enabledFlagsChanged`, so writes made by
+    /// `SettingsView`'s `@AppStorage` master-toggle binding flow into
+    /// `HomeFeature.State` and the home status label re-renders.
+    func test_task_streamsEnabledFlagsIntoState() async {
+        let (flagsStream, flagsContinuation) = AsyncStream<EnabledFlags>.makeStream()
+        var settings = TCATestDependencies.silentSettingsClient()
+        settings.enabledFlagsStream = { flagsStream }
+
+        let clock = TestClock()
+        let store = TestStore(initialState: HomeFeature.State()) {
+            HomeFeature()
+        } withDependencies: {
+            $0.settingsClient = settings
+            $0.notificationClient = TCATestDependencies.silentNotificationClient(
+                authorizationStatus: .authorized
+            )
+            $0.continuousClock = clock
+        }
+        store.exhaustivity = .off(showSkippedAssertions: false)
+
+        let task = await store.send(.task)
+
+        let pausedFlags = EnabledFlags(global: false, eyes: true, posture: true)
+        flagsContinuation.yield(pausedFlags)
+        await store.receive(\.enabledFlagsChanged) {
+            $0.globalEnabled = false
+        }
+
+        let perTypeOff = EnabledFlags(global: false, eyes: false, posture: false)
+        flagsContinuation.yield(perTypeOff)
+        await store.receive(\.enabledFlagsChanged) {
+            $0.eyesEnabled = false
+            $0.postureEnabled = false
+        }
+
+        flagsContinuation.finish()
         await task.cancel()
     }
 

--- a/Tests/EyePostureReminderTests/TCA/SettingsFeatureTests.swift
+++ b/Tests/EyePostureReminderTests/TCA/SettingsFeatureTests.swift
@@ -89,6 +89,8 @@ final class SettingsFeatureTests: XCTestCase {
             $0.settingsClient = SettingsClient(
                 snapshot: { snapshot },
                 stream: { .finished },
+                enabledFlagsSnapshot: { .allEnabled },
+                enabledFlagsStream: { .finished },
                 updateGlobalEnabled: { _ in },
                 updateEyesEnabled: { _ in },
                 updatePostureEnabled: { _ in },
@@ -167,6 +169,8 @@ final class SettingsFeatureTests: XCTestCase {
             $0.settingsClient = SettingsClient(
                 snapshot: { ReminderSettings(interval: 0, breakDuration: 0) },
                 stream: { .finished },
+                enabledFlagsSnapshot: { .allEnabled },
+                enabledFlagsStream: { .finished },
                 updateGlobalEnabled: { _ in },
                 updateEyesEnabled: { _ in },
                 updatePostureEnabled: { _ in },

--- a/Tests/EyePostureReminderTests/TCA/TCATestDependencies.swift
+++ b/Tests/EyePostureReminderTests/TCA/TCATestDependencies.swift
@@ -28,6 +28,8 @@ enum TCATestDependencies {
         SettingsClient(
             snapshot: { ReminderSettings(interval: 0, breakDuration: 0) },
             stream: { .finished },
+            enabledFlagsSnapshot: { .allEnabled },
+            enabledFlagsStream: { .finished },
             updateGlobalEnabled: { _ in },
             updateEyesEnabled: { _ in },
             updatePostureEnabled: { _ in },

--- a/Tests/EyePostureReminderUITests/HomeScreenTests.swift
+++ b/Tests/EyePostureReminderUITests/HomeScreenTests.swift
@@ -140,20 +140,11 @@ final class HomeScreenTests: XCTestCase {
         XCTAssertTrue(statusLabel.waitForExistence(timeout: 3))
         let updatedText = statusLabel.label
 
-        // `HomeFeature.State.globalEnabled` is seeded once on `task` and never
-        // updates from AppStorage writes made through `SettingsView`'s master
-        // toggle — tracked under #785. Drop this `XCTExpectFailure` wrapper
-        // when that bug is closed.
-        XCTExpectFailure(
-            "Master-toggle → status-label reactivity is broken after TCA migration; tracked in #785.",
-            strict: false
-        ) {
-            XCTAssertNotEqual(
-                initialText,
-                updatedText,
-                "Status label should update after toggling the global switch."
-            )
-        }
+        XCTAssertNotEqual(
+            initialText,
+            updatedText,
+            "Status label should update after toggling the global switch."
+        )
     }
 
     // MARK: - test_homeScreen_onLaunch_titleShowsKshana

--- a/Tests/EyePostureReminderUITests/README.md
+++ b/Tests/EyePostureReminderUITests/README.md
@@ -19,7 +19,6 @@ linked to a tracking issue — drop the wrapper once the underlying fix lands:
 
 | Test | Tracking issue | Reason |
 |---|---|---|
-| `HomeScreenTests.test_homeScreen_toggleGlobalSwitch_statusLabelChanges` | [#785](https://github.com/yashasg/fantastic-octo-fortnight/issues/785) | TCA regression: status label not reactive to master toggle |
 | `OverlayPresentationTests.test_overlay_settingsLink_opensSettingsWithSnoozeOptions` | [#786](https://github.com/yashasg/fantastic-octo-fortnight/issues/786) | TCA regression: overlay → Settings sheet routing dropped |
 | `SettingsFlowTests.test_settings_savedBanner_appearsOnToggle` | [#787](https://github.com/yashasg/fantastic-octo-fortnight/issues/787) | XCUI flake: transient banner not discoverable in CI |
 


### PR DESCRIPTION
## Summary

Closes #785. Re-wires the Home status label so it reacts in real time to master / per-type toggle changes made from Settings, after the MVVM→TCA migration broke that reactivity.

## Root cause

`HomeFeature.State.globalEnabled` / `.eyesEnabled` / `.postureEnabled` were seeded once on `State.init` and never updated. The Phase-0 `SettingsClient.stream()` only carries `ReminderSettings` (eyes interval + breakDuration), so flag changes never reached the store. `SettingsView` writes the master toggle directly via `@AppStorage(SettingsStore.Keys.globalEnabled)`, which bypasses `SettingsStore` setters entirely — so even the existing `SettingsStore.broadcastChange()` observer would never have fired.

## Fix

- Adds an `EnabledFlags` value type (`global` / `eyes` / `posture`) and a parallel snapshot+stream surface on `SettingsClient`:
  - `enabledFlagsSnapshot: @Sendable () -> EnabledFlags`
  - `enabledFlagsStream: @Sendable () -> AsyncStream<EnabledFlags>`
- `LiveSettingsBridge.bootstrap()` now observes `UserDefaults.didChangeNotification` and re-broadcasts the three flag values whenever any of the three keys change. This catches **both** the `SettingsStore` setter path **and** the `@AppStorage` direct path uniformly — every write to the persisted defaults flows through the same multicast.
- `HomeFeature.onAppear` seeds the three flag fields from `enabledFlagsSnapshot()`. `HomeFeature.task` subscribes to `enabledFlagsStream()` and pipes each emission through a new `.enabledFlagsChanged(EnabledFlags)` action.

## New TestStore coverage

- `HomeFeatureTests.test_onAppear_seedsEnabledFlagsFromSnapshot` — proves `.onAppear` no longer ignores persisted flag state.
- `HomeFeatureTests.test_enabledFlagsChanged_writesAllThreeFlagsToState` — direct reducer-action coverage.
- `HomeFeatureTests.test_task_streamsEnabledFlagsIntoState` — asserts each `enabledFlagsStream` emission lands in `State`.

## Verification

- `./scripts/build.sh test` → **1823 tests, 0 failures, 0 unexpected** (was 1820 — 3 new tests).
- `./scripts/build.sh lint` → clean.
- `./scripts/build.sh check` → green.

## Out of scope / follow-up

- The `XCTExpectFailure` wrapper around `HomeScreenTests.test_homeScreen_toggleGlobalSwitch_statusLabelChanges` and the README tracking-table row for #785 live on `users/squad/778-reenable-uitests-ci` (PR #788). Once #788 merges, a follow-up commit on this branch (or an immediate post-merge cleanup) will drop them; called out in the issue AC.
- Per-type toggle reactivity (eyes / posture switches) rides on the same `UserDefaults` notification path and is covered by the new `.enabledFlagsChanged` action — no separate plumbing needed.

## Risk

- The `UserDefaults.didChangeNotification` listener fires on **any** defaults write, including unrelated keys. We coalesce by reading the three flag values and skipping the broadcast when `EnabledFlags` is unchanged from the cache, so subscribers only see flag deltas. Cost is one dict-lookup-equality per notification — negligible.
- Backward compatible at the API surface: `SettingsClient` gains two properties with defaulted `liveValue` wiring; every existing call-site in tests is updated to pass the two new closures explicitly (the `@DependencyClient` macro requires them at the call site even when property defaults exist).