### PR TITLE
chore(tests): remove stale hasSeenOnboarding placeholder comment (#792)

### DIFF
--- a/Tests/EyePostureReminderTests/Models/SettingsStorePhase2Tests.swift
+++ b/Tests/EyePostureReminderTests/Models/SettingsStorePhase2Tests.swift
@@ -89,9 +89,4 @@ final class SettingsStorePhase2Tests: XCTestCase {
         sut.snoozeCount = 1
         XCTAssertNil(sut.snoozedUntil, "Setting snoozeCount must not affect snoozedUntil")
     }
-
-    // MARK: - Onboarding
-    // Note: hasSeenOnboarding is not yet implemented in Phase 2 source.
-    // Tests will be added in a future phase once AppCoordinator / SettingsStore
-    // gains the `hasSeenOnboarding` property.
 }


### PR DESCRIPTION
Closes #792

Scope reduced after investigation: the reducer-bridge action
`AppFeature.hasSeenOnboardingChanged` already has 3 dedicated tests
in `Tests/EyePostureReminderTests/TCA/AppFeatureTests.swift:128-167`
and the UserDefaults round-trip is covered by 12 tests in
`Tests/EyePostureReminderTests/Models/OnboardingTests.swift`. The
only outstanding work is deleting the misleading deferral comment in
`SettingsStorePhase2Tests.swift:93-97`.

### Verification
- `./scripts/build.sh lint` — clean.
- `./scripts/build.sh test` — 1823 tests, 0 failures (delta = comment-only).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>