### PR TITLE
chore(tests): remove dead SettingsViewModel deferral headers from integration tests (#794)

### DIFF
--- a/Tests/EyePostureReminderTests/Integration/IntegrationTests.swift
+++ b/Tests/EyePostureReminderTests/Integration/IntegrationTests.swift
@@ -2,18 +2,6 @@ import XCTest
 
 @testable import EyePostureReminder
 
-// MARK: - SettingsStore ↔ SettingsViewModel Integration (removed #755 Phase B)
-//
-// The `SettingsStoreViewModelIntegrationTests` class was removed when
-// `SettingsViewModel` was deleted. `SettingsStore` round-trip coverage
-// (UserDefaults persistence, observer broadcast, snooze setters) is
-// preserved under `SettingsStoreTests` and `AppConfigSettingsStoreIntegrationTests`
-// below. The view-model proxy / `cancelSnooze` / `globalToggleChanged`
-// behaviours will be re-covered as `SettingsFeature` TestStore cases
-// under #679.
-//
-// `SettingsFeature` TestStore + integration cases under #679.
-
 // MARK: - AppConfig → SettingsStore First Launch Integration
 
 /// Verifies the data-driven defaults pipeline using real `UserDefaults` suites

--- a/Tests/EyePostureReminderTests/Integration/MultiServicePipelineIntegrationTests.swift
+++ b/Tests/EyePostureReminderTests/Integration/MultiServicePipelineIntegrationTests.swift
@@ -6,12 +6,6 @@ import XCTest
 
 /// Verifies that changes flow correctly across multiple real services without breaking
 /// the pipeline. Tests respect `@MainActor` boundaries using async/await patterns.
-///
-/// The `SettingsStore ↔ SettingsViewModel ↔ Scheduler` slice of this pipeline was
-/// retired alongside `SettingsViewModel` in #755 Phase B. The remaining coverage
-/// exercises pause-condition + observer fan-out paths that still live on
-/// `SettingsStore`. The deleted `SettingsViewModel`-driven slice will be re-covered
-/// as `SettingsFeature` TestStore + integration cases under #679.
 @MainActor
 final class MultiServicePipelineIntegrationTests: XCTestCase {
 


### PR DESCRIPTION
## Summary
- remove the obsolete SettingsViewModel/#679 deferral header from `Tests/EyePostureReminderTests/Integration/IntegrationTests.swift`
- remove the matching stale `#679` prose from `Tests/EyePostureReminderTests/Integration/MultiServicePipelineIntegrationTests.swift`
- keep the surviving integration test bodies intact while relying on existing TCA coverage in `Tests/EyePostureReminderTests/TCA/SettingsFeatureToggleEmissionTests.swift` and `Tests/EyePostureReminderTests/TCA/SettingsFeatureBindingTests.swift`

## Verification
- `./scripts/build.sh lint`
- `./scripts/build.sh all`
- `#679` search under `Tests/EyePostureReminderTests/Integration/`: no hits
- `func test_` counts unchanged: `IntegrationTests.swift` = 20, `MultiServicePipelineIntegrationTests.swift` = 4

Closes #794