### PR TITLE
chore(tests): strip stale AppCoordinator / SettingsViewModel archaeology

### DIFF
--- a/Tests/EyePostureReminderTests/RegressionTests.swift
+++ b/Tests/EyePostureReminderTests/RegressionTests.swift
@@ -714,7 +714,7 @@ final class PauseConditionColdStartTests: XCTestCase {
     }
 
     /// Verify the `onPauseStateChanged` callback fires immediately on startMonitoring()
-    /// when focus is already active — callers (AppCoordinator) must receive the signal.
+    /// when focus is already active — SchedulingFeature must receive the signal.
     func test_coldStart_focusAlreadyActive_startMonitoring_firesCallback() {
         let mockFocus = MockFocusStatusDetector()
         let mockPersistence = MockSettingsPersisting()
@@ -835,9 +835,9 @@ final class ScreenTimeDoubleResignTests: XCTestCase {
 ///   3. `isOverlayVisible` remains `false` (no scene → no window created).
 ///   4. `clearQueue()` drains the queue without crash (proves a queue exists to drain).
 ///
-/// For the AppCoordinator-level verification that the queued request surfaces once
-/// `presentPendingOverlayIfNeeded()` is called, see
-/// `AppCoordinatorTests.test_handleNotification_eyes_thenPresentPending_callsShowOverlayWithEyes`.
+/// Reducer-level notification-routing coverage lives in
+/// `SchedulingNotificationRoutingTests.test_notificationRouted_reminderEyes_runsFallbackPipeline`;
+/// this class stays focused on the no-scene queueing contract inside `OverlayManager`.
 @MainActor
 final class OverlayQueueNoSceneTests: XCTestCase {
 
@@ -866,7 +866,7 @@ final class OverlayQueueNoSceneTests: XCTestCase {
         XCTAssertFalse(
             dismissFired,
             "#117 regression: onDismiss must not fire synchronously for a queued request. "
-            + "A silent drop that calls onDismiss() immediately would cause AppCoordinator to "
+            + "A silent drop that calls onDismiss() immediately would cause the scheduling flow to "
             + "reschedule the reminder without ever having shown the overlay.")
 
         manager.clearQueue()

--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -734,17 +734,6 @@ final class AppDelegateTests: XCTestCase {
         }
     }
 
-    // MARK: - handleNotification routing (coordinator path exercised by delegate)
-    //
-    // Follow-up #680: rewrite these handleNotification / scheduleReminders
-    // coverage checks as `SchedulingFeature` TestStore assertions. The legacy
-    // `AppCoordinator` was deleted in `#755` Phase E and the routing surface
-    // they exercised now lives in `SchedulingFeature.notificationRoutedEffect`
-    // / `SchedulingFeature.scheduleReminders`. The
-    // `dispatchNotificationRoute` tests further above (which run through the
-    // store directly) cover the public route contract; this section only held
-    // duplicate coverage against the deleted coordinator helpers.
-
     func test_dispatchNotificationRoute_beforeStoreWiring_replaysReminderWhenStoreIsSet() async {
         delegate.store = nil
         settings.snoozeCount = 4
@@ -787,16 +776,6 @@ final class AppDelegateTests: XCTestCase {
         )
     }
 
-    // MARK: - Snooze-wake routing (scheduleReminders path exercised by delegate)
-    //
-    // Follow-up #680: rewrite the snooze-wake coverage as a
-    // `SchedulingFeature` TestStore assertion against
-    // `.notificationRouted(.snoozeWake)`. The legacy
-    // `AppCoordinator.scheduleReminders()` shim was deleted in `#755`
-    // Phase E; the snooze-wake category routing is now driven entirely
-    // by the store (see `AppDelegate.notificationRoute(for:)` →
-    // `SchedulingFeature.snoozeWakeCategory`).
-
     private func makeIsolatedDefaults(suffix: String) throws -> UserDefaults {
         let suiteName = "AppDelegateTests.\(suffix).\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
@@ -810,3 +789,4 @@ final class AppDelegateTests: XCTestCase {
     }
 }
 // swiftlint:enable type_body_length
+// swiftlint:enable file_length

--- a/Tests/EyePostureReminderTests/Services/DeviceActivityMonitorTests.swift
+++ b/Tests/EyePostureReminderTests/Services/DeviceActivityMonitorTests.swift
@@ -8,8 +8,6 @@ import XCTest
 /// - `DeviceActivityMonitorNoop` compile-safe behaviour (no FamilyControls required)
 /// - `DeviceActivityMonitorProviding` protocol contract via `MockDeviceActivityMonitorProviding`
 /// - `ShieldSession(type:durationSeconds:triggeredAt:)` convenience initialiser
-/// - `AppCoordinator` integration: `deviceActivityMonitor` is called on threshold
-///   (when `isAvailable` is true) and on `cancelAllReminders()`
 ///
 /// No test imports or instantiates `DeviceActivity`, `ManagedSettings`, or `FamilyControls`.
 /// All tests are safe to run in the iOS Simulator and SPM test host.
@@ -222,17 +220,6 @@ final class DeviceActivityMonitorTests: XCTestCase {
         XCTAssertEqual(mock.cancelCallCount, 0)
         XCTAssertTrue(mock.scheduledSessions.isEmpty)
     }
-
-    // MARK: - AppCoordinator integration
-    //
-    // Follow-up #680: rewrite the deleted coverage as `SchedulingFeature`
-    // TestStore assertions. The previous tests in this section constructed
-    // an `AppCoordinator` directly to verify that `cancelAllReminders()` /
-    // threshold scheduling correctly delegated to `DeviceActivityMonitor`.
-    // After `#755` Phase E removed the coordinator stack, the same wiring
-    // now lives in `SchedulingFeature` (see `cancelRemindersEffect` and
-    // `notificationRoutedEffect`) and should be covered with TCA-native
-    // assertions instead of resurrected here.
 
     // MARK: - Helpers
 

--- a/Tests/EyePostureReminderTests/Services/DrivingDetectionExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/Services/DrivingDetectionExtendedTests.swift
@@ -306,14 +306,3 @@ final class DrivingDetectionExtendedTests: XCTestCase {
             "Rapid driving toggles ending on driving=true must leave manager paused")
     }
 }
-
-// MARK: - DrivingSettingsViewModelTests removed (#755 Phase B)
-//
-// The `SettingsViewModel.pauseWhileDriving` getter/setter coverage that
-// previously lived in `DrivingSettingsViewModelTests` was removed when
-// `SettingsViewModel` was deleted. The `pauseWhileDriving` binding is now
-// driven from `SettingsView` via `@AppStorage(SettingsStore.Keys.pauseWhileDriving)`
-// and exercised through `SettingsStore` directly.
-//
-// Rewrite as `SettingsFeature` TestStore coverage once the reducer owns the
-// `pauseWhileDriving` analytics emission — tracked under #679.

--- a/Tests/EyePostureReminderTests/Services/FocusModeExtendedTests.swift
+++ b/Tests/EyePostureReminderTests/Services/FocusModeExtendedTests.swift
@@ -218,14 +218,3 @@ final class FocusModeExtendedTests: XCTestCase {
             "onPauseStateChanged must not fire when state remains paused after one condition clears")
     }
 }
-
-// MARK: - FocusModeSettingsViewModelTests removed (#755 Phase B)
-//
-// The `SettingsViewModel.pauseDuringFocus` getter/setter coverage that
-// previously lived in `FocusModeSettingsViewModelTests` was removed when
-// `SettingsViewModel` was deleted. The `pauseDuringFocus` binding is now
-// driven from `SettingsView` via `@AppStorage(SettingsStore.Keys.pauseDuringFocus)`
-// and exercised through `SettingsStore` directly.
-//
-// Rewrite as `SettingsFeature` TestStore coverage once the reducer owns the
-// `pauseDuringFocus` analytics emission — tracked under #679.

--- a/Tests/EyePostureReminderTests/Services/PauseConditionManagerTests.swift
+++ b/Tests/EyePostureReminderTests/Services/PauseConditionManagerTests.swift
@@ -159,8 +159,8 @@ final class PauseConditionManagerTests: XCTestCase {
     // MARK: - Snooze Interaction
     //
     // PauseConditionManager and snooze are independent pause axes (per spec).
-    // PauseConditionManager reports its own state truthfully; AppCoordinator is
-    // responsible for checking both before calling resumeAll().
+    // PauseConditionManager reports its own state truthfully; SchedulingFeature
+    // is responsible for checking both before calling resumeAll().
 
     func test_pause_whenPauseClearsWhileSnoozeActive_conditionManagerReportsNotPaused() {
         settings.pauseDuringFocus = true
@@ -176,9 +176,9 @@ final class PauseConditionManagerTests: XCTestCase {
 
         XCTAssertFalse(sut.isPaused, "PauseConditionManager.isPaused is false: all conditions have cleared")
         XCTAssertEqual(callbackValue, false, "onPauseStateChanged fires false when all conditions clear")
-        // The consumer (AppCoordinator) must still gate resumeAll() behind this snooze check:
+        // SchedulingFeature must still gate resumeAll() behind this snooze check:
         let snoozeStillActive = settings.snoozedUntil.map { $0 > Date() } ?? false
-        XCTAssertTrue(snoozeStillActive, "Snooze is still active — AppCoordinator must not resume tracking yet")
+        XCTAssertTrue(snoozeStillActive, "Snooze is still active — SchedulingFeature must not resume tracking yet")
     }
 
     func test_snooze_aloneDoesNotAffect_isPaused() {

--- a/Tests/EyePostureReminderTests/Services/ScreenTimeShieldTests.swift
+++ b/Tests/EyePostureReminderTests/Services/ScreenTimeShieldTests.swift
@@ -12,7 +12,7 @@ import XCTest
 /// All tests use `ScreenTimeShieldNoop` (the pre-entitlement stub) and
 /// verify the domain types and protocol contract. When the real
 /// `ScreenTimeShieldManager` is added in M3.3, a parallel test file with
-/// a `MockScreenTimeShieldProviding` will test `AppCoordinator` integration.
+/// a `MockScreenTimeShieldProviding` can cover the reducer-driven shield flow.
 @MainActor
 final class ScreenTimeShieldTests: XCTestCase {
 
@@ -26,8 +26,8 @@ final class ScreenTimeShieldTests: XCTestCase {
     func test_noop_beginShield_doesNotThrow() async throws {
         let sut = ScreenTimeShieldNoop()
         let session = makeSession()
-        // Must not throw — AppCoordinator calls this regardless of availability guard
-        // in test builds; the real guard lives in the caller.
+        // Must not throw — test-only callers may hit the noop implementation
+        // before availability is checked at the call site.
         try await sut.beginShield(for: session)
     }
 

--- a/Tests/EyePostureReminderTests/Services/ServiceCoverageBoostTests.swift
+++ b/Tests/EyePostureReminderTests/Services/ServiceCoverageBoostTests.swift
@@ -6,9 +6,7 @@ import XCTest
 
 /// Additional service and model tests targeting coverage gaps in partially-covered
 /// production files: PauseConditionManager, OverlayManager, MetricKitSubscriber,
-/// AppDelegate, and AppCoordinator. (The legacy `SettingsViewModel` section was
-/// removed alongside `SettingsViewModel` in #755 Phase B; the `SettingsFeature`
-/// TestStore replacement is tracked under #679.)
+/// AppDelegate, and related service helpers.
 @MainActor
 final class ServiceCoverageBoostTests: XCTestCase {
 
@@ -271,19 +269,6 @@ final class ServiceCoverageBoostTests: XCTestCase {
 @MainActor
 final class ServiceCoverageBoostTests2: XCTestCase {
 
-    // MARK: - AppCoordinator — Coverage Gaps
-    //
-    // Follow-up #680: rewrite these coverage-only smoke tests as
-    // `SchedulingFeature` / `SettingsFeature` TestStore assertions. They
-    // previously instantiated `AppCoordinator` directly purely to bump
-    // coverage on private helpers (`presentPendingOverlayIfNeeded`,
-    // `appWillResignActive`, `cancelSnoozeWakeTaskIfNeeded`,
-    // `handleNotification`, `scheduleReminders`, `refreshAuthStatus`,
-    // `clearExpiredSnoozeIfNeeded`, `handleForegroundTransition`). After
-    // `#755` Phase E deleted the coordinator stack, every one of those
-    // surfaces is now exercised through reducer actions covered by
-    // `SchedulingFeatureTests`.
-
     // MARK: - AudioInterruptionManager
 
     func test_audioInterruptionManager_pauseAndResume() {
@@ -316,18 +301,6 @@ final class ServiceCoverageBoostTests2: XCTestCase {
         XCTAssertEqual(mock.pauseCallCount, 0)
         XCTAssertEqual(mock.resumeCallCount, 0)
     }
-
-    // MARK: - SettingsViewModel — Removed (#755 Phase B)
-    //
-    // The SettingsViewModel coverage block previously here was deleted when
-    // `SettingsViewModel` was removed (#755 Phase B). The legacy interval /
-    // break-duration label formatters now live on `SettingsPickerOptions`
-    // and are covered by `CoverageBoostTests` /
-    // `OnboardingViewTests`. The snooze, global-toggle, reminder-setting
-    // changed, and pause-* setter cases will be rewritten as
-    // `SettingsFeature` TestStore coverage under #679.
-    //
-    // Rewrite as `SettingsFeature` TestStore coverage — tracked under #679.
 
     // MARK: - ReminderType — Additional Coverage
 


### PR DESCRIPTION
## Summary
- remove stale AppCoordinator / SettingsViewModel archaeology comments and empty MARK blocks from legacy Services and Regression tests
- reword the remaining test narrative toward SchedulingFeature / the scheduling flow without changing any test assertions
- absorb #795 by restoring a symmetric SwiftLint pragma pair in `AppDelegateTests.swift`

## Verification
- `./scripts/build.sh lint` ✅
- `./scripts/build.sh all` ✅ (`1823` tests, `1` skipped, `0` failures)

Closes #793
Closes #795