### PR TITLE
chore(lint): make AppDelegateTests swiftlint pragma symmetric (#795)

### DIFF
--- a/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
+++ b/Tests/EyePostureReminderTests/Services/AppDelegateTests.swift
@@ -809,4 +809,4 @@ final class AppDelegateTests: XCTestCase {
         return defaults
     }
 }
-// swiftlint:enable type_body_length
+// swiftlint:enable type_body_length file_length


### PR DESCRIPTION
## Summary

`Tests/EyePostureReminderTests/Services/AppDelegateTests.swift:19` opens with
`// swiftlint:disable type_body_length file_length` but `:812` only restores
`type_body_length`. The asymmetric `file_length` is a latent footgun — the
rule stays disabled for anything appended below the closing pragma.

This PR adds `file_length` to the closing `swiftlint:enable` directive so the
disable/enable pair is symmetric. The 812-line file is still over the
600-line `file_length` warning (and the ~771-line type body is over the
400-line `type_body_length` warning), so option (1) from the issue — dropping
both disables — is not yet safe; that should be revisited after #793 trims
the dead `AppCoordinator`-era deferral comments out of the body.

## Files

- `Tests/EyePostureReminderTests/Services/AppDelegateTests.swift:812` — pair
  `file_length` onto the existing closing `enable` directive.

## Verification

- `./scripts/build.sh all` (full build + lint + 1823 unit tests, 0 failures)
  green on the parent `main` (606accb) immediately before this commit.
- `./scripts/build.sh lint` re-run after the edit: clean.
- `rg -n 'swiftlint:(disable|enable)' Tests/EyePostureReminderTests/Services/AppDelegateTests.swift`
  shows symmetric `type_body_length file_length` pairs at `:19`/`:812`.

## Acceptance criteria (from #795)

- [x] `./scripts/build.sh all` passes (`swiftlint --strict` clean).
- [x] `rg` shows symmetric pragmas.
- [x] No test methods removed or altered.

Closes #795

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>