### PR TITLE
chore(docs): refresh OnboardingSetupView header (#800)

### DIFF
--- a/EyePostureReminder/Views/Onboarding/OnboardingSetupView.swift
+++ b/EyePostureReminder/Views/Onboarding/OnboardingSetupView.swift
@@ -5,10 +5,9 @@
 // Users choose their eye break and posture check windows before getting started.
 // Selections bind directly to `@AppStorage(SettingsStore.Keys.*)` so the same
 // values surface in `SettingsView` later — no environment-object plumbing
-// required. Picker option lists / labels still come from the legacy
-// `SettingsViewModel` statics until `#755` Phase B's `SettingsPickerOptions`
-// extraction lands; the rebase swaps the references over without touching this
-// file's shape.
+// required. Picker option lists and labels come from
+// `SettingsPickerOptions` (the canonical preset source extracted in `#755`
+// Phase B).
 
 import SwiftUI
 
@@ -19,7 +18,7 @@ struct OnboardingSetupView: View {
     /// matches `AppConfig.fallback.defaults.eyeInterval` so the first cold
     /// launch (before `SettingsStore` has persisted anything to UserDefaults)
     /// lands on a picker option that exists in
-    /// `SettingsViewModel.intervalOptions`.
+    /// `SettingsPickerOptions.intervalOptions`.
     @AppStorage(SettingsStore.Keys.eyesInterval) private var eyesInterval: Double = 1200
     @AppStorage(SettingsStore.Keys.eyesBreakDuration) private var eyesBreakDuration: Double = 20
     @AppStorage(SettingsStore.Keys.postureInterval) private var postureInterval: Double = 1800


### PR DESCRIPTION
## Summary

The `OnboardingSetupView` header describes a transitional state that no longer exists:

> Picker option lists / labels still come from the legacy `SettingsViewModel` statics until `#755` Phase B's `SettingsPickerOptions` extraction lands; the rebase swaps the references over without touching this file's shape.

— but every call site in this file already references `SettingsPickerOptions.{intervalOptions, breakDurationOptions, labelForInterval, labelForBreakDuration}` (lines 157, 158, 185, 186, 222, 223), and `SettingsViewModel` itself was **deleted** in `#755` Phase E (commit b9a1c96, PR #760).

This PR rewrites the header to describe the current shape, and updates the `eyesInterval` doc-comment to cite `SettingsPickerOptions.intervalOptions` instead of the deleted `SettingsViewModel.intervalOptions`.

## Diff

- `EyePostureReminder/Views/Onboarding/OnboardingSetupView.swift`: header rewrite + one doc-comment citation update. 4 lines added, 5 removed.

## Out of scope

Other migration-provenance comments in the codebase (e.g. `SchedulingFeature.swift` "ported from the deleted `AppCoordinator.scheduleReminders`", `SettingsFeature.swift` "Phase 1 reducer replacing the legacy `SettingsViewModel`", etc.) **stay as-is** — those are forensic "ported from / mirrors" references that explain why current code took its shape, not transitional placeholders.

## Validation

- `./scripts/build.sh all` ✅ (1825 tests, 0 failures, 138s).
- Doc-only change — no behaviour delta.

Closes #800
