### PR TITLE
chore(docs): refresh SettingsView reminder-row comments (#804)

### DIFF
--- a/EyePostureReminder/Views/SettingsView.swift
+++ b/EyePostureReminder/Views/SettingsView.swift
@@ -240,10 +240,11 @@ struct SettingsView: View {
                 interval: $store.eyesInterval,
                 breakDuration: $store.eyesBreakDuration
             ) {
-                // `eyesInterval` / `eyesBreakDuration` debounce-reschedule
-                // inside the reducer; the legacy
-                // `viewModel?.reminderSettingChanged(.eyes)` callback is
-                // deferred to `p0-tca-16` (#679).
+                // Eyes-side reschedule + `setting_changed` analytics are
+                // reducer-owned: `$store.eyesInterval` /
+                // `$store.eyesBreakDuration` flow through `SettingsFeature`'s
+                // bindable surface, which debounces and dispatches the
+                // reschedule effect. No view-level callback needed here.
             }
             .listRowBackground(AppColor.surface)
             .listRowSeparatorTint(AppColor.separatorSoft)
@@ -270,9 +271,17 @@ struct SettingsView: View {
                 interval: $postureInterval,
                 breakDuration: $postureBreakDuration
             ) {
-                // Posture-side reschedule is deferred to `p0-tca-16` (#679);
-                // once `SettingsClient.snapshot` vends posture values the
-                // reducer will own this debounce.
+                // Posture-side pickers still bind directly through
+                // `@AppStorage(SettingsStore.Keys.postureInterval)` /
+                // `@AppStorage(SettingsStore.Keys.postureBreakDuration)` —
+                // they are not yet on `SettingsFeature`'s bindable surface.
+                // Persistence + reschedule continue to flow via
+                // `SettingsStore` → `SettingsClient.liveValue` →
+                // `SchedulingFeature`; `setting_changed` analytics emit
+                // from the `.onChangeCompat` watchers below.
+                // Migration onto the reducer's bindable surface is tracked
+                // by #805 (extend `SettingsClient.snapshot` to vend
+                // posture-side values).
             }
             .listRowBackground(AppColor.surface)
             .listRowSeparatorTint(AppColor.separatorSoft)


### PR DESCRIPTION
## Summary

Refreshes the two trailing-closure comments inside `SettingsView.eyesSection` / `SettingsView.postureSection` (lines 243–248 / 273–285 pre-edit) that had gone stale.

Both blocks cited #679 (`p0-tca-16 Rewrite SettingsViewModelTests as SettingsFeature TestStore tests`) and the legacy `viewModel?.reminderSettingChanged(...)` callback as the "deferred to" anchor. Both are gone:

- **#679 has shipped** — closed on 2026-05-15.
- **`SettingsViewModel` no longer exists** — deleted in #755 Phase B. The `viewModel?.reminderSettingChanged(.eyes)` symbol the comments referenced is not in the codebase.

## Refreshed copy

### Eyes section (`SettingsView.swift:243–247`)
Drops the legacy view-model framing and the "deferred to #679" citation. States plainly that `$store.eyesInterval` / `$store.eyesBreakDuration` flow through `SettingsFeature`'s bindable surface and that the reducer owns the debounced reschedule — no view-level callback needed.

### Posture section (`SettingsView.swift:273–285`)
- Acknowledges that posture pickers still bind directly through `@AppStorage(SettingsStore.Keys.postureInterval)` / `@AppStorage(SettingsStore.Keys.postureBreakDuration)` and are **not yet** on `SettingsFeature`'s bindable surface.
- Describes the current persistence + reschedule flow: `SettingsStore` → `SettingsClient.liveValue` → `SchedulingFeature`, with `setting_changed` analytics emitted from the `.onChangeCompat` watchers further down in the file.
- Re-anchors the forward-looking deferral to **#805** — the live tracker that owns extending `SettingsClient.snapshot` to vend posture-side values + migrating posture pickers onto `SettingsFeature`'s bindable surface. (#679 was the wrong anchor; #805 is the correct one and already exists.)

## Investigation note

Per the issue, I verified that a tracker for the posture-bindable migration already exists before citing it:

- **#805** — `feat(tca): extend SettingsClient snapshot to vend posture-side values and migrate posture pickers onto SettingsFeature bindable surface` (priority:p2, squad:basher, open). Scope matches exactly: extend the snapshot/stream surface, add `postureInterval`/`postureBreakDuration` to `SettingsFeature`'s bindable surface mirroring the eyes-side flow.

So no new tracking issue is needed — the refreshed posture comment cites #805.

## Behavioural delta

None — comment-only change.

## Verification

`./scripts/build.sh all` (build + lint + tests) passed locally:

```
✓ Build succeeded
✓ Lint passed
✓ Tests passed (1826 tests, 1 skipped, 0 failures)
✓ All steps passed in 98s
```

Closes #804