### PR TITLE
chore(docs): refresh SettingsView reminder-row comments (#804)

### DIFF
--- a/EyePostureReminder/Views/SettingsView.swift
+++ b/EyePostureReminder/Views/SettingsView.swift
@@ -240,10 +240,11 @@ struct SettingsView: View {
                 interval: $store.eyesInterval,
                 breakDuration: $store.eyesBreakDuration
             ) {
-                // `eyesInterval` / `eyesBreakDuration` debounce-reschedule
-                // inside the reducer; the legacy
-                // `viewModel?.reminderSettingChanged(.eyes)` callback is
-                // deferred to `p0-tca-16` (#679).
+                // `eyesInterval` / `eyesBreakDuration` flow through
+                // `SettingsFeature`'s bindable surface; the reducer owns
+                // the debounce-reschedule effect (see
+                // `SettingsFeature.swift` `.binding(\.eyesInterval)` /
+                // `.binding(\.eyesBreakDuration)` cases).
             }
             .listRowBackground(AppColor.surface)
             .listRowSeparatorTint(AppColor.separatorSoft)
@@ -270,9 +271,14 @@ struct SettingsView: View {
                 interval: $postureInterval,
                 breakDuration: $postureBreakDuration
             ) {
-                // Posture-side reschedule is deferred to `p0-tca-16` (#679);
-                // once `SettingsClient.snapshot` vends posture values the
-                // reducer will own this debounce.
+                // Posture-side pickers still bind through
+                // `@AppStorage(SettingsStore.Keys.posture*)` directly: the
+                // shared `SettingsClient` snapshot/stream surface only
+                // vends eyes-side `ReminderSettings` today, so
+                // `SettingsFeature` does not yet host bindable
+                // `postureInterval` / `postureBreakDuration` mirrors.
+                // Tracked by #805 (extend snapshot + migrate onto the
+                // reducer's bindable surface).
             }
             .listRowBackground(AppColor.surface)
             .listRowSeparatorTint(AppColor.separatorSoft)


### PR DESCRIPTION
## Summary

`SettingsView.eyesSection` and `SettingsView.postureSection` carried inline comments that cited the closed `p0-tca-16` (#679) and the deleted `viewModel?.reminderSettingChanged(.eyes)` callback. Both citations are now archaeology — #679 shipped 2026-05-15, and `SettingsViewModel` was deleted in `#755` Phase B.

This PR rewrites both comments to describe the actual current shape:

- **Eyes** — the picker values flow through `SettingsFeature`'s bindable surface and the reducer already owns the debounce-reschedule effect via the `.binding(\.eyesInterval)` / `.binding(\.eyesBreakDuration)` cases.
- **Posture** — the picker values still bind through `@AppStorage(SettingsStore.Keys.posture*)` directly because `SettingsClient.snapshot()` only vends eyes-side `ReminderSettings` today. Comment now cites the new live tracker (#805 — extend the snapshot surface to vend posture-side values and migrate the pickers onto the bindable reducer surface) instead of the wrong `p0-tca-16 / #679` framing.

## Investigation note (per #804)

Before landing, I searched for an existing tracker for the posture-pickers-onto-bindable-surface migration and found none. The `prev*` doc-comments in `SettingsFeature.swift` (lines 48–55) cite `p0-tca-15 / #678`, but #678 was about converting `SelectedAppsState` into an `IPCClient` extension — unrelated to posture snapshots. So I filed **#805** as the proper anchor and cite it from the refreshed posture-side comment. (Cleaning up the stale `p0-tca-15` citations in `SettingsFeature.swift` is part of #805's acceptance criteria; not done here to keep this PR strictly scoped to #804.)

## Diff

`EyePostureReminder/Views/SettingsView.swift`: 13 lines added, 7 removed.

## Validation

- `./scripts/build.sh all` ✅ (1825 tests, 0 failures, 155s).
- Doc-only change.

Closes #804
